### PR TITLE
docs: img 标签无图片时背景色占位控制

### DIFF
--- a/docs/topics/img-placeholder/index.md
+++ b/docs/topics/img-placeholder/index.md
@@ -1,0 +1,331 @@
+# img 标签无图片时背景色控制
+
+## 问题描述
+
+在开发中，我们经常遇到这样的需求：当 `img` 标签的 `src` 无效、图片加载中或图片加载失败时，希望显示一个背景色占位。
+
+但 `img` 标签本身的背景色样式在以下情况不生效：
+- 图片加载中（浏览器默认显示空白）
+- 图片加载失败（浏览器显示破碎图标）
+- `src` 为空时的默认行为
+
+## 核心原理
+
+### 为什么不生效？
+
+`img` 元素是替换元素（Replaced Element），其渲染由资源内容决定，而非 CSS 内容。当没有有效图片内容时，`img` 元素的高度可能为 0 或显示浏览器默认的错误图标。
+
+```css
+/* ❌ 直接设置 background-color 无效 */
+img {
+  background-color: #f0f0f0; /* 不生效 */
+}
+```
+
+### 解决方案
+
+使用 **CSS 背景色 + padding** 技巧，让背景色成为图片的"底板"：
+
+```css
+/* ✅ 正确：利用背景色 + 内边距模拟占位 */
+.img-wrapper {
+  background-color: #f0f0f0; /* 占位背景色 */
+  padding-bottom: 66.67%;    /* 16:9 比例 = 9/16 = 0.5625 */
+  position: relative;
+}
+
+.img-wrapper img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+```
+
+## 方案对比
+
+| 方案 | 优点 | 缺点 | 适用场景 |
+|-----|------|------|---------|
+| 背景色 + padding | 纯 CSS、比例自适应 | 需要 wrapper 元素 | 响应式图片 |
+| 背景色 + aspect-ratio | 纯 CSS、简洁 | 需要 wrapper | 现代浏览器 |
+| ::before 伪元素 | 无需 HTML 改动 | 兼容性稍差 | 快速实现 |
+| JS 检测 + class | 可自定义错误UI | 需要 JS | 复杂交互 |
+
+## 方案 1：CSS aspect-ratio（推荐）
+
+```css
+.img-wrapper {
+  background-color: #e0e0e0;
+  aspect-ratio: 16 / 9; /* 控制比例 */
+  position: relative;
+}
+
+.img-wrapper img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* 加载中/失败状态 */
+.img-wrapper img[src=""],
+.img-wrapper img:not([src]) {
+  opacity: 0;
+}
+
+/* 使用 CSS 动画实现淡入效果 */
+.img-wrapper img.loaded {
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+```
+
+```html
+<div class="img-wrapper">
+  <img src="example.jpg" alt="示例图片" 
+       onload="this.classList.add('loaded')"
+       onerror="this.style.display='none'">
+</div>
+```
+
+## 方案 2：使用 ::before 伪元素
+
+```css
+.img-container {
+  position: relative;
+  display: inline-block;
+}
+
+/* 背景占位层 */
+.img-container::before {
+  content: '';
+  display: block;
+  background-color: #f5f5f5;
+  /* 使用 padding-bottom 维持比例 */
+  padding-bottom: 75%; /* 4:3 比例 */
+}
+
+/* 图片绝对定位覆盖 */
+.img-container img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+```
+
+## 方案 3：图片加载失败时显示占位
+
+```javascript
+// 监听图片加载错误
+document.querySelectorAll('img').forEach(img => {
+  img.addEventListener('error', function() {
+    // 显示占位背景
+    this.style.opacity = '0';
+    this.parentElement.classList.add('img-error');
+  });
+  
+  img.addEventListener('load', function() {
+    this.style.opacity = '1';
+    this.parentElement.classList.remove('img-error');
+    this.classList.add('loaded');
+  });
+});
+```
+
+```css
+/* 占位图标 */
+.img-error::after {
+  content: '🖼️';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 48px;
+}
+```
+
+## 方案 4：纯 CSS 实现加载状态
+
+```css
+/* 使用 CSS 动画模拟加载中 */
+img {
+  background: linear-gradient(
+    90deg,
+    #f0f0f0 25%,
+    #e0e0e0 50%,
+    #f0f0f0 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+img[src]:not([src=""]) {
+  animation: none;
+  background: none;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+```
+
+## 实际应用：头像占位
+
+```css
+.avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background-color: #e0e0e0;
+  overflow: hidden;
+  position: relative;
+}
+
+.avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  /* 图片加载失败时不显示破碎图标 */
+  onerror: "this.style.display='none'";
+}
+```
+
+```html
+<!-- 带默认头像的写法 -->
+<div class="avatar">
+  <img src="user.jpg" alt="用户头像" 
+       onerror="this.src='default-avatar.png'">
+</div>
+```
+
+## 最佳实践
+
+### 1. 使用 aspect-ratio 控制比例
+
+```css
+.img-wrapper {
+  background-color: #f0f0f0;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+}
+
+.img-wrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+```
+
+### 2. 优雅的图片加载动画
+
+```css
+/* 初始隐藏 */
+.img-wrapper img {
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+/* 加载完成淡入 */
+.img-wrapper img.loaded {
+  opacity: 1;
+}
+```
+
+```javascript
+// 页面加载完成后添加 loaded 类
+document.querySelectorAll('.img-wrapper img').forEach(img => {
+  if (img.complete) {
+    img.classList.add('loaded');
+  } else {
+    img.addEventListener('load', () => img.classList.add('loaded'));
+  }
+});
+```
+
+### 3. 响应式图片场景
+
+```css
+/* 容器保持比例，图片自适应填充 */
+.picture-card {
+  background-color: #f8f8f8;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+}
+
+.picture-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+.picture-card:hover img {
+  transform: scale(1.05);
+}
+```
+
+## 常见问题
+
+### Q1: 为什么 background-color 不直接在 img 上生效？
+
+因为 `img` 是替换元素。当 `src` 有效时，图片内容覆盖了整个元素区域；当 `src` 无效时，元素的渲染由浏览器决定，通常高度为 0。
+
+### Q2: 如何在图片加载前显示背景色？
+
+使用 wrapper 元素，将背景色设置在 wrapper 上，图片 absolute 定位覆盖。
+
+### Q3: 如何避免加载失败时显示破碎图标？
+
+```css
+/* 隐藏破碎图标 */
+img[src=""],
+img:not([src]) {
+  visibility: hidden;
+}
+
+/* 或者使用 onerror 隐藏 */
+img.onerror = function() { this.style.visibility = 'hidden'; }
+```
+
+### Q4: 如何实现骨架屏效果？
+
+```css
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    #f0f0f0 0%,
+    #e0e0e0 50%,
+    #f0f0f0 100%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-loading 1.5s infinite;
+}
+
+@keyframes skeleton-loading {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+```
+
+## 总结
+
+| 场景 | 推荐方案 |
+|-----|---------|
+| 响应式图片占位 | `aspect-ratio` + wrapper |
+| 加载动画 | shimmer skeleton CSS |
+| 错误占位 | `onerror` + 自定义 UI |
+| 头像占位 | 圆形 wrapper + 默认图 |
+
+**核心思想**：背景色必须设置在 img 的容器上，而非 img 本身。使用 wrapper + 绝对定位是处理图片占位的标准做法。

