### PR TITLE
feat: flex-wrap 包裹效果与 React Native 实现对比

### DIFF
--- a/examples/css/demos/flex-wrap-effect.html
+++ b/examples/css/demos/flex-wrap-effect.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>包裹效果 — flex-wrap 布局演示</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      padding: 40px;
+      background: #f5f5f5;
+    }
+    h1 { font-size: 18px; margin-bottom: 24px; color: #333; }
+    h2 { font-size: 14px; margin: 20px 0 10px; color: #555; }
+    .container {
+      background: #fff;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    }
+    .label { font-size: 12px; color: #888; margin-bottom: 12px; }
+    .note { font-size: 12px; color: #666; margin-top: 12px; padding: 8px 12px; background: #f9f9f9; border-radius: 4px; }
+
+    .flex-demo {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      background: #f0f0f0;
+      padding: 10px;
+      border-radius: 6px;
+    }
+    .flex-item {
+      width: 120px;
+      height: 60px;
+      background: linear-gradient(135deg, #667eea, #764ba2);
+      border-radius: 6px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      font-size: 13px;
+    }
+
+    /* nowrap 对比 */
+    .flex-nowrap {
+      display: flex;
+      flex-wrap: nowrap;
+      gap: 10px;
+      background: #f0f0f0;
+      padding: 10px;
+      border-radius: 6px;
+      overflow-x: auto;
+    }
+    .flex-nowrap .flex-item {
+      flex-shrink: 0;
+    }
+
+    /* wrap-reverse */
+    .flex-wrap-reverse {
+      display: flex;
+      flex-wrap: wrap-reverse;
+      gap: 10px;
+      background: #f0f0f0;
+      padding: 10px;
+      border-radius: 6px;
+    }
+
+    /* align-content */
+    .flex-align-content {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      background: #f0f0f0;
+      padding: 10px;
+      border-radius: 6px;
+      min-height: 200px;
+    }
+
+    .code-block {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 16px;
+      border-radius: 6px;
+      font-family: 'Fira Code', 'Consolas', monospace;
+      font-size: 13px;
+      overflow-x: auto;
+      margin-top: 12px;
+    }
+    .code-block .comment { color: #6a9955; }
+    .code-block .property { color: #9cdcfe; }
+    .code-block .value { color: #ce9178; }
+
+    /* RN 代码对比 */
+    .rn-compare {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 20px;
+    }
+    @media (max-width: 768px) {
+      .rn-compare { grid-template-columns: 1fr; }
+    }
+    .rn-panel {
+      background: #1e1e1e;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .rn-panel-header {
+      background: #333;
+      padding: 10px 16px;
+      font-size: 12px;
+      color: #888;
+    }
+    .rn-panel pre {
+      padding: 16px;
+      margin: 0;
+      font-size: 13px;
+      color: #d4d4d4;
+      overflow-x: auto;
+    }
+    .rn-keyword { color: #569cd6; }
+    .rn-string { color: #ce9178; }
+    .rn-prop { color: #9cdcfe; }
+    .rn-value { color: #b5cea8; }
+  </style>
+</head>
+<body>
+
+  <h1>包裹效果 — flex-wrap 布局演示</h1>
+
+  <!-- 包裹 vs 不包裹对比 -->
+  <div class="container">
+    <div class="label">flex-wrap: wrap vs nowrap</div>
+    <div class="rn-compare">
+      <div>
+        <h2>❌ nowrap（不包裹）</h2>
+        <div class="flex-nowrap">
+          <div class="flex-item">元素 A</div>
+          <div class="flex-item">元素 B</div>
+          <div class="flex-item">元素 C</div>
+          <div class="flex-item">元素 D</div>
+          <div class="flex-item">元素 E</div>
+        </div>
+        <div class="note">⚠️ 元素被压缩（flex-shrink: 1）挤在一行，超出容器可滚动</div>
+      </div>
+      <div>
+        <h2>✅ wrap（包裹）</h2>
+        <div class="flex-demo">
+          <div class="flex-item">元素 A</div>
+          <div class="flex-item">元素 B</div>
+          <div class="flex-item">元素 C</div>
+          <div class="flex-item">元素 D</div>
+          <div class="flex-item">元素 E</div>
+        </div>
+        <div class="note">✅ 元素保持设定宽度，超出一行自动换行</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- wrap-reverse -->
+  <div class="container">
+    <div class="label">flex-wrap: wrap-reverse（反向换行）</div>
+    <div class="flex-wrap-reverse">
+      <div class="flex-item">元素 A (row 3)</div>
+      <div class="flex-item">元素 B (row 3)</div>
+      <div class="flex-item">元素 C (row 2)</div>
+      <div class="flex-item">元素 D (row 2)</div>
+      <div class="flex-item">元素 E (row 1)</div>
+      <div class="flex-item">元素 F (row 1)</div>
+    </div>
+    <div class="note">✅ wrap-reverse 从底部开始向上堆叠，第一行出现在底部</div>
+  </div>
+
+  <!-- align-content 多行对齐 -->
+  <div class="container">
+    <div class="label">align-content: 多行对齐方式</div>
+    <div style="display:grid;grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 20px;">
+      <div>
+        <h2>align-content: flex-start</h2>
+        <div class="flex-align-content" style="align-content: flex-start;">
+          <div class="flex-item" style="width:80px;height:50px;">A</div>
+          <div class="flex-item" style="width:80px;height:50px;">B</div>
+          <div class="flex-item" style="width:80px;height:50px;">C</div>
+          <div class="flex-item" style="width:80px;height:50px;">D</div>
+        </div>
+      </div>
+      <div>
+        <h2>align-content: center</h2>
+        <div class="flex-align-content" style="align-content: center;">
+          <div class="flex-item" style="width:80px;height:50px;">A</div>
+          <div class="flex-item" style="width:80px;height:50px;">B</div>
+          <div class="flex-item" style="width:80px;height:50px;">C</div>
+          <div class="flex-item" style="width:80px;height:50px;">D</div>
+        </div>
+      </div>
+      <div>
+        <h2>align-content: space-between</h2>
+        <div class="flex-align-content" style="align-content: space-between;">
+          <div class="flex-item" style="width:80px;height:50px;">A</div>
+          <div class="flex-item" style="width:80px;height:50px;">B</div>
+          <div class="flex-item" style="width:80px;height:50px;">C</div>
+          <div class="flex-item" style="width:80px;height:50px;">D</div>
+        </div>
+      </div>
+      <div>
+        <h2>align-content: stretch</h2>
+        <div class="flex-align-content" style="align-content: stretch;">
+          <div class="flex-item" style="width:80px;min-height:50px;">A</div>
+          <div class="flex-item" style="width:80px;min-height:50px;">B</div>
+          <div class="flex-item" style="width:80px;min-height:50px;">C</div>
+          <div class="flex-item" style="width:80px;min-height:50px;">D</div>
+        </div>
+      </div>
+    </div>
+    <div class="note">align-content 只在多行（flex-wrap: wrap/wrap-reverse）时生效</div>
+  </div>
+
+  <!-- RN 对应实现 -->
+  <div class="container">
+    <div class="label">React Native 对应实现</div>
+    <div class="rn-compare">
+      <div class="rn-panel">
+        <div class="rn-panel-header">CSS → React Native 映射</div>
+        <pre><span class="rn-keyword">// CSS</span>
+<span class="rn-prop">display</span>: <span class="rn-value">flex</span>;
+<span class="rn-prop">flex-wrap</span>: <span class="rn-value">wrap</span>;
+<span class="rn-prop">gap</span>: <span class="rn-value">10px</span>;
+
+<span class="rn-keyword">// RN (React Native)</span>
+<span class="rn-prop">display</span>: <span class="rn-string">'flex'</span>;
+<span class="rn-prop">flexWrap</span>: <span class="rn-string">'wrap'</span>;
+<span class="rn-prop">gap</span>: <span class="rn-string">10</span>;
+
+<span class="rn-comment">// 注意：gap 在 RN 0.76+ 支持</span></pre>
+      </div>
+      <div class="rn-panel">
+        <div class="rn-panel-header">完整 RN 包裹布局示例</div>
+        <pre><span class="rn-keyword">import</span> { View, StyleSheet } <span class="rn-keyword">from</span> <span class="rn-string">'react-native'</span>;
+
+<span class="rn-keyword">const</span> WrapDemo = () => (
+  <span class="rn-keyword">View</span> style=<span class="rn-prop">{</span>styles.container<span class="rn-prop">}</span>>
+    <span class="rn-keyword">View</span> style=<span class="rn-prop">{</span>styles.item<span class="rn-prop">}</span>>A&lt;/<span class="rn-keyword">View</span>>
+    <span class="rn-keyword">View</span> style=<span class="rn-prop">{</span>styles.item<span class="rn-prop">}</span>>B&lt;/<span class="rn-keyword">View</span>>
+    <span class="rn-keyword">View</span> style=<span class="rn-prop">{</span>styles.item<span class="rn-prop">}</span>>C&lt;/<span class="rn-keyword">View</span>>
+  &lt;/<span class="rn-keyword">View</span>>
+);
+
+<span class="rn-keyword">const</span> styles = StyleSheet.create(<span class="rn-prop">{</span>
+  container: <span class="rn-prop">{</span>
+    <span class="rn-prop">display</span>: <span class="rn-string">'flex'</span>,
+    <span class="rn-prop">flexDirection</span>: <span class="rn-string">'row'</span>,
+    <span class="rn-prop">flexWrap</span>: <span class="rn-string">'wrap'</span>,
+    <span class="rn-prop">gap</span>: <span class="rn-string">10</span>,
+  <span class="rn-prop">}</span>,
+  item: <span class="rn-prop">{</span>
+    <span class="rn-prop">width</span>: <span class="rn-string">100</span>,
+    <span class="rn-prop">height</span>: <span class="rn-string">60</span>,
+    <span class="rn-prop">backgroundColor</span>: <span class="rn-string">'#667eea'</span>,
+    <span class="rn-prop">borderRadius</span>: <span class="rn-string">6</span>,
+  <span class="rn-prop">}</span>,
+<span class="rn-prop">}</span>);</pre>
+      </div>
+    </div>
+  </div>
+
+  <!-- 关键属性对比表 -->
+  <div class="container">
+    <div class="label">flex-wrap 关键属性对比</div>
+    <table style="width:100%;border-collapse:collapse;font-size:13px;">
+      <thead>
+        <tr style="background:#f5f5f5;">
+          <th style="padding:10px;text-align:left;border-bottom:1px solid #ddd;">CSS 属性</th>
+          <th style="padding:10px;text-align:left;border-bottom:1px solid #ddd;">RN 属性</th>
+          <th style="padding:10px;text-align:left;border-bottom:1px solid #ddd;">值</th>
+          <th style="padding:10px;text-align:left;border-bottom:1px solid #ddd;">说明</th>
+        </tr>
+      </thead>
+      <tbody style="color:#333;">
+        <tr><td style="padding:8px;border-bottom:1px solid #eee;">flex-wrap</td><td style="padding:8px;border-bottom:1px solid #eee;">flexWrap</td><td style="padding:8px;border-bottom:1px solid #eee;">'wrap'</td><td style="padding:8px;border-bottom:1px solid #eee;">允许换行</td></tr>
+        <tr><td style="padding:8px;border-bottom:1px solid #eee;"></td><td style="padding:8px;border-bottom:1px solid #eee;"></td><td style="padding:8px;border-bottom:1px solid #eee;">'nowrap'</td><td style="padding:8px;border-bottom:1px solid #eee;">不换行（默认）</td></tr>
+        <tr><td style="padding:8px;border-bottom:1px solid #eee;"></td><td style="padding:8px;border-bottom:1px solid #eee;"></td><td style="padding:8px;border-bottom:1px solid #eee;">'wrap-reverse'</td><td style="padding:8px;border-bottom:1px solid #eee;">反向换行</td></tr>
+        <tr><td style="padding:8px;border-bottom:1px solid #eee;">gap</td><td style="padding:8px;border-bottom:1px solid #eee;">gap</td><td style="padding:8px;border-bottom:1px solid #eee;">10</td><td style="padding:8px;border-bottom:1px solid #eee;">间距 RN 0.76+</td></tr>
+        <tr><td style="padding:8px;border-bottom:1px solid #eee;">align-content</td><td style="padding:8px;border-bottom:1px solid #eee;">alignContent</td><td style="padding:8px;border-bottom:1px solid #eee;">'flex-start'</td><td style="padding:8px;border-bottom:1px solid #eee;">多行顶部对齐</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+</body>
+</html>

--- a/examples/css/demos/layout-equal-width-gap-last-right.html
+++ b/examples/css/demos/layout-equal-width-gap-last-right.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>等宽布局 — 间隔 10px，容器内自动增长，最后元素靠右</title>
+  <style>
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      padding: 40px;
+      background: #f5f5f5;
+    }
+
+    h1 {
+      font-size: 18px;
+      margin-bottom: 24px;
+      color: #333;
+    }
+
+    h2 {
+      font-size: 14px;
+      margin: 24px 0 12px;
+      color: #666;
+    }
+
+    .container {
+      background: #fff;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    }
+
+    .label {
+      font-size: 12px;
+      color: #999;
+      margin-bottom: 12px;
+    }
+
+    /* ============================================
+       方案：CSS Grid + auto-fill + minmax
+       核心：
+         - repeat(auto-fill, minmax(最小宽度, 1fr)) 让所有元素等宽
+         - gap: 10px 控制间隔
+         - 元素自动填满容器，溢出则换行
+       ============================================ */
+    .grid-equal {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(min-content, 1fr));
+      gap: 10px;
+    }
+
+    .grid-equal .item {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: #fff;
+      padding: 16px 12px;
+      border-radius: 6px;
+      text-align: center;
+      font-size: 14px;
+      min-width: 0; /* 防止内容溢出 */
+      word-break: break-word;
+    }
+
+    /* ============================================
+       方案二：Flexbox + flex:1
+       等宽 + 间隔 10px，最后元素靠右
+       ============================================ */
+    .flex-equal {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .flex-equal .item {
+      flex: 1;
+      /* min-width 防止元素被压得太窄 */
+      min-width: 120px;
+      background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+      color: #fff;
+      padding: 16px 12px;
+      border-radius: 6px;
+      text-align: center;
+      font-size: 14px;
+    }
+
+    /* 最后一个元素靠右（如果换行则整行居左） */
+    .flex-equal .item:last-child {
+      /* 如果一行放得下，靠右效果通过 margin-left: auto 实现 */
+    }
+
+    /* ============================================
+       方案三：Grid + justify-content: space-between
+       缺点：最后一行不会左对齐（会分散）
+       ============================================ */
+    .grid-between {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 10px;
+    }
+
+    .grid-between .item {
+      background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+      color: #fff;
+      padding: 16px 12px;
+      border-radius: 6px;
+      text-align: center;
+      font-size: 14px;
+    }
+
+    /* ============================================
+       方案四：精准右对齐（容器内靠右）
+       场景：固定 N 列，最后元素位置精确控制
+       ============================================ */
+    .grid-right {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 10px;
+      justify-content: end;
+    }
+
+    .grid-right .item {
+      background: linear-gradient(135deg, #43e97b 0%, #38f9d7 100%);
+      color: #fff;
+      padding: 16px 12px;
+      border-radius: 6px;
+      text-align: center;
+      font-size: 14px;
+    }
+
+    /* 当只有 3 个元素时，靠右对齐 */
+    .grid-right.cols-3 {
+      grid-template-columns: repeat(3, 1fr);
+    }
+
+    /* ============================================
+       方案五（最佳）：Flexbox + ::after 占位
+       实现真正的"最后元素靠右，同时多行左对齐"
+       ============================================ */
+    .flex-pseudo {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .flex-pseudo .item {
+      flex: 1;
+      min-width: 100px;
+      max-width: calc(25% - 8px); /* 最多4列 */
+      background: linear-gradient(135deg, #fa709a 0%, #fee140 100%);
+      color: #fff;
+      padding: 16px 12px;
+      border-radius: 6px;
+      text-align: center;
+      font-size: 14px;
+    }
+
+    /* 通过 ::after 占位实现最后元素靠右 */
+    .flex-pseudo::after {
+      content: '';
+      flex: 1;
+      min-width: 100px;
+      /* 让最后一个 ::after 在必要时撑起空间 */
+    }
+
+    .note {
+      font-size: 12px;
+      color: #888;
+      margin-top: 8px;
+      padding: 8px 12px;
+      background: #f9f9f9;
+      border-radius: 4px;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>等宽布局 — 间隔 10px · 最后元素靠右 · 自动增长</h1>
+
+  <!-- 方案一：Grid auto-fill（推荐） -->
+  <div class="container">
+    <div class="label">方案一：grid + auto-fill + minmax(min-content, 1fr)</div>
+    <div class="grid-equal">
+      <div class="item">内容A</div>
+      <div class="item">内容B，稍长一点</div>
+      <div class="item">内容C</div>
+      <div class="item">内容D，内容更多一些</div>
+      <div class="item">内容E</div>
+      <div class="item">内容F，最后一个</div>
+    </div>
+    <div class="note">✅ 元素等宽（1fr），间隔 10px，自动填满换行，内容自适应宽度</div>
+  </div>
+
+  <!-- 方案二：Flexbox flex:1 -->
+  <div class="container">
+    <div class="label">方案二：flex + flex:1 + gap:10px</div>
+    <div class="flex-equal">
+      <div class="item">内容A</div>
+      <div class="item">内容B，稍长一点</div>
+      <div class="item">内容C</div>
+      <div class="item">内容D，内容更多一些</div>
+      <div class="item">内容E</div>
+      <div class="item">内容F，最后一个</div>
+    </div>
+    <div class="note">⚠️ flex:1 让所有元素等宽，但最后一行不一定靠右对齐</div>
+  </div>
+
+  <!-- 方案三：Grid space-between -->
+  <div class="container">
+    <div class="label">方案三：grid + repeat(4, 1fr) + justify-content:space-between</div>
+    <div class="grid-between">
+      <div class="item">内容A</div>
+      <div class="item">内容B</div>
+      <div class="item">内容C</div>
+      <div class="item">内容D</div>
+      <div class="item">内容E</div>
+      <div class="item">内容F</div>
+    </div>
+    <div class="note">⚠️ 最后一行会分散对齐（space-between 效果）</div>
+  </div>
+
+  <!-- 方案四：精准右对齐 -->
+  <div class="container">
+    <div class="label">方案四：grid + repeat(N, 1fr)，精确控制列数</div>
+    <div class="grid-right">
+      <div class="item">内容A</div>
+      <div class="item">内容B</div>
+      <div class="item">内容C</div>
+      <div class="item">内容D</div>
+      <div class="item">内容E</div>
+      <div class="item">内容F</div>
+    </div>
+    <div class="note">⚠️ 固定 4 列，最后一行 2 个元素不会靠右对齐</div>
+  </div>
+
+  <!-- 方案五：Flexbox + ::after -->
+  <div class="container">
+    <div class="label">方案五：flex + ::after 占位（实现最后元素靠右）</div>
+    <div class="flex-pseudo">
+      <div class="item">内容A</div>
+      <div class="item">内容B</div>
+      <div class="item">内容C</div>
+      <div class="item">内容D</div>
+      <div class="item">内容E</div>
+      <div class="item">内容F，最后一个</div>
+    </div>
+    <div class="note">✅ ::after 占位实现多行时整体靠右布局效果</div>
+  </div>
+
+</body>
+</html>

--- a/examples/css/demos/visibility-detection-stacking.html
+++ b/examples/css/demos/visibility-detection-stacking.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>判断层叠组件是否可见 — 组件可见性检测</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      padding: 40px;
+      background: #f5f5f5;
+    }
+    h1 { font-size: 18px; margin-bottom: 24px; color: #333; }
+    h2 { font-size: 14px; margin: 20px 0 10px; color: #555; }
+    .container {
+      background: #fff;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    }
+    .label { font-size: 12px; color: #888; margin-bottom: 12px; }
+
+    /* ============================================
+       场景一：z-index 层叠遮盖检测
+       ============================================ */
+    .stacking-demo {
+      position: relative;
+      height: 120px;
+      background: #eee;
+      border-radius: 6px;
+      overflow: hidden;
+    }
+    .box {
+      position: absolute;
+      padding: 12px 16px;
+      border-radius: 4px;
+      font-size: 13px;
+      color: #fff;
+    }
+    .box-red {
+      top: 20px; left: 20px;
+      width: 100px; height: 80px;
+      background: #e74c3c;
+      z-index: 1;
+    }
+    .box-green {
+      top: 40px; left: 40px;
+      width: 100px; height: 80px;
+      background: #27ae60;
+      z-index: 2;
+    }
+    .box-blue {
+      top: 60px; left: 60px;
+      width: 100px; height: 80px;
+      background: #3498db;
+      z-index: 3;
+    }
+    .mask {
+      position: absolute;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background: rgba(0,0,0,0.3);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 14px;
+      color: #fff;
+    }
+
+    /* ============================================
+       场景二：Viewport 可见性检测（IntersectionObserver）
+       ============================================ */
+    .viewport-demo {
+      display: flex;
+      flex-direction: column;
+      gap: 400px;
+      padding: 20px 0;
+    }
+    .viewport-box {
+      height: 100px;
+      background: linear-gradient(135deg, #667eea, #764ba2);
+      border-radius: 6px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      font-size: 14px;
+      transition: opacity 0.3s;
+    }
+    .viewport-box.hidden {
+      opacity: 0.3;
+    }
+    .viewport-status {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      background: rgba(0,0,0,0.8);
+      color: #fff;
+      padding: 12px 16px;
+      border-radius: 8px;
+      font-size: 13px;
+      z-index: 9999;
+      max-width: 280px;
+    }
+    .viewport-status .item {
+      padding: 4px 0;
+      border-bottom: 1px solid rgba(255,255,255,0.1);
+    }
+    .viewport-status .item:last-child { border-bottom: none; }
+    .viewport-status .visible { color: #2ecc71; }
+    .viewport-status .hidden { color: #e74c3c; }
+
+    /* ============================================
+       场景三：opacity + visibility 隐藏检测
+       ============================================ */
+    .opacity-demo {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+    .opacity-box {
+      flex: 1;
+      min-width: 120px;
+      padding: 20px;
+      border-radius: 6px;
+      text-align: center;
+      color: #fff;
+      font-size: 13px;
+    }
+    .opacity-visible { background: #27ae60; }
+    .opacity-zero { background: #e74c3c; opacity: 0; }
+    .opacity-point1 { background: #e67e22; opacity: 0.1; }
+    .visibility-hidden { background: #9b59b6; visibility: hidden; }
+    .display-none { background: #34495e; display: none; }
+
+    /* ============================================
+       场景四：Stacking Context 创建条件
+       ============================================ */
+    .context-demo {
+      position: relative;
+      padding: 20px;
+      background: #eee;
+      border-radius: 6px;
+    }
+    .context-item {
+      position: relative;
+      padding: 10px 14px;
+      margin-bottom: 8px;
+      border-radius: 4px;
+      font-size: 13px;
+      color: #fff;
+    }
+    .parent-z {
+      background: #e74c3c;
+      z-index: 1; /* 创建新的 stacking context */
+    }
+    .child-z {
+      background: #3498db;
+      z-index: 999; /* 即使数值很大，仍在父级的 context 内 */
+      margin-top: -20px;
+    }
+    .no-context {
+      background: #95a5a6;
+      opacity: 0.5; /* 创建 stacking context */
+    }
+    .no-context-child {
+      background: #f39c12;
+      z-index: 9999; /* 仍在 no-context 的 context 内 */
+      margin-top: -20px;
+    }
+
+    .note {
+      font-size: 12px;
+      color: #888;
+      margin-top: 8px;
+      padding: 8px 12px;
+      background: #f9f9f9;
+      border-radius: 4px;
+    }
+
+    .result-panel {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background: rgba(0,0,0,0.85);
+      color: #fff;
+      padding: 16px 20px;
+      border-radius: 8px;
+      font-size: 13px;
+      z-index: 99999;
+      min-width: 240px;
+    }
+    .result-panel h3 { font-size: 14px; margin-bottom: 10px; color: #f39c12; }
+    .result-panel .row { padding: 4px 0; border-bottom: 1px solid rgba(255,255,255,0.1); }
+    .result-panel .row:last-child { border-bottom: none; }
+    .result-panel .tag {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 11px;
+      margin-left: 6px;
+    }
+    .tag-yes { background: #27ae60; }
+    .tag-no { background: #e74c3c; }
+  </style>
+</head>
+<body>
+
+  <h1>判断层叠组件是否可见 — 组件可见性检测</h1>
+
+  <!-- 检测结果面板 -->
+  <div class="result-panel" id="resultPanel">
+    <h3>🔍 可见性检测结果</h3>
+    <div class="row">viewport内可见: <span id="r1">-</span></div>
+    <div class="row">z-index遮盖: <span id="r2">-</span></div>
+    <div class="row">opacity隐藏: <span id="r3">-</span></div>
+    <div class="row">visibility隐藏: <span id="r4">-</span></div>
+    <div class="row">stacking context: <span id="r5">-</span></div>
+  </div>
+
+  <!-- 场景一：z-index 层叠 -->
+  <div class="container">
+    <div class="label">场景一：z-index 层叠遮盖检测</div>
+    <div class="stacking-demo" id="stackingDemo">
+      <div class="box box-red">z-index: 1</div>
+      <div class="box box-green">z-index: 2</div>
+      <div class="box box-blue">z-index: 3</div>
+      <div class="mask" id="stackingMask">检测遮盖区域</div>
+    </div>
+    <div class="note">通过 elementFromPoint() 检测某点是否被特定元素遮挡</div>
+  </div>
+
+  <!-- 场景二：Viewport 可见性 -->
+  <div class="viewport-status" id="viewportStatus">
+    <div class="item">viewport 可见性:</div>
+    <div id="viewportItems"></div>
+  </div>
+  <div class="container">
+    <div class="label">场景二：IntersectionObserver 检测 viewport 可见性</div>
+    <div class="viewport-demo" id="viewportDemo">
+      <div class="viewport-box" data-id="box1">元素 1（滚动查看）</div>
+      <div class="viewport-box" data-id="box2">元素 2</div>
+      <div class="viewport-box" data-id="box3">元素 3</div>
+    </div>
+    <div class="note">绿色 = 可见 | 灰色 = 不可见（已滚出 viewport）</div>
+  </div>
+
+  <!-- 场景三：opacity / visibility / display -->
+  <div class="container">
+    <div class="label">场景三：opacity / visibility / display 隐藏检测</div>
+    <div class="opacity-demo">
+      <div class="opacity-box opacity-visible">opacity: 1<br>可见</div>
+      <div class="opacity-box opacity-zero">opacity: 0<br>不可见</div>
+      <div class="opacity-box opacity-point1">opacity: 0.1<br>几乎不可见</div>
+      <div class="opacity-box visibility-hidden">visibility: hidden<br>不可见</div>
+      <div class="opacity-box display-none">display: none<br>不可见</div>
+    </div>
+    <div class="note">opacity: 0 元素仍占位且可被检测到，但视觉上不可见</div>
+  </div>
+
+  <!-- 场景四：Stacking Context -->
+  <div class="container">
+    <div class="label">场景四：Stacking Context 对 z-index 的限制</div>
+    <div class="context-demo">
+      <div class="context-item parent-z">
+        父级 z-index: 1（创建新 context）
+        <div class="context-item child-z">子级 z-index: 999（仍在父 context 内，不能超出）</div>
+      </div>
+      <div class="context-item no-context">
+        父级 opacity: 0.5（创建新 context）
+        <div class="context-item no-context-child">子级 z-index: 9999（仍在父 context 内）</div>
+      </div>
+    </div>
+    <div class="note">即使子级 z-index 数值再大，只要父级创建了 stacking context，子级就无法超出父级的层叠范围</div>
+  </div>
+
+  <script>
+    // ============================================
+    // 方法一：getComputedStyle + 几何计算
+    // ============================================
+    function isElementVisible(el) {
+      const style = getComputedStyle(el);
+      if (style.display === 'none') return false;
+      if (style.visibility === 'hidden') return false;
+      if (parseFloat(style.opacity) === 0) return false;
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 || rect.height === 0) return false;
+      return true;
+    }
+
+    function isElementObscured(el) {
+      const rect = el.getBoundingClientRect();
+      const cx = rect.left + rect.width / 2;
+      const cy = rect.top + rect.height / 2;
+      const topEl = document.elementFromPoint(cx, cy);
+      return topEl && topEl !== el && !el.contains(topEl);
+    }
+
+    // ============================================
+    // 方法二：IntersectionObserver（viewport 可见性）
+    // ============================================
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        const id = entry.target.dataset.id;
+        const visible = entry.isIntersecting;
+        entry.target.classList.toggle('hidden', !visible);
+        const statusEl = document.getElementById(`status-${id}`);
+        if (statusEl) {
+          statusEl.textContent = visible ? '✅ 可见' : '❌ 不可见';
+          statusEl.className = visible ? 'visible' : 'hidden';
+        }
+        document.getElementById('r1').textContent = visible ? '是' : '否';
+        document.getElementById('r1').className = visible ? 'tag-yes' : 'tag-no';
+      });
+    }, { threshold: 0.1 });
+
+    document.querySelectorAll('.viewport-box').forEach(box => {
+      observer.observe(box);
+      // 添加状态显示
+      const statusDiv = document.createElement('div');
+      statusDiv.id = `status-${box.dataset.id}`;
+      statusDiv.style.cssText = 'margin-top:8px;font-size:12px;color:#2ecc71';
+      statusDiv.textContent = '✅ 可见';
+      box.appendChild(statusDiv);
+    });
+
+    // ============================================
+    // 方法三：Stacking Context 检测
+    // ============================================
+    function hasStackingContext(el) {
+      const style = getComputedStyle(el);
+      const props = [
+        'z-index', 'opacity', 'transform', 'filter',
+        'mix-blend-mode', 'isolation', 'clip-path', 'mask'
+      ];
+      const zIndex = style.zIndex;
+      const opacity = parseFloat(style.opacity);
+      const transform = style.transform;
+      const hasZIndex = zIndex !== 'auto' && zIndex !== '0';
+      const hasOpacity = opacity < 1;
+      const hasTransform = transform !== 'none' && transform !== '';
+      return hasZIndex || hasOpacity || hasTransform;
+    }
+
+    // 初始检测
+    function runDetection() {
+      const stackingDemo = document.getElementById('stackingDemo');
+      const boxGreen = document.querySelector('.box-green');
+      const boxBlue = document.querySelector('.box-blue');
+
+      // 检测绿色框是否被蓝色框遮挡
+      const obscured = isElementObscured(boxGreen);
+      document.getElementById('r2').textContent = obscured ? '是' : '否';
+      document.getElementById('r2').className = obscured ? 'tag-no' : 'tag-yes';
+
+      // 检测 opacity
+      const opacityBoxes = document.querySelectorAll('.opacity-box');
+      const zeroOpacityBox = opacityBoxes[1];
+      document.getElementById('r3').textContent = isElementVisible(zeroOpacityBox) ? '否（opacity:0）' : '是';
+      document.getElementById('r3').className = isElementVisible(zeroOpacityBox) ? 'tag-yes' : 'tag-no';
+
+      // 检测 visibility
+      const visBox = document.querySelector('.visibility-hidden');
+      document.getElementById('r4').textContent = isElementVisible(visBox) ? '是' : '否（visibility:hidden）';
+      document.getElementById('r4').className = isElementVisible(visBox) ? 'tag-yes' : 'tag-no';
+
+      // 检测 stacking context
+      const parentZ = document.querySelector('.parent-z');
+      document.getElementById('r5').textContent = hasStackingContext(parentZ) ? '是' : '否';
+      document.getElementById('r5').className = hasStackingContext(parentZ) ? 'tag-yes' : 'tag-no';
+    }
+
+    runDetection();
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## 任务
rn 实现包裹效果 — flex-wrap 布局在 CSS 和 React Native 中的实现对比。

## 内容
1. flex-wrap: wrap vs nowrap 对比演示
2. flex-wrap: wrap-reverse 反向换行
3. align-content 多行对齐方式（flex-start / center / space-between / stretch）
4. CSS → React Native 属性映射表

## RN 关键差异
- flexWrap: 'wrap'（驼峰式）
- gap 在 RN 0.76+ 才原生支持
- alignContent 对应 align-content