### PR TITLE
feat: 新增 table cell 省略号不生效文档和交互演示

### DIFF
--- a/src/topics/02.layout/07.table-cell-ellipsis/_demos/table-cell-ellipsis.html
+++ b/src/topics/02.layout/07.table-cell-ellipsis/_demos/table-cell-ellipsis.html
@@ -1,0 +1,294 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Table Cell Ellipsis Demo</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+    
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f5f5f5;
+    }
+    
+    h1 {
+      text-align: center;
+      color: #333;
+      margin-bottom: 30px;
+    }
+    
+    .demo-section {
+      background: white;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    
+    .demo-title {
+      font-size: 18px;
+      font-weight: 600;
+      color: #333;
+      margin-bottom: 15px;
+      padding-bottom: 10px;
+      border-bottom: 2px solid #eee;
+    }
+    
+    .demo-title.error {
+      border-bottom-color: #ff4444;
+      color: #ff4444;
+    }
+    
+    .demo-title.success {
+      border-bottom-color: #44bb44;
+      color: #44bb44;
+    }
+    
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-bottom: 15px;
+    }
+    
+    td {
+      border: 1px solid #ddd;
+      padding: 10px;
+      background: #fafafa;
+    }
+    
+    .cell-ellipsis {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+    
+    .cell-normal {
+      /* 默认样式 */
+    }
+    
+    .summary-table td {
+      vertical-align: top;
+      font-size: 14px;
+    }
+    
+    code {
+      background: #f0f0f0;
+      padding: 2px 6px;
+      border-radius: 3px;
+      font-family: 'Monaco', 'Consolas', monospace;
+      font-size: 13px;
+    }
+    
+    .key-point {
+      background: #fff3cd;
+      border: 1px solid #ffc107;
+      border-radius: 4px;
+      padding: 12px;
+      margin: 10px 0;
+    }
+    
+    .key-point strong {
+      color: #856404;
+    }
+    
+    .comparison-table {
+      width: 100%;
+      margin-top: 10px;
+    }
+    
+    .comparison-table th,
+    .comparison-table td {
+      padding: 10px;
+      text-align: left;
+      border: 1px solid #ddd;
+    }
+    
+    .comparison-table th {
+      background: #f8f8f8;
+      font-weight: 600;
+    }
+    
+    .checklist {
+      background: #e8f5e9;
+      border: 1px solid #4caf50;
+      border-radius: 4px;
+      padding: 15px;
+    }
+    
+    .checklist h4 {
+      margin: 0 0 10px 0;
+      color: #2e7d32;
+    }
+    
+    .checklist ul {
+      margin: 0;
+      padding-left: 20px;
+    }
+    
+    .checklist li {
+      margin: 5px 0;
+      color: #333;
+    }
+    
+    .checklist li strong {
+      color: #1b5e20;
+    }
+  </style>
+</head>
+<body>
+  <h1>📏 Table Cell 省略号不生效 — 解决方案</h1>
+  
+  <!-- 问题演示 -->
+  <div class="demo-section">
+    <div class="demo-title error">❌ 错误演示：默认 table-layout: auto（省略号不生效）</div>
+    <table>
+      <tr>
+        <td class="cell-normal">这是一段很长的文字内容，超出单元格宽度后需要显示省略号，但是省略号不生效</td>
+      </tr>
+    </table>
+    <div class="key-point">
+      <strong>原因：</strong>默认 <code>table-layout: auto</code> 时，单元格宽度由内容决定，内容永远不会被"溢出"
+    </div>
+  </div>
+  
+  <!-- 正确解决方案 -->
+  <div class="demo-section">
+    <div class="demo-title success">✅ 正确方案一：table-layout: fixed + width</div>
+    <table style="table-layout: fixed; width: 300px;">
+      <tr>
+        <td class="cell-ellipsis">这是一段很长的文字内容，超出单元格宽度后显示省略号 ✓</td>
+      </tr>
+    </table>
+    <div class="key-point">
+      <strong>关键代码：</strong>
+      <code>table-layout: fixed</code> + <code>width: 300px</code>
+    </div>
+  </div>
+  
+  <!-- 多列表格 -->
+  <div class="demo-section">
+    <div class="demo-title success">✅ 正确方案二：多列表格 + 固定宽度</div>
+    <table style="table-layout: fixed; width: 100%;">
+      <colgroup>
+        <col style="width: 30%;">
+        <col style="width: 50%;">
+        <col style="width: 20%;">
+      </colgroup>
+      <tr>
+        <td class="cell-ellipsis">第一列的省略号内容</td>
+        <td class="cell-ellipsis">第二列的较长文字内容，也会省略显示省略号</td>
+        <td class="cell-ellipsis">第三列</td>
+      </tr>
+      <tr>
+        <td class="cell-ellipsis">第二行第一列</td>
+        <td class="cell-ellipsis">第二行第二列内容文字很长很长</td>
+        <td class="cell-ellipsis">第二行第三列</td>
+      </tr>
+    </table>
+  </div>
+  
+  <!-- 必要条件检查清单 -->
+  <div class="demo-section">
+    <div class="demo-title">📋 省略号生效的五个必要条件</div>
+    <div class="checklist">
+      <h4>检查清单（缺一不可）</h4>
+      <ul>
+        <li><strong>table-layout: fixed;</strong> — 表格使用固定布局</li>
+        <li><strong>width: 200px;</strong>（或 %） — 表格宽度必须 > 0</li>
+        <li><strong>overflow: hidden;</strong> — 溢出内容隐藏</li>
+        <li><strong>white-space: nowrap;</strong> — 禁止文字换行</li>
+        <li><strong>text-overflow: ellipsis;</strong> — 溢出显示省略号</li>
+      </ul>
+    </div>
+  </div>
+  
+  <!-- table-layout 对比 -->
+  <div class="demo-section">
+    <div class="demo-title">🔄 table-layout: auto vs fixed 对比</div>
+    <table class="comparison-table">
+      <thead>
+        <tr>
+          <th>特性</th>
+          <th>table-layout: auto</th>
+          <th>table-layout: fixed</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>布局算法</td>
+          <td>自动，内容决定列宽</td>
+          <td>固定，由定义决定列宽</td>
+        </tr>
+        <tr>
+          <td>省略号支持</td>
+          <td>❌ 不支持</td>
+          <td>✅ 支持</td>
+        </tr>
+        <tr>
+          <td>渲染性能</td>
+          <td>较慢（计算所有内容）</td>
+          <td>较快（只需计算首行）</td>
+        </tr>
+        <tr>
+          <td>适用场景</td>
+          <td>内容不确定的表格</td>
+          <td>需精确控制列宽的表格</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  
+  <!-- 常见踩坑 -->
+  <div class="demo-section">
+    <div class="demo-title">⚠️ 常见踩坑</div>
+    <table class="summary-table">
+      <tr>
+        <td style="width: 30%;"><strong>踩坑 1</strong></td>
+        <td>没有设置 <code>table-layout: fixed</code></td>
+      </tr>
+      <tr>
+        <td><strong>踩坑 2</strong></td>
+        <td>table 的 <code>width</code> 为 0 或未设置</td>
+      </tr>
+      <tr>
+        <td><strong>踩坑 3</strong></td>
+        <td>没有设置 <code>white-space: nowrap</code></td>
+      </tr>
+      <tr>
+        <td><strong>踩坑 4</strong></td>
+        <td><code>overflow</code> 不是 <code>hidden</code>（默认值是 visible）</td>
+      </tr>
+    </table>
+  </div>
+  
+  <!-- 完整代码模板 -->
+  <div class="demo-section">
+    <div class="demo-title">📝 完整代码模板</div>
+    <pre style="background: #2d2d2d; color: #f8f8f2; padding: 15px; border-radius: 4px; overflow-x: auto; font-size: 13px;">
+<code>&lt;style&gt;
+table {
+  table-layout: fixed;  /* 必须：固定表格布局 */
+  width: 300px;          /* 必须：宽度 > 0 */
+}
+
+td {
+  overflow: hidden;      /* 必须：隐藏溢出 */
+  white-space: nowrap;   /* 必须：禁止换行 */
+  text-overflow: ellipsis; /* 必须：显示省略号 */
+}
+&lt;/style&gt;
+
+&lt;table&gt;
+  &lt;tr&gt;
+    &lt;td&gt;很长很长的文字内容...&lt;/td&gt;
+  &lt;/tr&gt;
+&lt;/table&gt;</code></pre>
+  </div>
+</body>
+</html>

--- a/src/topics/02.layout/07.table-cell-ellipsis/index.mdx
+++ b/src/topics/02.layout/07.table-cell-ellipsis/index.mdx
@@ -1,0 +1,216 @@
+---
+title: Table Cell 省略号不生效
+category: 布局基础
+tags: [table, text-overflow, ellipsis, overflow, white-space]
+description: 详细介绍 CSS table cell 中 text-overflow: ellipsis 不生效的原因和多种解决方案。
+keywords: table, td, text-overflow, ellipsis, 省略号, overflow, white-space, nowrap
+---
+
+# Table Cell 省略号不生效
+
+**解决 table td 中 text-overflow: ellipsis 不生效的问题**
+
+## 问题描述
+
+在 `table` 的 `td` 中设置 `text-overflow: ellipsis` 想要实现文字溢出显示省略号，但发现省略号不生效。
+
+```html
+<table>
+  <tr>
+    <td class="cell">这是一段很长的文字内容，超出单元格宽度后需要显示省略号</td>
+  </tr>
+</table>
+```
+
+```css
+.cell {
+  text-overflow: ellipsis; /* ❌ 不生效 */
+  overflow: hidden;
+}
+```
+
+## 根本原因
+
+Table 默认采用 `table-layout: auto`，单元格的宽度由内容决定（自动表格布局算法）。
+
+`text-overflow: ellipsis` 生效的必要条件是**元素必须有明确的宽度约束**。当单元格宽度由内容决定时，内容永远不会被"溢出"，因此省略号永远不会触发。
+
+## 解决方案
+
+### 方案一：设置 table-layout: fixed（推荐）
+
+**核心原理**：`table-layout: fixed` 使表格使用固定表格布局算法，列宽由 `table` 或 `col` 元素的宽度决定，而非内容。
+
+```html
+<style>
+table {
+  table-layout: fixed; /* 关键：固定表格布局 */
+  width: 200px;       /* 必须设置宽度，且宽度 > 0 */
+}
+
+td {
+  overflow: hidden;
+  white-space: nowrap;   /* 关键：禁止换行 */
+  text-overflow: ellipsis; /* 关键：溢出显示省略号 */
+}
+</style>
+
+<table>
+  <tr>
+    <td>这是一段很长的文字内容...</td>
+  </tr>
+</table>
+```
+
+**生效的必要条件（缺一不可）**：
+1. `table` 设置 `table-layout: fixed`
+2. `table` 设置 `width`（且大于 0）
+3. `td` 设置 `overflow: hidden`
+4. `td` 设置 `white-space: nowrap`
+5. `td` 设置 `text-overflow: ellipsis`
+
+### 方案二：使用 colgroup 定义列宽
+
+使用 `<colgroup>` 定义列宽，配合 `table-layout: fixed` 实现精确控制：
+
+```html
+<table>
+  <colgroup>
+    <col style="width: 200px">
+    <col style="width: 100px">
+  </colgroup>
+  <tr>
+    <td>第一列内容</td>
+    <td>第二列内容</td>
+  </tr>
+</table>
+```
+
+### 方案三：同时限制最大宽度和最小宽度
+
+```css
+td {
+  max-width: 200px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+```
+
+注意：`max-width` 配合固定宽度表格使用效果更好。
+
+## 完整 Demo
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    .demo-table {
+      table-layout: fixed;
+      width: 300px;
+      border-collapse: collapse;
+    }
+    
+    .demo-table td {
+      border: 1px solid #ddd;
+      padding: 8px;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+  </style>
+</head>
+<body>
+  <table class="demo-table">
+    <tr>
+      <td>这是一段很长的文字内容，超出单元格宽度后需要显示省略号</td>
+    </tr>
+  </table>
+</body>
+</html>
+```
+
+## 常见踩坑
+
+### ❌ 踩坑 1：没有设置 table-layout: fixed
+
+```css
+/* 错误：默认 auto 布局，内容决定列宽 */
+table {
+  width: 300px;
+  /* 缺少 table-layout: fixed */
+}
+```
+
+### ❌ 踩坑 2：table 的 width 为 0 或未设置
+
+```css
+/* 错误：width 为 0 或 auto */
+table {
+  width: 0; /* 或 width: auto; */
+  table-layout: fixed;
+}
+```
+
+### ❌ 踩坑 3：没有设置 white-space: nowrap
+
+```css
+/* 错误：文字可以换行，省略号不会触发 */
+td {
+  white-space: normal; /* 或省略不写 */
+  text-overflow: ellipsis;
+}
+```
+
+### ❌ 踩坑 4：overflow 不是 hidden
+
+```css
+/* 错误：overflow 默认是 visible */
+td {
+  overflow: visible;
+  text-overflow: ellipsis;
+}
+```
+
+## table-layout: auto vs fixed 对比
+
+| 特性 | `table-layout: auto` | `table-layout: fixed` |
+|------|---------------------|---------------------|
+| 布局算法 | 自动（内容决定列宽） | 固定（列宽由定义决定） |
+| 列宽 | 由最宽内容决定 | 由首行/colgroup 决定 |
+| 性能 | 较慢（需计算所有内容） | 较快（只需计算首行） |
+| 省略号支持 | ❌ 不支持 | ✅ 支持 |
+| 适用场景 | 内容不确定的表格 | 需要精确控制列宽的表格 |
+
+## 浏览器兼容性
+
+所有主流浏览器都支持 `table-layout: fixed` 和 `text-overflow: ellipsis`：
+- Chrome 1+
+- Firefox 7+
+- Safari 3.1+
+- Edge 12+
+- IE 8+（部分兼容）
+
+## 相关属性速查
+
+```css
+/* 省略号三件套 */
+text-overflow: ellipsis;  /* 溢出显示省略号 */
+overflow: hidden;         /* 隐藏溢出内容 */
+white-space: nowrap;      /* 禁止换行 */
+
+/* 表格固定布局 */
+table-layout: fixed;      /* 固定表格布局 */
+width: 200px;             /* 表格宽度（必须 > 0） */
+```
+
+## 总结
+
+Table cell 省略号不生效的核心原因是**默认的 `table-layout: auto` 使单元格宽度由内容决定**，省略号无法触发。
+
+解决方法是：
+1. 在 `table` 上设置 `table-layout: fixed` 和 `width`
+2. 在 `td` 上设置 `overflow: hidden`、`white-space: nowrap`、`text-overflow: ellipsis`
+
+记住省略号生效的**五个必要条件**，缺一不可！


### PR DESCRIPTION
## 📝 任务完成

**问题**：table cell 中 text-overflow: ellipsis 不生效

**仓库**：learn-css

**核心结论**：
- 	able-layout: auto 时单元格宽度由内容决定，省略号无法触发
- 必须设置 	able-layout: fixed + width + overflow: hidden + white-space: nowrap + 	ext-overflow: ellipsis

## 📦 新增内容

### 技术文档
- src/topics/02.layout/07.table-cell-ellipsis/index.mdx（3700+ 字）
  - 问题描述与根因分析
  - 5 种必要条件详解
  - table-layout: auto vs fixed 对比表
  - 常见踩坑汇总
  - 完整代码模板

### 交互演示
- _demos/table-cell-ellipsis.html
  - 错误演示（省略号不生效）
  - 正确方案（table-layout: fixed）
  - 多列表格示例
  - 必要条件检查清单
  - 常见踩坑对照表

## Reminder ID
4B92451C-7C8C-436A-8BA3-10E4BA1E032F