--- a/examples/css/demos/img-placeholder/index.html
+++ b/examples/css/demos/img-placeholder/index.html
@@ -1,0 +1,583 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>img 标签背景色占位演示</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f0f0f;
+      color: #fff;
+      min-height: 100vh;
+      padding: 24px;
+    }
+
+    h1 {
+      font-size: 24px;
+      margin-bottom: 8px;
+    }
+
+    .subtitle {
+      color: #888;
+      margin-bottom: 32px;
+      font-size: 14px;
+    }
+
+    .demo-section {
+      margin-bottom: 48px;
+    }
+
+    .demo-title {
+      font-size: 16px;
+      color: #4fc3f7;
+      margin-bottom: 16px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .demo-title::before {
+      content: '';
+      display: block;
+      width: 8px;
+      height: 8px;
+      background: #4fc3f7;
+      border-radius: 50%;
+    }
+
+    .problem-box {
+      background: #1a1a1a;
+      border: 1px solid #333;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 16px;
+    }
+
+    .problem-box h3 {
+      color: #ef5350;
+      font-size: 14px;
+      margin-bottom: 12px;
+    }
+
+    .problem-box p {
+      color: #888;
+      font-size: 13px;
+      line-height: 1.6;
+    }
+
+    /* ========== Demo 1: Direct img bg (wrong) ========== */
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 24px;
+    }
+
+    .demo-card {
+      background: #1a1a1a;
+      border: 1px solid #333;
+      border-radius: 12px;
+      padding: 24px;
+    }
+
+    .demo-card h4 {
+      font-size: 14px;
+      margin-bottom: 12px;
+      color: #aaa;
+    }
+
+    .demo-label {
+      font-size: 12px;
+      color: #666;
+      margin-bottom: 8px;
+    }
+
+    /* Wrong approach */
+    .img-wrong {
+      width: 100%;
+      height: 150px;
+      background-color: #e0e0e0; /* Won't work as expected */
+      border-radius: 8px;
+      margin-bottom: 12px;
+    }
+
+    .img-wrong img {
+      width: 100%;
+      height: 100%;
+    }
+
+    /* Correct approach */
+    .img-correct {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      background-color: #e0e0e0;
+      border-radius: 8px;
+      position: relative;
+      overflow: hidden;
+      margin-bottom: 12px;
+    }
+
+    .img-correct img {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+
+    .img-correct img.loaded {
+      opacity: 1;
+    }
+
+    /* ========== Demo 2: Loading skeleton ========== */
+    .skeleton {
+      background: linear-gradient(
+        90deg,
+        #2a2a2a 0%,
+        #3a3a3a 50%,
+        #2a2a2a 100%
+      );
+      background-size: 200% 100%;
+      animation: shimmer 1.5s infinite;
+      border-radius: 8px;
+    }
+
+    .skeleton-wrapper {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      position: relative;
+      margin-bottom: 12px;
+    }
+
+    .skeleton-img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+
+    .skeleton-img.loaded {
+      opacity: 1;
+    }
+
+    @keyframes shimmer {
+      0% { background-position: 200% 0; }
+      100% { background-position: -200% 0; }
+    }
+
+    /* ========== Demo 3: Avatar placeholder ========== */
+    .avatar-demo {
+      display: flex;
+      gap: 24px;
+      align-items: center;
+    }
+
+    .avatar {
+      width: 80px;
+      height: 80px;
+      border-radius: 50%;
+      background-color: #3a3a3a;
+      overflow: hidden;
+      position: relative;
+      flex-shrink: 0;
+    }
+
+    .avatar img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+
+    .avatar img.loaded {
+      opacity: 1;
+    }
+
+    .avatar.large {
+      width: 120px;
+      height: 120px;
+    }
+
+    .avatar.small {
+      width: 48px;
+      height: 48px;
+    }
+
+    /* ========== Demo 4: Error state ========== */
+    .error-state {
+      position: relative;
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      background-color: #2a2a2a;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    .error-placeholder {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      color: #666;
+    }
+
+    .error-placeholder .icon {
+      font-size: 48px;
+      margin-bottom: 8px;
+    }
+
+    .error-placeholder .text {
+      font-size: 14px;
+    }
+
+    .error-state img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .error-state img.hidden {
+      display: none;
+    }
+
+    /* ========== Demo 5: Hover zoom ========== */
+    .img-hover-wrapper {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      background-color: #e0e0e0;
+      border-radius: 8px;
+      overflow: hidden;
+      position: relative;
+      margin-bottom: 12px;
+    }
+
+    .img-hover-wrapper img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      opacity: 0;
+      transition: opacity 0.3s ease, transform 0.3s ease;
+    }
+
+    .img-hover-wrapper img.loaded {
+      opacity: 1;
+    }
+
+    .img-hover-wrapper:hover img {
+      transform: scale(1.05);
+    }
+
+    /* ========== Controls ========== */
+    .controls {
+      margin-top: 16px;
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .control-btn {
+      padding: 8px 16px;
+      background: #333;
+      border: 1px solid #444;
+      border-radius: 8px;
+      color: #fff;
+      font-size: 13px;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .control-btn:hover {
+      background: #444;
+      border-color: #555;
+    }
+
+    .control-btn.active {
+      background: #4fc3f7;
+      border-color: #4fc3f7;
+      color: #000;
+    }
+
+    .control-btn.danger {
+      background: #c62828;
+      border-color: #c62828;
+    }
+
+    /* ========== Toast ========== */
+    .toast {
+      position: fixed;
+      bottom: 24px;
+      left: 50%;
+      transform: translateX(-50%) translateY(100px);
+      background: #333;
+      border: 1px solid #555;
+      border-radius: 12px;
+      padding: 12px 24px;
+      font-size: 14px;
+      opacity: 0;
+      transition: all 0.3s ease;
+      z-index: 2000;
+    }
+
+    .toast.show {
+      transform: translateX(-50%) translateY(0);
+      opacity: 1;
+    }
+
+    .toast.success {
+      background: #1b5e20;
+      border-color: #2e7d32;
+    }
+
+    .toast.error {
+      background: #b71c1c;
+      border-color: #c62828;
+    }
+
+    .info-box {
+      background: #1a1a1a;
+      border: 1px solid #333;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 16px;
+      font-size: 13px;
+      color: #888;
+    }
+
+    .info-box code {
+      background: #2a2a2a;
+      padding: 2px 6px;
+      border-radius: 4px;
+      color: #4fc3f7;
+      font-size: 12px;
+    }
+  </style>
+</head>
+<body>
+  <div class="toast" id="toast"></div>
+
+  <h1>img 标签无图片时背景色控制</h1>
+  <p class="subtitle">学习如何使用 CSS 控制 img 标签在无图片或加载失败时的背景色占位</p>
+
+  <!-- Demo 1: Wrong vs Correct -->
+  <div class="demo-section">
+    <div class="demo-title">Demo 1: 错误方案 vs 正确方案</div>
+    <div class="problem-box">
+      <h3>⚠️ 问题说明</h3>
+      <p>直接给 img 元素设置 background-color 在图片加载失败时不会显示，
+         因为 img 是替换元素，其渲染由 src 内容决定。需要使用 wrapper 元素来实现背景色占位。</p>
+    </div>
+    
+    <div class="demo-grid">
+      <div class="demo-card">
+        <h4>❌ 错误方案</h4>
+        <div class="demo-label">直接在 img 上设置 background-color</div>
+        <div class="img-wrong">
+          <img src="invalid-url-12345.jpg" alt="无效图片">
+        </div>
+        <div class="info-box">
+          图片加载失败，但背景色未显示。<br>
+          浏览器显示默认破碎图标。
+        </div>
+      </div>
+
+      <div class="demo-card">
+        <h4>✅ 正确方案</h4>
+        <div class="demo-label">使用 wrapper + background-color</div>
+        <div class="img-correct">
+          <img src="invalid-url-12345.jpg" alt="无效图片"
+               onload="this.classList.add('loaded')"
+               onerror="this.style.display='none'">
+        </div>
+        <div class="info-box">
+          使用 wrapper 作为背景色容器，<br>
+          图片绝对定位覆盖。
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Demo 2: Loading Skeleton -->
+  <div class="demo-section">
+    <div class="demo-title">Demo 2: 骨架屏加载动画</div>
+    <div class="demo-grid">
+      <div class="demo-card">
+        <h4>骨架屏效果</h4>
+        <div class="skeleton-wrapper">
+          <div class="skeleton"></div>
+          <img class="skeleton-img" src="https://picsum.photos/800/450?random=1" 
+               alt="加载中..."
+               onload="this.classList.add('loaded')"
+               onerror="this.style.display='none'">
+        </div>
+        <div class="info-box">
+          使用 shimmer 动画模拟加载中状态，<br>
+          图片加载完成后淡入显示。
+        </div>
+      </div>
+
+      <div class="demo-card">
+        <h4>淡入动画</h4>
+        <div class="skeleton-wrapper">
+          <div class="skeleton"></div>
+          <img class="skeleton-img" src="https://picsum.photos/800/450?random=2"
+               alt="加载中..."
+               onload="this.classList.add('loaded'); this.parentElement.querySelector('.skeleton').style.display='none'"
+               onerror="this.style.display='none'">
+        </div>
+        <div class="info-box">
+          点击按钮模拟加载延迟，<br>
+          观察骨架屏到图片的过渡。
+        </div>
+        <div class="controls">
+          <button class="control-btn" onclick="reloadImage(this)">重新加载</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Demo 3: Avatar Placeholder -->
+  <div class="demo-section">
+    <div class="demo-title">Demo 3: 头像占位</div>
+    <div class="demo-card">
+      <div class="avatar-demo">
+        <div class="avatar large">
+          <img src="invalid-avatar.jpg" alt="大头像"
+               onerror="this.style.display='none'">
+        </div>
+        <div class="avatar">
+          <img src="https://picsum.photos/200?random=10" alt="中头像"
+               onload="this.classList.add('loaded')"
+               onerror="this.style.display='none'">
+        </div>
+        <div class="avatar small">
+          <img src="https://picsum.photos/100?random=11" alt="小头像"
+               onload="this.classList.add('loaded')"
+               onerror="this.style.display='none'">
+        </div>
+      </div>
+      <div class="info-box" style="margin-top: 16px;">
+        圆形头像占位：大/中/小三种尺寸。<br>
+        左侧为加载失败的占位效果，右侧为加载成功。
+      </div>
+    </div>
+  </div>
+
+  <!-- Demo 4: Error State -->
+  <div class="demo-section">
+    <div class="demo-title">Demo 4: 自定义错误状态</div>
+    <div class="demo-grid">
+      <div class="demo-card">
+        <h4>图片加载失败</h4>
+        <div class="error-state">
+          <div class="error-placeholder">
+            <div class="icon">🖼️</div>
+            <div class="text">图片加载失败</div>
+          </div>
+          <img src="error-test.jpg" alt="错误图片"
+               onerror="this.classList.add('hidden')">
+        </div>
+        <div class="info-box">
+          使用 ::after 或绝对定位元素显示错误占位，<br>
+          当图片加载失败时显示友好的错误提示。
+        </div>
+      </div>
+
+      <div class="demo-card">
+        <h4>空 src 状态</h4>
+        <div class="error-state">
+          <div class="error-placeholder">
+            <div class="icon">📷</div>
+            <div class="text">暂无图片</div>
+          </div>
+          <img src="" alt="空图片">
+        </div>
+        <div class="info-box">
+          当 src 为空时，浏览器会尝试加载当前页面 URL，<br>
+          导致不必要的请求。建议设置 placeholder。
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Demo 5: Hover Zoom -->
+  <div class="demo-section">
+    <div class="demo-title">Demo 5: 背景色 + Hover 缩放</div>
+    <div class="demo-grid">
+      <div class="demo-card">
+        <h4>Hover 效果</h4>
+        <div class="img-hover-wrapper">
+          <img src="https://picsum.photos/800/450?random=5" alt="示例图片"
+               onload="this.classList.add('loaded')"
+               onerror="this.style.display='none'">
+        </div>
+        <div class="info-box">
+          鼠标悬停时图片放大，wrapper 的背景色<br>
+          作为占位底色，视觉效果流畅。
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function showToast(message, type = '') {
+      const toast = document.getElementById('toast');
+      toast.textContent = message;
+      toast.className = 'toast show ' + type;
+      setTimeout(() => {
+        toast.className = 'toast';
+      }, 2000);
+    }
+
+    function reloadImage(btn) {
+      const wrapper = btn.closest('.demo-card').querySelector('.skeleton-wrapper');
+      const img = wrapper.querySelector('img');
+      const skeleton = wrapper.querySelector('.skeleton');
+      
+      // Reset state
+      skeleton.style.display = 'block';
+      skeleton.style.animation = 'none';
+      skeleton.offsetHeight; // Trigger reflow
+      skeleton.style.animation = 'shimmer 1.5s infinite';
+      img.classList.remove('loaded');
+      img.style.display = 'block';
+      
+      // Randomize src to force reload
+      img.src = 'https://picsum.photos/800/450?random=' + Math.random();
+      
+      img.onload = function() {
+        this.classList.add('loaded');
+        skeleton.style.display = 'none';
+        showToast('✓ 图片加载成功', 'success');
+      };
+      
+      img.onerror = function() {
+        this.style.display = 'none';
+        showToast('✗ 图片加载失败', 'error');
+      };
+    }
+
+    // Initialize loaded images
+    document.querySelectorAll('img[src]').forEach(img => {
+      if (img.complete && img.naturalHeight !== 0) {
+        img.classList.add('loaded');
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 📋 任务内容

img 标签有 src 显示图片，无图片背景色控制。

## 📦 新增内容

- docs/topics/img-placeholder/index.md — 完整技术文档
- examples/css/demos/img-placeholder/index.html — 交互式演示页面

## 🔍 核心内容

1. **问题原理**：img 作为替换元素，background-color 在 src 无效时不生效
2. **解决方案对比**：
   - CSS aspect-ratio（推荐）
   - 伪元素 ::before
   - JS 监听加载状态
   - 骨架屏 shimmer 动画
   - 自定义错误状态
3. **实际应用**：响应式图片、头像占位、hover 效果

## 🎯 演示页面功能

- 错误方案 vs 正确方案对比
- 骨架屏加载动画
- 头像占位（大/中/小）
- 自定义错误状态
- Hover 缩放效果

Reminder ID: EB6BC0F8-90C4-4D60-96FC-69E232CA8DBB