### PR TITLE
feat: devicePixelRatio 计算方法详解

### DIFF
--- a/examples/css/demos/device-pixel-ratio.html
+++ b/examples/css/demos/device-pixel-ratio.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>devicePixelRatio 计算方法</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; padding: 40px; background: #f5f5f5; }
+    h1 { font-size: 18px; margin-bottom: 24px; color: #333; }
+    h2 { font-size: 14px; margin: 16px 0 8px; color: #555; }
+    .container { background: #fff; border-radius: 8px; padding: 20px; margin-bottom: 20px; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+    .label { font-size: 12px; color: #888; margin-bottom: 12px; }
+    .note { font-size: 13px; color: #666; margin-top: 12px; padding: 12px; background: #f9f9f9; border-radius: 4px; border-left: 3px solid #667eea; }
+    .result-panel { position: fixed; top: 20px; right: 20px; background: rgba(0,0,0,0.85); color: #fff; padding: 16px 20px; border-radius: 8px; font-size: 13px; z-index: 9999; min-width: 260px; }
+    .result-panel h3 { font-size: 14px; margin-bottom: 10px; color: #f39c12; }
+    .result-panel .row { padding: 4px 0; border-bottom: 1px solid rgba(255,255,255,0.1); }
+    .result-panel .row:last-child { border-bottom: none; }
+    .result-panel .value { color: #2ecc71; font-weight: bold; }
+    .code-block { background: #1e1e1e; color: #d4d4d4; padding: 16px; border-radius: 6px; font-family: 'Consolas', monospace; font-size: 13px; overflow-x: auto; }
+    .code-block .comment { color: #6a9955; }
+    .code-block .keyword { color: #569cd6; }
+    .code-block .prop { color: #9cdcfe; }
+    .code-block .value { color: #b5cea8; }
+    table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    th { text-align: left; padding: 10px; background: #f5f5f5; border-bottom: 2px solid #ddd; }
+    td { padding: 10px; border-bottom: 1px solid #eee; }
+    .tag { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 11px; }
+    .tag-retina { background: #d4edda; color: #155724; }
+    canvas { border: 1px solid #ddd; border-radius: 4px; background: #fff; }
+  </style>
+</head>
+<body>
+
+  <h1>devicePixelRatio — 物理像素 vs CSS 像素计算</h1>
+
+  <div class="result-panel" id="panel">
+    <h3>📊 你的设备参数</h3>
+    <div class="row">devicePixelRatio: <span class="value" id="dpr">-</span></div>
+    <div class="row">物理宽度: <span class="value" id="physW">-</span>px</div>
+    <div class="row">dip 宽度: <span class="value" id="dipW">-</span>px</div>
+    <div class="row">1 CSS px = <span class="value" id="physPx">-</span> 物理像素</div>
+    <div class="row">设备: <span class="value" id="desc">-</span></div>
+  </div>
+
+  <div class="container">
+    <div class="label">核心公式</div>
+    <div class="code-block"><span class="keyword">devicePixelRatio</span> = 屏幕物理像素分辨率 / CSS 像素分辨率
+
+<span class="comment">// Retina 屏幕示例</span>
+<span class="prop">devicePixelRatio</span> = 1920 / 960 = <span class="value">2</span>
+
+<span class="comment">// 含义：1 个 CSS 像素实际渲染为 2×2 = 4 个物理像素</span></div>
+    <div class="note">
+      <strong>物理像素</strong>：显示器实际发光点，由 R/G/B 子像素组成<br>
+      <strong>dip / CSS 像素</strong>：CSS 和 JS 使用的抽象单位，设备无关
+    </div>
+  </div>
+
+  <div class="container">
+    <div class="label">DPR 视觉效果对比</div>
+    <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:20px;">
+      <div>
+        <h2>DPR = 1</h2>
+        <div style="background:#f0f0f0;padding:20px;border-radius:6px;text-align:center;">
+          <div style="width:16px;height:16px;background:#667eea;margin:0 auto;border-radius:2px;"></div>
+          <div style="font-size:12px;color:#888;margin-top:8px;">1 CSS px = 1×1 物理像素</div>
+        </div>
+      </div>
+      <div>
+        <h2>DPR = 2</h2>
+        <div style="background:#f0f0f0;padding:20px;border-radius:6px;text-align:center;">
+          <div style="display:grid;grid-template-columns:repeat(2,1fr);width:16px;height:16px;margin:0 auto;">
+            <div style="background:#764ba2;"></div><div style="background:#764ba2;"></div>
+            <div style="background:#764ba2;"></div><div style="background:#764ba2;"></div>
+          </div>
+          <div style="font-size:12px;color:#888;margin-top:8px;">1 CSS px = 2×2 物理像素</div>
+        </div>
+      </div>
+      <div>
+        <h2>DPR = 3</h2>
+        <div style="background:#f0f0f0;padding:20px;border-radius:6px;text-align:center;">
+          <div style="display:grid;grid-template-columns:repeat(3,1fr);width:16px;height:16px;margin:0 auto;">
+            <div style="background:#f39c12;"></div><div style="background:#f39c12;"></div><div style="background:#f39c12;"></div>
+            <div style="background:#f39c12;"></div><div style="background:#f39c12;"></div><div style="background:#f39c12;"></div>
+            <div style="background:#f39c12;"></div><div style="background:#f39c12;"></div><div style="background:#f39c12;"></div>
+          </div>
+          <div style="font-size:12px;color:#888;margin-top:8px;">1 CSS px = 3×3 物理像素</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="container">
+    <div class="label">常见设备计算</div>
+    <table>
+      <thead><tr><th>设备</th><th>物理分辨率</th><th>CSS 分辨率</th><th>dpr</th><th>类型</th></tr></thead>
+      <tbody style="color:#333;">
+        <tr><td>iPhone SE</td><td>1334×750</td><td>667×375</td><td><strong>2</strong></td><td><span class="tag tag-retina">Retina</span></td></tr>
+        <tr><td>iPhone 14 Pro</td><td>2556×1179</td><td>393×852</td><td><strong>3</strong></td><td><span class="tag tag-retina">超 Retina</span></td></tr>
+        <tr><td>普通 Android</td><td>1920×1080</td><td>360×640</td><td><strong>3</strong></td><td><span class="tag tag-retina">高 DPR</span></td></tr>
+        <tr><td>MacBook Pro</td><td>3024×1964</td><td>1512×982</td><td><strong>2</strong></td><td><span class="tag tag-retina">Retina</span></td></tr>
+        <tr><td>老式显示器</td><td>1440×900</td><td>1440×900</td><td><strong>1</strong></td><td>标准 DPR</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="container">
+    <div class="label">Canvas 中的 DPR 处理</div>
+    <div style="display:grid;grid-template-columns:1fr 1fr;gap:20px;">
+      <div>
+        <h2>❌ 不考虑 DPR（模糊）</h2>
+        <div class="code-block"><span class="keyword">const</span> canvas = getElementById(<span class="value">'c1'</span>);
+canvas.<span class="prop">width</span> = <span class="value">300</span>;
+canvas.<span class="prop">height</span> = <span class="value">150</span>;</div>
+        <canvas id="c1" width="300" height="150" style="width:300px;height:150px;"></canvas>
+        <div class="note">DPR=2 时，物理像素只有 300×150，放大后模糊</div>
+      </div>
+      <div>
+        <h2>✅ 考虑 DPR（清晰）</h2>
+        <div class="code-block"><span class="keyword">const</span> dpr = devicePixelRatio;
+canvas.<span class="prop">width</span> = <span class="value">300</span> * dpr;
+canvas.<span class="prop">height</span> = <span class="value">150</span> * dpr;
+canvas.<span class="prop">style</span>.width = <span class="value">'300px'</span>;
+canvas.<span class="prop">style</span>.height = <span class="value">'150px'</span>;
+ctx.<span class="prop">scale</span>(dpr, dpr);</div>
+        <canvas id="c2" style="width:300px;height:150px;"></canvas>
+        <div class="note">物理像素 = CSS 像素 × DPR，清晰锐利</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="container">
+    <div class="label">DPR 对前端的影响</div>
+    <table>
+      <thead><tr><th>场景</th><th>问题</th><th>解决方案</th></tr></thead>
+      <tbody style="color:#333;">
+        <tr><td>Canvas 绘图</td><td>不乘 DPR → 模糊</td><td>canvas.width = CSS像素 × DPR; ctx.scale(DPR, DPR)</td></tr>
+        <tr><td>图片高清</td><td>普通图在 Retina 模糊</td><td>提供 @2x/@3x 图，或用 srcset</td></tr>
+        <tr><td>border: 1px</td><td>Retina 上实际 2 物理像素</td><td>0.5px 或 box-shadow 模拟</td></tr>
+        <tr><td>小图标</td><td>Retina 显示不清</td><td>SVG / icon font / 多倍图</td></tr>
+      </tbody>
+    </table>
+  </div>
+
+  <script>
+    const dpr = window.devicePixelRatio || 1;
+    document.getElementById('dpr').textContent = dpr;
+    document.getElementById('physW').textContent = window.screen.width * dpr;
+    document.getElementById('dipW').textContent = window.screen.width;
+    document.getElementById('physPx').textContent = `${dpr}×${dpr} = ${dpr * dpr}个`;
+    document.getElementById('desc').textContent = dpr >= 3 ? '超 Retina' : dpr >= 2 ? 'Retina' : '标准屏';
+
+    // 不考虑 DPR
+    const c1 = document.getElementById('c1');
+    const ctx1 = c1.getContext('2d');
+    ctx1.fillStyle = '#667eea';
+    ctx1.fillRect(10, 10, 100, 50);
+
+    // 考虑 DPR
+    const c2 = document.getElementById('c2');
+    const d = window.devicePixelRatio || 1;
+    c2.width = 300 * d;
+    c2.height = 150 * d;
+    const ctx2 = c2.getContext('2d');
+    ctx2.scale(d, d);
+    ctx2.fillStyle = '#667eea';
+    ctx2.fillRect(10, 10, 100, 50);
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
## 任务
说一下 devicePixelRatio 是如何计算的。

## 内容
### 核心公式
devicePixelRatio = 屏幕物理像素分辨率 / CSS 像素分辨率

### DPR 视觉效果对比
- DPR=1：1 CSS 像素 = 1×1 物理像素（标准屏）
- DPR=2：1 CSS 像素 = 2×2 物理像素（Retina）
- DPR=3：1 CSS 像素 = 3×3 物理像素（超 Retina）

### 常见设备计算
| 设备 | 物理分辨率 | CSS 分辨率 | dpr |
|------|-----------|-----------|-----|
| iPhone SE | 1334×750 | 667×375 | 2 |
| iPhone 14 Pro | 2556×1179 | 393×852 | 3 |
| MacBook Pro | 3024×1964 | 1512×982 | 2 |

### Canvas DPR 处理
- 正确：canvas.width = CSS像素 × DPR; ctx.scale(DPR, DPR)
- 错误：直接设置 canvas.width = CSS像素（在高 DPR 屏模糊）

### DPR 对前端的影响
- Canvas 绘图模糊
- 图片高清适配（srcset）
- border: 1px 在 Retina 上实际 2 物理像素