### PR TITLE
feat(css): 重新补充 sticky 定位完整指南

### DIFF
--- a/docs/css/sticky-position.md
+++ b/docs/css/sticky-position.md
@@ -1,0 +1,502 @@
+﻿# CSS Sticky 定位完全指南
+
+> 本文档详细解析 CSS `position: sticky` 的工作原理、实现卡片内部按钮固定效果的方案，以及常见陷阱与最佳实践。
+
+---
+
+## 一、Sticky 定位核心原理
+
+### 1.1 什么是 Sticky 定位？
+
+`position: sticky` 是一种**混合定位模式**，元素在滚动容器中表现为：
+
+- **未滚动时**：相当于 `position: relative`
+- **滚动超过阈值时**：相当于 `position: fixed`
+
+```css
+.sticky-element {
+  position: sticky;
+  top: 0; /* 距离顶部 0px 时固定 */
+}
+```
+
+### 1.2 生效的必要条件
+
+Sticky 要正常工作，必须满足以下条件：
+
+| 条件 | 说明 | 常见错误 |
+|------|------|----------|
+| 父容器不能有 `overflow: hidden/auto/scroll` | 否则会创建 BFC，阻断滚动传播 | 父元素设置了 `overflow: hidden` |
+| 父容器高度必须大于 sticky 元素 | 否则没有滚动空间 | 父元素高度为 0 或 auto |
+| 必须指定 top/bottom/left/right 之一 | 否则行为等同于 `position: relative` | 忘记写 `top: 0` |
+| 祖先元素不能有 `transform` 属性 | transform 会创建新的 containing block | 祖先有 `transform: translateZ(0)` |
+
+### 1.3 滚动阈值计算
+
+```
+sticky 触发位置 = sticky 元素顶部位置 - top 值
+sticky 解除位置 = 父容器底部 - sticky 元素高度 - top 值
+```
+
+---
+
+## 二、Sticky vs 其他定位对比
+
+| 定位类型 | 参照物 | 脱标 | 滚动时行为 |
+|----------|--------|------|------------|
+| `relative` | 元素原位置 | 否 | 随页面滚动 |
+| `absolute` | 最近的定位祖先 | 是 | 随容器滚动 |
+| `fixed` | 视口 | 是 | 固定不动 |
+| `sticky` | 滚动容器 | 否 | 未达阈值随页面滚动，超过后固定 |
+
+---
+
+## 三、Sticky 实现卡片内按钮固定
+
+### 3.1 核心场景
+
+需求：卡片在页面中滚动，当卡片顶部滚过视口顶部时，卡片内部的「操作按钮」需要固定在视口顶部。
+
+```
+初始状态：
+┌─────────────────────┐
+│        页面         │
+│  ┌─────────────────┐│
+│  │    卡片内容      ││
+│  │                 ││
+│  │    [按钮]       ││  ← 按钮在卡片内部
+│  └─────────────────┘│
+└─────────────────────┘
+
+滚动后：
+┌─────────────────────┐
+│  [按钮]              │  ← 按钮固定在视口顶部
+├─────────────────────┤
+│  卡片内容（继续滚动）  │
+│  ...                │
+└─────────────────────┘
+```
+
+### 3.2 实现方案
+
+#### 方案一：Sticky 包裹按钮（推荐）
+
+```html
+<div class="card">
+  <div class="card-content">
+    <!-- 卡片内容 -->
+    <p>这里是很长的卡片内容...</p>
+    <p>会随着页面滚动而滚动...</p>
+  </div>
+  <div class="card-sticky-footer">
+    <button class="sticky-btn">操作按钮</button>
+  </div>
+</div>
+```
+
+```css
+.card {
+  position: relative;
+  margin-bottom: 20px;
+}
+
+.card-sticky-footer {
+  position: sticky;
+  bottom: 0;
+  background: white;
+  padding: 10px;
+  box-shadow: 0 -2px 10px rgba(0,0,0,0.1);
+}
+
+.sticky-btn {
+  width: 100%;
+  padding: 12px;
+  background: #007AFF;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}
+```
+
+#### 方案二：按钮独立 sticky
+
+```css
+.card {
+  position: relative;
+  padding-bottom: 60px; /* 为固定按钮留出空间 */
+}
+
+.sticky-btn {
+  position: sticky;
+  bottom: 10px;
+  width: calc(100% - 20px);
+  margin: 0 10px;
+  padding: 12px;
+  background: #007AFF;
+  color: white;
+  border: none;
+  border-radius: 8px;
+}
+```
+
+### 3.3 完整示例代码
+
+```html
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Sticky 卡片按钮固定示例</title>
+<style>
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  body {
+    padding: 20px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #f5f5f5;
+  }
+
+  h1 {
+    text-align: center;
+    margin-bottom: 30px;
+    color: #333;
+  }
+
+  .container {
+    max-width: 400px;
+    margin: 0 auto;
+  }
+
+  /* 卡片样式 */
+  .card {
+    position: relative;
+    background: white;
+    border-radius: 12px;
+    margin-bottom: 20px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    overflow: hidden;
+  }
+
+  .card-image {
+    width: 100%;
+    height: 150px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    object-fit: cover;
+  }
+
+  .card-body {
+    padding: 16px;
+  }
+
+  .card-title {
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 8px;
+    color: #333;
+  }
+
+  .card-text {
+    font-size: 14px;
+    color: #666;
+    line-height: 1.6;
+  }
+
+  /* Sticky 按钮容器 */
+  .card-footer {
+    position: sticky;
+    bottom: 0;
+    background: white;
+    padding: 12px 16px;
+    border-top: 1px solid #eee;
+    box-shadow: 0 -2px 10px rgba(0,0,0,0.05);
+  }
+
+  /* 固定按钮 */
+  .btn-primary {
+    width: 100%;
+    padding: 12px 20px;
+    background: #007AFF;
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s;
+  }
+
+  .btn-primary:hover {
+    background: #0056b3;
+  }
+
+  /* 滚动提示 */
+  .scroll-hint {
+    text-align: center;
+    padding: 20px;
+    color: #999;
+    font-size: 14px;
+  }
+</style>
+</head>
+<body>
+  <div class="container">
+    <h1>卡片内按钮 Sticky 固定效果</h1>
+
+    <div class="scroll-hint">↓ 向下滚动查看效果 ↓</div>
+
+    <!-- 卡片 1 -->
+    <div class="card">
+      <img src="https://picsum.photos/400/150?random=1" alt="卡片图片" class="card-image">
+      <div class="card-body">
+        <h3 class="card-title">卡片标题 1</h3>
+        <p class="card-text">
+          这是卡片的内容区域。向下滚动页面，当这个卡片滚过视口顶部时，底部的按钮将自动固定在视口底部...
+        </p>
+      </div>
+      <div class="card-footer">
+        <button class="btn-primary">操作按钮 1</button>
+      </div>
+    </div>
+
+    <!-- 卡片 2 -->
+    <div class="card">
+      <img src="https://picsum.photos/400/150?random=2" alt="卡片图片" class="card-image">
+      <div class="card-body">
+        <h3 class="card-title">卡片标题 2</h3>
+        <p class="card-text">
+          继续滚动。每个卡片的按钮都是独立固定的，不会互相影响...
+        </p>
+      </div>
+      <div class="card-footer">
+        <button class="btn-primary">操作按钮 2</button>
+      </div>
+    </div>
+
+    <!-- 卡片 3 -->
+    <div class="card">
+      <img src="https://picsum.photos/400/150?random=3" alt="卡片图片" class="card-image">
+      <div class="card-body">
+        <h3 class="card-title">卡片标题 3</h3>
+        <p class="card-text">
+          这是第三张卡片。Sticky 定位只在父容器内有效，所以每个卡片都有独立的 sticky 行为。
+        </p>
+      </div>
+      <div class="card-footer">
+        <button class="btn-primary">操作按钮 3</button>
+      </div>
+    </div>
+
+    <div class="scroll-hint">↑ 已到底部 ↑</div>
+  </div>
+</body>
+</html>
+```
+
+---
+
+## 四、常见问题与解决方案
+
+### 4.1 Sticky 不生效
+
+**检查清单：**
+
+```css
+/* 1. 父容器 overflow 检查 */
+.parent {
+  overflow: visible; /* 不是 hidden/auto/scroll */
+}
+
+/* 2. 父容器高度检查 */
+.parent {
+  min-height: 100vh; /* 确保有滚动空间 */
+}
+
+/* 3. top/bottom/left/right 至少写一个 */
+.sticky {
+  position: sticky;
+  top: 0; /* 必写！ */
+}
+
+/* 4. 祖先元素 transform 检查 */
+.ancestor:not(.no-transform) {
+  transform: none; /* 移除 transform */
+}
+```
+
+### 4.2 Sticky 在 iOS Safari 失效
+
+iOS Safari 的某些版本对 sticky 支持有问题，解决方案：
+
+```css
+.sticky-element {
+  position: sticky;
+  top: 0;
+  -webkit-position: sticky; /* iOS Safari hack */
+  transform: translateZ(0); /* 触发 GPU 加速但不创建新 stacking context */
+}
+```
+
+### 4.3 多个 Sticky 元素重叠
+
+```css
+/* 确保每个 sticky 元素有不同的高度或偏移 */
+.sticky-1 { top: 0; }
+.sticky-2 { top: 50px; } /* 错开位置 */
+```
+
+---
+
+## 五、实际应用场景
+
+### 5.1 表单提交按钮固定
+
+```html
+<div class="form-container">
+  <div class="form-content">
+    <!-- 长表单内容 -->
+  </div>
+  <div class="form-footer">
+    <button type="submit">提交表单</button>
+  </div>
+</div>
+
+<style>
+.form-container {
+  position: relative;
+  padding-bottom: 70px;
+}
+
+.form-footer {
+  position: sticky;
+  bottom: 0;
+  background: white;
+  padding: 15px;
+  border-top: 1px solid #ddd;
+}
+</style>
+```
+
+### 5.2 表格列头固定
+
+```html
+<table class="sticky-table">
+  <thead>
+    <tr>
+      <th>列1</th>
+      <th>列2</th>
+      <th>列3</th>
+    </tr>
+  </thead>
+  <tbody>
+    <!-- 大量数据行 -->
+  </tbody>
+</table>
+
+<style>
+.sticky-table thead th {
+  position: sticky;
+  top: 0;
+  background: #f5f5f5;
+  z-index: 1;
+}
+</style>
+```
+
+### 5.3 导航项高亮跟随
+
+```html
+<div class="nav-container">
+  <div class="nav-item active">Section 1</div>
+  <div class="nav-item">Section 2</div>
+  <div class="nav-item">Section 3</div>
+</div>
+<div class="content">
+  <section id="s1">...</section>
+  <section id="s2">...</section>
+  <section id="s3">...</section>
+</div>
+
+<style>
+.nav-container {
+  position: sticky;
+  top: 0;
+  background: white;
+}
+</style>
+```
+
+---
+
+## 六、浏览器兼容性
+
+| 浏览器 | 支持版本 | 备注 |
+|--------|----------|------|
+| Chrome | 56+ | 完全支持 |
+| Firefox | 59+ | 完全支持 |
+| Safari | 6.1+ (iOS 7.1+) | 需要 -webkit- 前缀 |
+| Edge | 16+ | 完全支持 |
+| IE | 不支持 | 使用 position: fixed 降级 |
+
+### 降级方案
+
+```css
+@supports (position: sticky) {
+  .sticky-element {
+    position: sticky;
+    top: 0;
+  }
+}
+
+@supports not (position: sticky) {
+  .sticky-element {
+    position: fixed;
+    top: 0;
+    width: 100%;
+  }
+}
+```
+
+---
+
+## 七、决策树：选择哪种定位方案？
+
+```
+需要元素固定在视口？
+    │
+    ├── 是 → 是否需要随页面滚动而进入/退出？
+    │       │
+    │       ├── 是 → position: sticky + top/bottom
+    │       └── 否 → position: fixed
+    │
+    └── 否 → 元素是否相对于自身位置偏移？
+            │
+            ├── 是 → position: relative
+            └── 否 → 是否需要相对于祖先定位？
+                    │
+                    ├── 是 → position: absolute
+                    └── 否 → position: static (默认)
+```
+
+---
+
+## 八、关键总结
+
+1. **Sticky = relative + fixed 的混合体**，在阈值前后表现不同
+2. **父容器是关键**，overflow/height/transform 都会影响 sticky 行为
+3. **必须指定 top/bottom/left/right**，否则等同于 relative
+4. **iOS Safari 需要 -webkit- 前缀**和一些 hack
+5. **没有完美的 sticky**，复杂场景考虑 JavaScript 或 fixed 替代
+
+---
+
+## 九、参考资料
+
+- [MDN: position](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
+- [CSS Tricks: Sticky](https://css-tricks.com/position-sticky/)
+- [Caniuse: position: sticky](https://caniuse.com/css-sticky)

--- a/docs/effects/backdrop-filter/index.md
+++ b/docs/effects/backdrop-filter/index.md
@@ -1,0 +1,86 @@
+# backdrop-filter 使用指南
+
+## 概述
+
+`backdrop-filter` 是 CSS 属性，允许对一个元素**后方**的内容应用图形效果，如模糊、颜色变换等。常用于创建玻璃拟态（Glassmorphism）等现代 UI 效果。
+
+## 核心语法
+
+```css
+.element {
+  backdrop-filter: <filter-function> [<filter-function>]*;
+  /* 或 */
+  backdrop-filter: none;
+}
+```
+
+## 可用的滤镜函数
+
+| 函数 | 说明 | 示例 |
+|------|------|------|
+| `blur()` | 高斯模糊 | `blur(10px)` |
+| `brightness()` | 亮度调整 | `brightness(1.2)` |
+| `contrast()` | 对比度调整 | `contrast(0.8)` |
+| `drop-shadow()` | 投影 | `drop-shadow(0 4px 8px rgba(0,0,0,0.3))` |
+| `grayscale()` | 灰度转换 | `grayscale(100%)` |
+| `hue-rotate()` | 色相旋转 | `hue-rotate(90deg)` |
+| `invert()` | 反转颜色 | `invert(100%)` |
+| `opacity()` | 透明度 | `opacity(0.8)` |
+| `saturate()` | 饱和度 | `saturate(2)` |
+| `sepia()` | 棕褐色调 | `sepia(50%)` |
+
+## 浏览器兼容性
+
+| 浏览器 | 支持情况 |
+|--------|----------|
+| Chrome | ✅ 76+ |
+| Safari | ✅ 9+（需要 `-webkit-backdrop-filter`） |
+| Firefox | ✅ 103+ |
+| Edge | ✅ 17+ |
+
+### Safari 兼容写法
+
+```css
+.glass {
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+}
+```
+
+## 玻璃拟态（Glassmorphism）
+
+玻璃拟态是现代 UI 设计的热门风格，核心就是 `backdrop-filter: blur()`。
+
+```css
+.glass-card {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 16px;
+}
+```
+
+## 性能注意事项
+
+1. **GPU 加速**：backdrop-filter 会创建新的图层，建议配合 `will-change` 使用
+2. **性能开销**：模糊半径越大，性能开销越大
+3. **移动端谨慎使用**：移动设备性能有限，过度使用可能导致卡顿
+
+## 常见问题
+
+### Q: backdrop-filter 不生效？
+
+检查：
+1. 元素是否有背景（background 或 rgba）
+2. 元素下方是否有内容
+3. Safari 浏览器需要添加 `-webkit-backdrop-filter`
+
+### Q: 与 `filter` 的区别？
+
+- `filter`：影响元素**自身**
+- `backdrop-filter`：影响元素**后方**的内容
+
+## 参考资料
+
+- [MDN backdrop-filter](https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter)
+- [Can I Use - backdrop-filter](https://caniuse.com/css-backdrop-filter)

--- a/docs/js/cssom-guide.md
+++ b/docs/js/cssom-guide.md
@@ -1,0 +1,899 @@
+# JavaScript CSS 操作方法详解
+
+## 概述
+
+CSSOM（CSS Object Model，CSS 对象模型）是 JavaScript 操作 CSS 样式的核心接口。与 `element.style` 直接操作行内样式不同，CSSOM 提供了获取计算样式、批量设置、属性级别操作等能力，是现代前端开发中不可或缺的技能。
+
+本文档系统介绍所有 CSSOM 操作方法，涵盖行内样式操作、计算样式获取、元素尺寸测量等场景。
+
+## 目录
+
+- [1. element.style 行内样式操作](#1-elementstyle-行内样式操作)
+  - [1.1 直接属性访问](#11-直接属性访问)
+  - [1.2 cssText 批量设置](#12-csstext-批量设置)
+  - [1.3 setProperty() 设置带优先级的属性](#13-setproperty-设置带优先级的属性)
+  - [1.4 getPropertyValue() 获取属性值](#14-getpropertyvalue-获取属性值)
+  - [1.5 removeProperty() 移除属性](#15-removeproperty-移除属性)
+- [2. window.getComputedStyle() 获取计算样式](#2-windowgetcomputedstyle-获取计算样式)
+- [3. element.getBoundingClientRect() 元素尺寸与位置](#3-elementgetboundingclientrect-元素尺寸与位置)
+- [4. CSSStyleDeclaration 对象完整参考](#4-cssstyledeclaration-对象完整参考)
+- [5. 实践指南与最佳实践](#5-实践指南与最佳实践)
+
+---
+
+## 1. element.style 行内样式操作
+
+每个 HTML 元素都有一个 `style` 属性，返回该元素的行内样式对象（`CSSStyleDeclaration` 类型）。这个对象只能访问行内样式（`style` 属性中定义的样式），无法获取 `<style>` 标签或外部 CSS 文件中的样式。
+
+### 1.1 直接属性访问
+
+最直观的方式是通过点符号直接读写 CSS 属性。
+
+**语法：**
+
+```javascript
+element.style.propertyName = value;
+```
+
+**驼峰命名法：** CSS 属性名中的连字符需要转换为驼峰命名：
+- `background-color` → `backgroundColor`
+- `font-size` → `fontSize`
+- `border-left-width` → `borderLeftWidth`
+- `margin-top` → `marginTop`
+
+**示例：**
+
+```javascript
+const box = document.querySelector('.box');
+
+// 读取行内样式
+console.log(box.style.color);        // "red"
+console.log(box.style.fontSize);    // "16px"
+
+// 设置行内样式
+box.style.color = 'blue';
+box.style.fontSize = '20px';
+box.style.backgroundColor = '#f0f0f0';
+box.style.borderRadius = '8px';
+
+// 设置多个属性
+box.style.width = '200px';
+box.style.height = '200px';
+box.style.marginTop = '20px';
+```
+
+**注意事项：**
+
+- 读取时返回**空字符串**（如果该属性未在行内样式中定义）
+- 设置时会自动添加单位（对于数值会自动转为字符串）
+- 优先级高于 CSS 选择器规则（但不高于 `!important`）
+
+```javascript
+const el = document.getElementById('myDiv');
+
+// 未定义的属性返回空字符串
+console.log(el.style.color); // ""
+
+// 设置值
+el.style.opacity = '0.5';
+console.log(el.style.opacity); // "0.5"
+```
+
+### 1.2 cssText 批量设置
+
+`cssText` 属性允许一次性读取或设置整个行内样式块内容。
+
+**语法：**
+
+```javascript
+// 读取
+const styles = element.style.cssText;
+
+// 设置（会覆盖原有行内样式）
+element.style.cssText = "color: red; font-size: 16px; background-color: #fff;";
+```
+
+**示例：**
+
+```javascript
+const box = document.querySelector('.box');
+
+// 获取当前所有行内样式
+console.log(box.style.cssText);
+// 输出类似: "position: absolute; left: 100px; top: 50px;"
+
+// 批量设置样式（覆盖原有）
+box.style.cssText = `
+  width: 300px;
+  height: 200px;
+  background-color: #3498db;
+  color: white;
+  border-radius: 12px;
+  padding: 20px;
+`;
+
+// 追加样式（需要保留原有 cssText）
+const currentStyles = box.style.cssText;
+box.style.cssText = currentStyles + ' border: 2px solid #2c3e50;';
+```
+
+**⚠️ 重要注意事项：**
+
+1. **完全覆盖**：`cssText` 设置时会**完全覆盖**元素原有的行内样式
+2. **无返回值语义**：读取时返回完整的 CSS 字符串（包括分号）
+3. **浏览器兼容性**：现代浏览器均支持，但在旧版 IE 中行为略有差异
+
+```javascript
+// ❌ 错误：覆盖了原有样式
+box.style.cssText = "width: 100px;";
+box.style.cssText = "height: 100px;"; // 宽度样式丢失！
+
+// ✅ 正确：追加样式
+box.style.cssText += "; height: 100px;"; // 注意分号分隔
+```
+
+### 1.3 setProperty() 设置带优先级的属性
+
+`setProperty()` 方法允许精确设置 CSS 属性，包括是否添加 `!important` 优先级。
+
+**语法：**
+
+```javascript
+element.style.setProperty(propertyName, value, priority);
+```
+
+**参数：**
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `propertyName` | string | CSS 属性名（可用连字符形式或驼峰形式） |
+| `value` | string | 属性值 |
+| `priority` | string | 可选，设为 `"important"` 添加 `!important` 优先级，或留空 `""` |
+
+**示例：**
+
+```javascript
+const box = document.querySelector('.box');
+
+// 普通设置
+box.style.setProperty('color', 'red');
+
+// 带 !important 优先级（最高优先级）
+box.style.setProperty('display', 'none', 'important');
+
+// 使用驼峰命名
+box.style.setProperty('backgroundColor', '#3498db');
+box.style.setProperty('fontSize', '18px');
+
+// 设置多个属性
+box.style.setProperty('width', '200px');
+box.style.setProperty('height', '200px');
+box.style.setProperty('margin', '10px 20px');
+```
+
+**与直接赋值的区别：**
+
+```javascript
+// 这两种写法效果相同：
+element.style.setProperty('color', 'red');
+element.style.color = 'red';
+
+// 但 setProperty 可以设置优先级：
+element.style.setProperty('color', 'red', 'important'); // 最高优先级
+element.style.color = 'red'; // 普通优先级
+```
+
+### 1.4 getPropertyValue() 获取属性值
+
+`getPropertyValue()` 用于精确获取某个 CSS 属性的值，返回字符串。
+
+**语法：**
+
+```javascript
+const value = element.style.getPropertyValue(propertyName);
+```
+
+**参数：**
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `propertyName` | string | CSS 属性名（可用连字符形式或驼峰形式） |
+
+**返回值：** 返回属性值的字符串，未设置则返回空字符串。
+
+**示例：**
+
+```javascript
+const box = document.querySelector('.box');
+
+// 假设元素行内样式为: style="color: red; font-size: 16px;"
+
+// 使用连字符形式
+console.log(box.style.getPropertyValue('color'));        // "red"
+console.log(box.style.getPropertyValue('font-size'));    // "16px"
+
+// 使用驼峰形式也可以
+console.log(box.style.getPropertyValue('color'));        // "red"
+
+// 未设置的属性返回空字符串
+console.log(box.style.getPropertyValue('background-color')); // ""
+```
+
+**与直接属性访问对比：**
+
+```javascript
+// 这两种方式返回相同结果：
+box.style.getPropertyValue('color')  // "red"
+box.style.color                        // "red"
+
+// 区别在于 getPropertyValue 需要传入字符串形式的属性名
+// 直接访问需要驼峰命名
+```
+
+### 1.5 removeProperty() 移除属性
+
+`removeProperty()` 用于移除行内样式中的某个 CSS 属性。
+
+**语法：**
+
+```javascript
+const removedValue = element.style.removeProperty(propertyName);
+```
+
+**参数：**
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `propertyName` | string | 要移除的 CSS 属性名 |
+
+**返回值：** 返回被移除的属性值（移除前的值）。
+
+**示例：**
+
+```javascript
+const box = document.querySelector('.box');
+
+// 假设元素有 style="color: red; font-size: 16px; background-color: blue;"
+
+// 移除单个属性
+const oldColor = box.style.removeProperty('color');
+console.log(oldColor); // "red"
+// 现在元素样式变为: style="font-size: 16px; background-color: blue;"
+
+// 移除不存在的属性（安全操作）
+box.style.removeProperty('border'); // 返回空字符串，不报错
+
+// 移除后浏览器会使用默认/继承样式
+box.style.removeProperty('background-color');
+```
+
+**应用场景：**
+
+```javascript
+// 动态主题切换
+function setTheme(isDark) {
+  const root = document.documentElement;
+  if (isDark) {
+    root.style.setProperty('--bg-color', '#1a1a1a');
+    root.style.setProperty('--text-color', '#ffffff');
+  } else {
+    root.style.removeProperty('--bg-color');
+    root.style.removeProperty('--text-color');
+  }
+}
+
+// 动画结束后清除样式
+element.addEventListener('transitionend', (e) => {
+  if (e.propertyName === 'opacity') {
+    element.style.removeProperty('transition');
+    element.style.removeProperty('opacity');
+  }
+});
+```
+
+---
+
+## 2. window.getComputedStyle() 获取计算样式
+
+`getComputedStyle()` 返回元素**最终计算后**的样式，包括行内样式、CSS 选择器规则、`!important` 规则以及浏览器默认样式。
+
+**语法：**
+
+```javascript
+const computedStyle = window.getComputedStyle(element, [pseudoElement]);
+```
+
+**参数：**
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `element` | Element | 要获取计算样式的元素 |
+| `pseudoElement` | string | 可选，伪元素选择器（如 `'::before'`、`'::after'`、`':hover'`） |
+
+**返回值：** `CSSStyleDeclaration` 对象，包含所有计算后的 CSS 属性。
+
+**示例：**
+
+```javascript
+const box = document.querySelector('.box');
+
+// 获取计算样式
+const styles = window.getComputedStyle(box);
+
+// 读取计算后的值
+console.log(styles.width);              // "200px"（可能经过计算）
+console.log(styles.height);             // "100px"
+console.log(styles.backgroundColor);    // "rgb(52, 152, 219)"（RGB格式）
+console.log(styles.display);            // "block"
+console.log(styles.fontSize);           // "16px"
+
+// 获取伪元素样式
+const stylesBefore = window.getComputedStyle(box, '::before');
+console.log(stylesBefore.content);      // "\"\""
+console.log(stylesBefore.display);      // "block"
+```
+
+**关键特点：**
+
+1. **返回只读对象**：计算样式对象是只读的，不能直接修改
+2. **返回值已计算**：
+   - 相对单位（`em`、`rem`、`%`）会转换为绝对单位（`px`）
+   - 颜色可能转换为 `rgb()` 或 `rgba()` 格式
+   - 简写属性可能不会返回完整值
+
+```javascript
+const el = document.querySelector('.box');
+
+// CSS: width: 50%; font-size: 2em; color: blue;
+const styles = window.getComputedStyle(el);
+
+console.log(styles.width);        // "400px"（计算后的像素值）
+console.log(styles.fontSize);      // "32px"（假设根字体为16px）
+console.log(styles.color);        // "rgb(0, 0, 255)"（蓝色转为RGB）
+```
+
+**与 element.style 的区别：**
+
+| 特性 | `element.style` | `window.getComputedStyle()` |
+|------|-----------------|----------------------------|
+| 读取内容 | 仅行内样式 | 所有来源的样式 |
+| 是否只读 | 可读写 | 只读 |
+| 单位转换 | 保持原样 | 转换为绝对值 |
+| 获取伪元素 | ❌ | ✅ |
+| 返回值 | 原始字符串 | 计算后的值 |
+
+```javascript
+<div id="test" style="width: 50%;">内容</div>
+<style>
+#test { width: 25%; font-size: 20px; }
+</style>
+
+const el = document.getElementById('test');
+
+console.log(el.style.width);                    // "50%"
+console.log(window.getComputedStyle(el).width); // "400px"（假设视口800px）
+
+console.log(el.style.fontSize);                 // ""（行内未定义）
+console.log(window.getComputedStyle(el).fontSize); // "20px"
+```
+
+**常见应用场景：**
+
+```javascript
+// 1. 检测元素是否隐藏
+function isHidden(el) {
+  const styles = window.getComputedStyle(el);
+  return styles.display === 'none' || styles.visibility === 'hidden';
+}
+
+// 2. 获取元素实际尺寸
+function getElementSize(el) {
+  const styles = window.getComputedStyle(el);
+  return {
+    width: parseFloat(styles.width),
+    height: parseFloat(styles.height),
+    padding: {
+      top: parseFloat(styles.paddingTop),
+      right: parseFloat(styles.paddingRight),
+      bottom: parseFloat(styles.paddingBottom),
+      left: parseFloat(styles.paddingLeft)
+    }
+  };
+}
+
+// 3. 获取动画/过渡的实际值
+el.style.transition = 'all 0.3s ease';
+const transitionDuration = window.getComputedStyle(el).transitionDuration;
+console.log(transitionDuration); // "0.3s"
+```
+
+---
+
+## 3. element.getBoundingClientRect() 元素尺寸与位置
+
+`getBoundingClientRect()` 返回元素的大小及其相对于**视口（viewport）**的位置。
+
+**语法：**
+
+```javascript
+const rect = element.getBoundingClientRect();
+```
+
+**返回值：** `DOMRect` 对象，包含以下属性：
+
+| 属性 | 类型 | 说明 |
+|------|------|------|
+| `x` / `left` | number | 元素左边框相对于视口左边的距离 |
+| `y` / `top` | number | 元素上边框相对于视口顶边的距离 |
+| `width` | number | 元素 border-box 的宽度（含边框） |
+| `height` | number | 元素 border-box 的高度（含边框） |
+| `right` | number | 元素右边框相对于视口左边的距离 |
+| `bottom` | number | 元素下边框相对于视口顶边的距离 |
+
+**示意图：**
+
+```
+视口 (viewport)
+┌────────────────────────────────┐
+│                                │
+│    ┌─────────────────────┐     │
+│    │       top           │     │
+│    │  ┌───────────────┐  │     │
+│    │ l│               │r│     │
+│    │ e│    element    │i│     │
+│    │ f│               │g│     │
+│    │ t│               │h│     │
+│    │  │               │t│     │
+│    │  └───────────────┘  │     │
+│    │       bottom        │     │
+│    └─────────────────────┘     │
+│          x, y (left, top)      │
+└────────────────────────────────┘
+```
+
+**示例：**
+
+```javascript
+const box = document.querySelector('.box');
+const rect = box.getBoundingClientRect();
+
+// 获取位置
+console.log(rect.top);    // 元素上边到视口上边的距离
+console.log(rect.right);  // 元素右边到视口左边的距离
+console.log(rect.bottom); // 元素下边到视口上边的距离
+console.log(rect.left);   // 元素左边到视口左边的距离
+
+// 获取尺寸
+console.log(rect.width);  // 元素宽度（含边框）
+console.log(rect.height); // 元素高度（含边框）
+
+// x 和 y 是 left 和 top 的别名
+console.log(rect.x);      // 等同于 rect.left
+console.log(rect.y);      // 等同于 rect.top
+```
+
+**实用函数封装：**
+
+```javascript
+// 获取元素相对于文档的位置
+function getElementDocumentPosition(el) {
+  const rect = el.getBoundingClientRect();
+  return {
+    top: rect.top + window.scrollY,
+    left: rect.left + window.scrollX,
+    right: rect.right + window.scrollX,
+    bottom: rect.bottom + window.scrollY
+  };
+}
+
+// 获取元素相对于另一个元素的位置
+function getRelativePosition(el, targetEl) {
+  const elRect = el.getBoundingClientRect();
+  const targetRect = targetEl.getBoundingClientRect();
+  
+  return {
+    top: elRect.top - targetRect.top,
+    left: elRect.left - targetRect.left,
+    right: elRect.right - targetRect.right,
+    bottom: elRect.bottom - targetRect.bottom
+  };
+}
+
+// 检测元素是否在视口内
+function isInViewport(el) {
+  const rect = el.getBoundingClientRect();
+  return (
+    rect.top >= 0 &&
+    rect.left >= 0 &&
+    rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+    rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+  );
+}
+
+// 检测两个元素是否重叠
+function isOverlapping(el1, el2) {
+  const rect1 = el1.getBoundingClientRect();
+  const rect2 = el2.getBoundingClientRect();
+  
+  return !(
+    rect1.right < rect2.left ||
+    rect1.left > rect2.right ||
+    rect1.bottom < rect2.top ||
+    rect1.top > rect2.bottom
+  );
+}
+```
+
+**与 offsetWidth / offsetHeight 的对比：**
+
+| 特性 | `getBoundingClientRect()` | `offsetWidth` / `offsetHeight` |
+|------|---------------------------|-------------------------------|
+| 返回类型 | DOMRect 对象 | 数值 |
+| 包含内容 | width + height（含 border） | 数值（不含 margin） |
+| 位置信息 | ✅ 包含 | ❌ 不包含 |
+| 滚动影响 | 相对于视口 | 不受滚动影响 |
+| 性能 | 稍慢（需创建对象） | 更快（直接属性访问） |
+
+```javascript
+const box = document.querySelector('.box');
+
+// 两种方式都能获取尺寸
+const rect = box.getBoundingClientRect();
+console.log(rect.width);      // 包含 border
+console.log(box.offsetWidth); // 包含 border，不包含 margin
+
+// getBoundingClientRect 提供位置信息
+console.log(rect.top);        // 距离视口顶部
+console.log(box.offsetTop);   // 距离定位父元素顶部
+```
+
+**在动画和滚动中的应用：**
+
+```javascript
+// 懒加载：当元素进入视口时加载
+function lazyLoad(element, callback) {
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        callback(entry.target);
+        observer.unobserve(entry.target);
+      }
+    });
+  });
+  
+  observer.observe(element);
+}
+
+// 平滑滚动到元素
+function scrollToElement(el) {
+  const rect = el.getBoundingClientRect();
+  window.scrollTo({
+    top: rect.top + window.scrollY - 100, // 留出偏移量
+    behavior: 'smooth'
+  });
+}
+
+// 拖拽实现
+function enableDrag(el) {
+  let offsetX, offsetY;
+  
+  el.addEventListener('mousedown', (e) => {
+    const rect = el.getBoundingClientRect();
+    offsetX = e.clientX - rect.left;
+    offsetY = e.clientY - rect.top;
+    
+    document.addEventListener('mousemove', onMouseMove);
+    document.addEventListener('mouseup', onMouseUp);
+  });
+  
+  function onMouseMove(e) {
+    el.style.position = 'fixed';
+    el.style.left = (e.clientX - offsetX) + 'px';
+    el.style.top = (e.clientY - offsetY) + 'px';
+  }
+  
+  function onMouseUp() {
+    document.removeEventListener('mousemove', onMouseMove);
+    document.removeEventListener('mouseup', onMouseUp);
+  }
+}
+```
+
+---
+
+## 4. CSSStyleDeclaration 对象完整参考
+
+`CSSStyleDeclaration` 是表示 CSS 声明块的对象，通过以下方式获取：
+
+- `element.style` — 行内样式（可读写）
+- `window.getComputedStyle(element)` — 计算样式（只读）
+- `element.style.cssText` — 样式字符串
+
+### 4.1 常用属性一览
+
+| 属性/方法 | 类型 | 说明 | 示例 |
+|-----------|------|------|------|
+| `.cssText` | string | 整个样式声明块 | `"color: red; width: 100px;"` |
+| `.length` | number | 声明块中的属性数量 | `3` |
+| `.parentRule` | CSSRule | 关联的 CSS 规则 | 父级 CSSRule 对象 |
+
+### 4.2 属性操作方法
+
+| 方法 | 说明 | 返回值 |
+|------|------|--------|
+| `getPropertyValue(prop)` | 获取属性值 | string |
+| `setProperty(prop, val, priority)` | 设置属性值 | void |
+| `removeProperty(prop)` | 移除属性 | string |
+| `getPropertyPriority(prop)` | 获取优先级 | string（`'important'` 或 `''`） |
+| `item(index)` | 按索引获取属性名 | string |
+| `[prop]` 或 `.prop` | 直接访问属性 | string |
+
+### 4.3 遍历样式属性
+
+```javascript
+const box = document.querySelector('.box');
+const styles = box.style;
+
+// 方式1：for...of 遍历
+for (const prop of styles) {
+  console.log(`${prop}: ${styles.getPropertyValue(prop)}`);
+}
+
+// 方式2：使用 length 和 item()
+for (let i = 0; i < styles.length; i++) {
+  const prop = styles.item(i);
+  console.log(`${prop}: ${styles.getPropertyValue(prop)}`);
+}
+
+// 方式3：Object.keys 遍历（需转换）
+Object.keys(styles).forEach(key => {
+  if (key.includes('-')) {
+    console.log(`${key}: ${styles.getPropertyValue(key)}`);
+  }
+});
+```
+
+### 4.4 获取所有属性名（结合 computedStyle）
+
+```javascript
+function getAllStyleProperties(el) {
+  const inlineStyles = el.style;
+  const computedStyles = window.getComputedStyle(el);
+  
+  const properties = {};
+  
+  // 从行内样式获取
+  for (let i = 0; i < inlineStyles.length; i++) {
+    const prop = inlineStyles[i];
+    properties[prop] = {
+      inline: inlineStyles.getPropertyValue(prop),
+      computed: computedStyles.getPropertyValue(prop)
+    };
+  }
+  
+  return properties;
+}
+
+// 使用
+const props = getAllStyleProperties(document.querySelector('.box'));
+console.log(props);
+```
+
+---
+
+## 5. 实践指南与最佳实践
+
+### 5.1 样式操作模式
+
+**批量设置样式（性能优化）：**
+
+```javascript
+// ❌ 低效：每次都会触发重排/重绘
+element.style.width = '100px';
+element.style.height = '100px';
+element.style.color = 'red';
+element.style.backgroundColor = 'blue';
+
+// ✅ 高效：使用 cssText 合并
+element.style.cssText = `
+  width: 100px;
+  height: 100px;
+  color: red;
+  background-color: blue;
+`;
+
+// ✅ 高效：使用类切换
+element.classList.add('active-state');
+
+// ✅ 最高效：预先定义类，通过切换类改变样式
+```
+
+**使用 CSS 变量（自定义属性）：**
+
+```javascript
+// 设置 CSS 变量
+document.documentElement.style.setProperty('--primary-color', '#3498db');
+
+// 读取 CSS 变量
+const color = getComputedStyle(document.documentElement)
+  .getPropertyValue('--primary-color')
+  .trim();
+console.log(color); // "#3498db"
+
+// 移除 CSS 变量
+document.documentElement.style.removeProperty('--primary-color');
+```
+
+### 5.2 避免样式操作陷阱
+
+**1. 使用类而不是直接操作样式：**
+
+```javascript
+// ❌ 直接操作样式难以维护
+box.style.position = 'absolute';
+box.style.left = '100px';
+box.style.top = '50px';
+
+// ✅ 更好的方式：使用类
+.box-positioned {
+  position: absolute;
+  left: 100px;
+  top: 50px;
+}
+// JS
+box.classList.add('box-positioned');
+```
+
+**2. 注意单位：**
+
+```javascript
+// ❌ 忘记单位
+element.style.width = 200; // 可能不生效
+
+// ✅ 正确添加单位
+element.style.width = '200px';
+element.style.opacity = '0.5'; // opacity 不需要单位
+element.style.flexGrow = '2';   // 数值属性可能需要字符串
+```
+
+**3. 处理带连字符的属性：**
+
+```javascript
+// ❌ 错误
+element.style.font-size = '16px';
+
+// ✅ 正确：驼峰命名
+element.style.fontSize = '16px';
+
+// ✅ 或者使用 setProperty
+element.style.setProperty('font-size', '16px');
+```
+
+### 5.3 性能考量
+
+**重排与重绘：**
+
+```javascript
+// ❌ 触发多次重排
+for (let i = 0; i < 100; i++) {
+  box.style.left = i + 'px'; // 每次都触发重排
+}
+
+// ✅ 一次性设置（触发一次重排）
+box.style.transform = `translateX(${i}px)`; // 使用 transform 避免重排
+
+// ✅ 使用 requestAnimationFrame
+function animate() {
+  i++;
+  box.style.transform = `translateX(${i}px)`;
+  requestAnimationFrame(animate);
+}
+```
+
+**读取布局属性会强制重排：**
+
+```javascript
+// ❌ 读取触发重排
+console.log(box.offsetWidth); // 强制重排
+box.style.width = '200px';    // 又一次重排
+
+// ✅ 先读后写，或使用 CSS 变量
+const width = box.offsetWidth; // 读取
+box.style.width = (width + 50) + 'px';
+
+// ✅ 使用 CSS 变量避免重排
+box.style.setProperty('--width', '250px'); // 仅重绘
+```
+
+### 5.4 完整示例：动态主题切换
+
+```javascript
+class ThemeManager {
+  constructor() {
+    this.cssVars = {};
+  }
+  
+  setVariable(name, value) {
+    document.documentElement.style.setProperty(name, value);
+    this.cssVars[name] = value;
+  }
+  
+  removeVariable(name) {
+    document.documentElement.style.removeProperty(name);
+    delete this.cssVars[name];
+  }
+  
+  getVariable(name) {
+    return getComputedStyle(document.documentElement)
+      .getPropertyValue(name)
+      .trim();
+  }
+  
+  applyTheme(theme) {
+    // 清除旧主题
+    Object.keys(this.cssVars).forEach(key => {
+      if (key.startsWith('--theme-')) {
+        this.removeVariable(key);
+      }
+    });
+    
+    // 应用新主题
+    Object.entries(theme).forEach(([key, value]) => {
+      this.setVariable(`--theme-${key}`, value);
+    });
+  }
+}
+
+// 使用
+const themeManager = new ThemeManager();
+
+themeManager.applyTheme({
+  'primary': '#3498db',
+  'secondary': '#2ecc71',
+  'text': '#2c3e50',
+  'background': '#ecf0f1'
+});
+
+console.log(themeManager.getVariable('--theme-primary')); // "#3498db"
+```
+
+### 5.5 现代 Web API 推荐
+
+**几何属性对比：**
+
+| API | 用途 | 是否触发重排 |
+|-----|------|-------------|
+| `getBoundingClientRect()` | 位置与尺寸 | ❌（但某些浏览器可能） |
+| `offsetLeft/Top` | 相对于 offsetParent | ✅ 触发 |
+| `clientLeft/Top` | 边框宽度 | ❌ |
+| `scrollLeft/Top` | 滚动位置 | ❌ |
+| `getComputedStyle()` | 计算样式 | ❌（读取时） |
+
+**ResizeObserver（监听尺寸变化）：**
+
+```javascript
+const observer = new ResizeObserver((entries) => {
+  for (const entry of entries) {
+    const { width, height } = entry.contentRect;
+    console.log(`尺寸变化: ${width}x${height}`);
+  }
+});
+
+observer.observe(document.querySelector('.box'));
+```
+
+---
+
+## 总结
+
+| 方法/属性 | 类型 | 用途 | 读写 |
+|-----------|------|------|------|
+| `element.style.prop` | 属性访问 | 读写行内样式 | 读写 |
+| `element.style.cssText` | 字符串 | 批量读写行内样式 | 读写 |
+| `element.style.setProperty()` | 方法 | 设置行内样式（可带优先级） | 写 |
+| `element.style.getPropertyValue()` | 方法 | 获取行内样式值 | 读 |
+| `element.style.removeProperty()` | 方法 | 移除行内样式 | 写 |
+| `window.getComputedStyle()` | 方法 | 获取计算后样式 | 读 |
+| `element.getBoundingClientRect()` | 方法 | 获取元素位置和尺寸 | 读 |
+
+掌握这些 API，你就能在 JavaScript 中灵活、精确地操作 CSS，实现各种动态效果和交互功能。

--- a/docs/topics/collision-detection/index.md
+++ b/docs/topics/collision-detection/index.md
@@ -1,0 +1,240 @@
+# 碰撞检测 (Collision Detection)
+
+## 概述
+
+碰撞检测是计算两个或多个对象是否在空间上重叠的技术，广泛应用于游戏开发、图形界面交互、物理模拟等领域。
+
+## 碰撞检测算法分类
+
+### 1. AABB (Axis-Aligned Bounding Box) 矩形碰撞
+
+最基础的碰撞检测算法，适用于轴对齐的矩形对象。
+
+```javascript
+function rectIntersect(r1, r2) {
+  return !(
+    r1.x + r1.width <= r2.x ||
+    r2.x + r2.width <= r1.x ||
+    r1.y + r1.height <= r2.y ||
+    r2.y + r2.height <= r1.y
+  );
+}
+```
+
+**适用场景**：贪吃蛇、俄罗斯方块、UI 拖拽检测
+
+### 2. 圆形碰撞检测
+
+基于圆心距离判断碰撞。
+
+```javascript
+function circleIntersect(c1, c2) {
+  const dx = c1.x - c2.x;
+  const dy = c1.y - c2.y;
+  const distance = Math.sqrt(dx * dx + dy * dy);
+  return distance < c1.radius + c2.radius;
+}
+```
+
+**适用场景**：球类游戏、弹珠、雷达检测
+
+### 3. 点与矩形碰撞
+
+```javascript
+function pointInRect(px, py, rect) {
+  return (
+    px >= rect.x &&
+    px <= rect.x + rect.width &&
+    py >= rect.y &&
+    py <= rect.y + rect.height
+  );
+}
+```
+
+### 4. 鼠标点击检测
+
+```javascript
+canvas.addEventListener('click', (e) => {
+  const rect = canvas.getBoundingClientRect();
+  const x = e.clientX - rect.left;
+  const y = e.clientY - rect.top;
+  
+  // 检测点击了哪个对象
+  for (const obj of objects) {
+    if (pointInRect(x, y, obj)) {
+      console.log('点击了对象:', obj.id);
+    }
+  }
+});
+```
+
+### 5. Separating Axis Theorem (SAT) 分离轴定理
+
+适用于凸多边形碰撞检测。
+
+**核心原理**：如果两个凸多边形不重叠，必然存在一条能将它们分开的轴。
+
+```javascript
+function getAxes(polygon) {
+  const axes = [];
+  for (let i = 0; i < polygon.length; i++) {
+    const p1 = polygon[i];
+    const p2 = polygon[(i + 1) % polygon.length];
+    // 计算边的垂直向量作为候选轴
+    const edge = { x: p2.x - p1.x, y: p2.y - p1.y };
+    const normal = { x: -edge.y, y: edge.x };
+    axes.push(normal);
+  }
+  return axes;
+}
+
+function project(polygon, axis) {
+  let min = Infinity, max = -Infinity;
+  for (const p of polygon) {
+    const proj = p.x * axis.x + p.y * axis.y;
+    min = Math.min(min, proj);
+    max = Math.max(max, proj);
+  }
+  return { min, max };
+}
+
+function polygonsIntersect(poly1, poly2) {
+  const axes = [...getAxes(poly1), ...getAxes(poly2)];
+  
+  for (const axis of axes) {
+    const proj1 = project(poly1, axis);
+    const proj2 = project(poly2, axis);
+    
+    // 检查投影是否重叠
+    if (proj1.max < proj2.min || proj2.max < proj1.min) {
+      return false; // 分离，检测到碰撞
+    }
+  }
+  return true; // 所有轴都重叠，碰撞
+}
+```
+
+### 6. 空间分区 (Spatial Partitioning)
+
+当对象数量增多时，使用空间数据结构提升效率。
+
+#### 网格分区 (Grid)
+
+```javascript
+class Grid {
+  constructor(cellSize) {
+    this.cellSize = cellSize;
+    this.cells = new Map();
+  }
+  
+  getKey(x, y) {
+    return `${Math.floor(x / this.cellSize)},${Math.floor(y / this.cellSize)}`;
+  }
+  
+  insert(obj) {
+    const key = this.getKey(obj.x, obj.y);
+    if (!this.cells.has(key)) this.cells.set(key, []);
+    this.cells.get(key).push(obj);
+  }
+  
+  query(x, y, radius) {
+    const results = [];
+    const checked = new Set();
+    const cellRadius = Math.ceil(radius / this.cellSize);
+    const cx = Math.floor(x / this.cellSize);
+    const cy = Math.floor(y / this.cellSize);
+    
+    for (let dx = -cellRadius; dx <= cellRadius; dx++) {
+      for (let dy = -cellRadius; dy <= cellRadius; dy++) {
+        const key = `${cx + dx},${cy + dy}`;
+        const cell = this.cells.get(key);
+        if (cell) {
+          for (const obj of cell) {
+            if (!checked.has(obj.id)) {
+              checked.add(obj.id);
+              const dist = Math.hypot(obj.x - x, obj.y - y);
+              if (dist <= radius + (obj.radius || 0)) {
+                results.push(obj);
+              }
+            }
+          }
+        }
+      }
+    }
+    return results;
+  }
+}
+```
+
+### 7. 射线投射 (Ray Casting)
+
+用于检测从一点发出的射线与对象的交点。
+
+```javascript
+function rayRectIntersect(ray, rect) {
+  const t1 = (rect.x - ray.x) / ray.dx;
+  const t2 = (rect.x + rect.width - ray.x) / ray.dx;
+  const t3 = (rect.y - ray.y) / ray.dy;
+  const t4 = (rect.y + rect.height - ray.y) / ray.dy;
+  
+  const tmin = Math.max(Math.min(t1, t2), Math.min(t3, t4));
+  const tmax = Math.min(Math.max(t1, t2), Math.max(t3, t4));
+  
+  if (tmax < 0 || tmin > tmax) return null; // 无交点
+  
+  return {
+    x: ray.x + ray.dx * tmin,
+    y: ray.y + ray.dy * tmin,
+    t: tmin
+  };
+}
+```
+
+## 常见应用场景
+
+| 场景 | 推荐算法 | 说明 |
+|------|----------|------|
+| 贪吃蛇/俄罗斯方块 | AABB | 矩形网格对齐，简单高效 |
+| 弹珠/球类游戏 | 圆形碰撞 | 基于距离判断 |
+| 复杂多边形游戏 | SAT | 通用凸多边形 |
+| UI 拖拽 | 点与矩形 | 检测鼠标是否在元素上 |
+| 射击游戏 | 射线投射 | 检测弹道是否命中 |
+| 大量对象游戏 | 空间分区 | 四叉树/网格优化 |
+
+## 性能优化技巧
+
+1. **Broad Phase (粗检测)**：先用 AABB 或空间分区快速排除不可能碰撞的对象对
+2. **Narrow Phase (精检测)**：对通过粗检测的对象使用精确算法
+3. **脏矩形渲染**：只重绘发生变化的区域
+4. **对象池**：复用对象，避免频繁创建销毁
+5. **分层检测**：按类型分层，同层对象互检，跨层不检
+
+## CSS 层叠与碰撞
+
+CSS 中的 `z-index` 和层叠上下文也会影响"碰撞"表现：
+
+- **视觉遮挡**：`z-index` 大的元素会遮挡小的，但不等于碰撞
+- **pointer-events**：可以控制哪些层叠元素响应鼠标事件
+- **transform: relative**：创建新的层叠上下文，影响 DOM 顺序
+
+```css
+/* 避免 transform 创建的层叠上下文干扰点击检测 */
+.layer {
+  transform: translateZ(0); /* 创建新层叠上下文 */
+  pointer-events: auto;
+}
+
+/* 让底层元素也可点击 */
+.overlay {
+  pointer-events: none;
+}
+.overlay button {
+  pointer-events: auto;
+}
+```
+
+## 参考资料
+
+- [MDN: 2D collision detection](https://developer.mozilla.org/en-US/docs/Games/Techniques/2D_collision_detection)
+- [Game Development: Collision Detection](https://developer.mozilla.org/en-US/docs/Games/Tutorials/2D_Breakout_game_pure_JavaScript/Collision_detection)
+- [SAT (Separating Axis Theorem)](https://www.seb.ly/posts/2010/09/sat-separating-axis-theorem-for-2d-collision-detection/)

--- a/docs/topics/img-placeholder/index.md
+++ b/docs/topics/img-placeholder/index.md
@@ -1,0 +1,331 @@
+# img 标签无图片时背景色控制
+
+## 问题描述
+
+在开发中，我们经常遇到这样的需求：当 `img` 标签的 `src` 无效、图片加载中或图片加载失败时，希望显示一个背景色占位。
+
+但 `img` 标签本身的背景色样式在以下情况不生效：
+- 图片加载中（浏览器默认显示空白）
+- 图片加载失败（浏览器显示破碎图标）
+- `src` 为空时的默认行为
+
+## 核心原理
+
+### 为什么不生效？
+
+`img` 元素是替换元素（Replaced Element），其渲染由资源内容决定，而非 CSS 内容。当没有有效图片内容时，`img` 元素的高度可能为 0 或显示浏览器默认的错误图标。
+
+```css
+/* ❌ 直接设置 background-color 无效 */
+img {
+  background-color: #f0f0f0; /* 不生效 */
+}
+```
+
+### 解决方案
+
+使用 **CSS 背景色 + padding** 技巧，让背景色成为图片的"底板"：
+
+```css
+/* ✅ 正确：利用背景色 + 内边距模拟占位 */
+.img-wrapper {
+  background-color: #f0f0f0; /* 占位背景色 */
+  padding-bottom: 66.67%;    /* 16:9 比例 = 9/16 = 0.5625 */
+  position: relative;
+}
+
+.img-wrapper img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+```
+
+## 方案对比
+
+| 方案 | 优点 | 缺点 | 适用场景 |
+|-----|------|------|---------|
+| 背景色 + padding | 纯 CSS、比例自适应 | 需要 wrapper 元素 | 响应式图片 |
+| 背景色 + aspect-ratio | 纯 CSS、简洁 | 需要 wrapper | 现代浏览器 |
+| ::before 伪元素 | 无需 HTML 改动 | 兼容性稍差 | 快速实现 |
+| JS 检测 + class | 可自定义错误UI | 需要 JS | 复杂交互 |
+
+## 方案 1：CSS aspect-ratio（推荐）
+
+```css
+.img-wrapper {
+  background-color: #e0e0e0;
+  aspect-ratio: 16 / 9; /* 控制比例 */
+  position: relative;
+}
+
+.img-wrapper img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+/* 加载中/失败状态 */
+.img-wrapper img[src=""],
+.img-wrapper img:not([src]) {
+  opacity: 0;
+}
+
+/* 使用 CSS 动画实现淡入效果 */
+.img-wrapper img.loaded {
+  animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+```
+
+```html
+<div class="img-wrapper">
+  <img src="example.jpg" alt="示例图片" 
+       onload="this.classList.add('loaded')"
+       onerror="this.style.display='none'">
+</div>
+```
+
+## 方案 2：使用 ::before 伪元素
+
+```css
+.img-container {
+  position: relative;
+  display: inline-block;
+}
+
+/* 背景占位层 */
+.img-container::before {
+  content: '';
+  display: block;
+  background-color: #f5f5f5;
+  /* 使用 padding-bottom 维持比例 */
+  padding-bottom: 75%; /* 4:3 比例 */
+}
+
+/* 图片绝对定位覆盖 */
+.img-container img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+```
+
+## 方案 3：图片加载失败时显示占位
+
+```javascript
+// 监听图片加载错误
+document.querySelectorAll('img').forEach(img => {
+  img.addEventListener('error', function() {
+    // 显示占位背景
+    this.style.opacity = '0';
+    this.parentElement.classList.add('img-error');
+  });
+  
+  img.addEventListener('load', function() {
+    this.style.opacity = '1';
+    this.parentElement.classList.remove('img-error');
+    this.classList.add('loaded');
+  });
+});
+```
+
+```css
+/* 占位图标 */
+.img-error::after {
+  content: '🖼️';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 48px;
+}
+```
+
+## 方案 4：纯 CSS 实现加载状态
+
+```css
+/* 使用 CSS 动画模拟加载中 */
+img {
+  background: linear-gradient(
+    90deg,
+    #f0f0f0 25%,
+    #e0e0e0 50%,
+    #f0f0f0 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+img[src]:not([src=""]) {
+  animation: none;
+  background: none;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+```
+
+## 实际应用：头像占位
+
+```css
+.avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  background-color: #e0e0e0;
+  overflow: hidden;
+  position: relative;
+}
+
+.avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  /* 图片加载失败时不显示破碎图标 */
+  onerror: "this.style.display='none'";
+}
+```
+
+```html
+<!-- 带默认头像的写法 -->
+<div class="avatar">
+  <img src="user.jpg" alt="用户头像" 
+       onerror="this.src='default-avatar.png'">
+</div>
+```
+
+## 最佳实践
+
+### 1. 使用 aspect-ratio 控制比例
+
+```css
+.img-wrapper {
+  background-color: #f0f0f0;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+}
+
+.img-wrapper img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+```
+
+### 2. 优雅的图片加载动画
+
+```css
+/* 初始隐藏 */
+.img-wrapper img {
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+/* 加载完成淡入 */
+.img-wrapper img.loaded {
+  opacity: 1;
+}
+```
+
+```javascript
+// 页面加载完成后添加 loaded 类
+document.querySelectorAll('.img-wrapper img').forEach(img => {
+  if (img.complete) {
+    img.classList.add('loaded');
+  } else {
+    img.addEventListener('load', () => img.classList.add('loaded'));
+  }
+});
+```
+
+### 3. 响应式图片场景
+
+```css
+/* 容器保持比例，图片自适应填充 */
+.picture-card {
+  background-color: #f8f8f8;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+}
+
+.picture-card img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.3s ease;
+}
+
+.picture-card:hover img {
+  transform: scale(1.05);
+}
+```
+
+## 常见问题
+
+### Q1: 为什么 background-color 不直接在 img 上生效？
+
+因为 `img` 是替换元素。当 `src` 有效时，图片内容覆盖了整个元素区域；当 `src` 无效时，元素的渲染由浏览器决定，通常高度为 0。
+
+### Q2: 如何在图片加载前显示背景色？
+
+使用 wrapper 元素，将背景色设置在 wrapper 上，图片 absolute 定位覆盖。
+
+### Q3: 如何避免加载失败时显示破碎图标？
+
+```css
+/* 隐藏破碎图标 */
+img[src=""],
+img:not([src]) {
+  visibility: hidden;
+}
+
+/* 或者使用 onerror 隐藏 */
+img.onerror = function() { this.style.visibility = 'hidden'; }
+```
+
+### Q4: 如何实现骨架屏效果？
+
+```css
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    #f0f0f0 0%,
+    #e0e0e0 50%,
+    #f0f0f0 100%
+  );
+  background-size: 200% 100%;
+  animation: skeleton-loading 1.5s infinite;
+}
+
+@keyframes skeleton-loading {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+```
+
+## 总结
+
+| 场景 | 推荐方案 |
+|-----|---------|
+| 响应式图片占位 | `aspect-ratio` + wrapper |
+| 加载动画 | shimmer skeleton CSS |
+| 错误占位 | `onerror` + 自定义 UI |
+| 头像占位 | 圆形 wrapper + 默认图 |
+
+**核心思想**：背景色必须设置在 img 的容器上，而非 img 本身。使用 wrapper + 绝对定位是处理图片占位的标准做法。

--- a/docs/topics/input-styling/index.md
+++ b/docs/topics/input-styling/index.md
@@ -1,0 +1,1152 @@
+# Input 样式完全指南
+
+## 概述
+
+表单输入元素（`<input>`、`<textarea>`、`<select>`）是 Web 界面中最常见的交互元素。浏览器为这些元素提供了默认样式，但通常与设计稿不符。本文档全面介绍如何自定义 input 样式，实现各种视觉效果。
+
+## Input 类型与默认样式
+
+### 常见 Input 类型
+
+| 类型 | 用途 | 默认样式特征 |
+|------|------|-------------|
+| `text` | 单行文本输入 | 边框 + 内边距 + 字体 |
+| `password` | 密码输入 | 圆点遮蔽字符 |
+| `email` | 邮箱输入 | 与 text 相同，浏览器可能验证格式 |
+| `number` | 数字输入 | 带上下箭头（不同浏览器表现不同） |
+| `tel` | 电话号码 | 与 text 相同，移动端可能调起数字键盘 |
+| `url` | URL 输入 | 与 text 相同，浏览器可能验证 URL 格式 |
+| `search` | 搜索框 | 带清除按钮，部分浏览器有圆角 |
+| `range` | 范围滑块 | 原生滑块控件 |
+| `checkbox` | 复选框 | 方框 + 对勾 |
+| `radio` | 单选框 | 圆框 + 圆点 |
+| `file` | 文件选择 | 按钮 + 文件名显示区 |
+| `submit/button` | 按钮 | 可点击的按钮样式 |
+| `hidden` | 隐藏字段 | 不可见 |
+
+## 重置默认样式
+
+### 完全重置 Input
+
+```css
+/* 重置所有 input */
+input {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  border: none;
+  outline: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  padding: 0;
+  margin: 0;
+}
+
+/* 更保守的重置（保留边框等基本样式） */
+input {
+  appearance: none;
+  -webkit-appearance: none;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  padding: 8px 12px;
+  font-size: 14px;
+}
+```
+
+## Pseudo-classes 伪类
+
+### 交互状态
+
+```css
+/* 默认状态 */
+input {
+  border: 1px solid #ccc;
+  background: #fff;
+}
+
+/* 悬停状态 */
+input:hover {
+  border-color: #999;
+}
+
+/* 聚焦状态 */
+input:focus {
+  border-color: #007aff;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.25);
+}
+
+/* 禁用状态 */
+input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  background: #f5f5f5;
+}
+
+/* 只读状态 */
+input:read-only {
+  background: #f9f9f9;
+  cursor: default;
+}
+```
+
+### 输入验证状态
+
+```css
+/* 有效输入 */
+input:valid {
+  border-color: #34c759;
+}
+
+/* 无效输入 */
+input:invalid {
+  border-color: #ff3b30;
+}
+
+/* 占位符可见时（部分浏览器支持） */
+input:placeholder-shown {
+  border-color: #ffcc00;
+}
+
+/* 必填字段 */
+input:required {
+  border-color: #ff9500;
+}
+
+/* 可选字段 */
+input:optional {
+  border-color: #ccc;
+}
+
+/* 输入中（正在输入） */
+input:placeholder-shown:not(:focus) {
+  font-style: italic;
+  color: #999;
+}
+```
+
+### Checkbox 与 Radio 特殊状态
+
+```css
+/* Checkbox 选中状态 */
+input[type="checkbox"]:checked {
+  background-color: #007aff;
+  border-color: #007aff;
+}
+
+/* Radio 选中状态 */
+input[type="radio"]:checked {
+  border-color: #007aff;
+}
+
+/* Checkbox 不确定状态（indeterminate） */
+input[type="checkbox"]:indeterminate {
+  background-color: #007aff;
+  border-color: #007aff;
+}
+
+/* Checkbox 禁用 */
+input[type="checkbox"]:disabled:checked {
+  opacity: 0.5;
+}
+```
+
+### 其他状态
+
+```css
+/* 启用状态（默认） */
+input:enabled {
+  cursor: text;
+}
+
+/* 聚焦可见（:focus-visible 选择性聚焦样式） */
+input:focus:not(:focus-visible) {
+  outline: none;
+}
+
+input:focus-visible {
+  outline: 2px solid #007aff;
+  outline-offset: 2px;
+}
+
+/* 正在填充（Autofill 状态）Chrome 特有 */
+input:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 100px #fff inset;
+  -webkit-text-fill-color: #000;
+}
+```
+
+## Pseudo-elements 伪元素
+
+### 占位符样式
+
+```css
+/* WebKit/Blink 浏览器 */
+input::placeholder {
+  color: #999;
+  font-style: italic;
+  opacity: 1; /* Firefox 需要 */
+}
+
+/* Firefox */
+input::-webkit-input-placeholder {
+  color: #999;
+  font-style: italic;
+}
+
+/* 聚焦时占位符样式变化 */
+input:focus::placeholder {
+  color: #ccc;
+}
+```
+
+### 选中文本样式
+
+```css
+input::selection {
+  background: rgba(0, 122, 255, 0.3);
+  color: inherit;
+}
+```
+
+### 输入区样式（仅部分浏览器支持）
+
+```css
+/* Chrome/Safari - 输入区域的样式 */
+input::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+}
+
+input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+}
+
+/* 搜索框清除按钮 */
+input[type="search"]::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+  height: 16px;
+  width: 16px;
+  background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="%23999"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>') no-repeat center;
+}
+
+/* 搜索框-decoration */
+input[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+```
+
+## 常见 Input 类型样式
+
+### 1. 文本输入框
+
+```css
+.input-text {
+  width: 100%;
+  max-width: 400px;
+  height: 44px;
+  padding: 0 16px;
+  border: 1px solid #d1d1d6;
+  border-radius: 8px;
+  font-size: 16px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.input-text:hover {
+  border-color: #b1b1b6;
+}
+
+.input-text:focus {
+  border-color: #007aff;
+  box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.15);
+}
+
+.input-text::placeholder {
+  color: #c7c7cc;
+}
+```
+
+### 2. 搜索框
+
+```css
+.input-search {
+  width: 100%;
+  max-width: 320px;
+  height: 36px;
+  padding: 0 12px 0 36px;
+  border: 1px solid #e5e5ea;
+  border-radius: 18px;
+  background: #f2f2f7 url('search-icon.svg') no-repeat 12px center;
+  font-size: 14px;
+  transition: background-color 0.2s, border-color 0.2s;
+}
+
+.input-search:focus {
+  background-color: #fff;
+  border-color: #007aff;
+  outline: none;
+}
+
+/* 移除浏览器默认搜索框样式 */
+.input-search {
+  appearance: none;
+  -webkit-appearance: none;
+}
+```
+
+### 3. 密码输入框
+
+```css
+.input-password {
+  position: relative;
+  width: 100%;
+  max-width: 320px;
+}
+
+.input-password input {
+  width: 100%;
+  height: 44px;
+  padding: 0 44px 0 16px;
+  border: 1px solid #d1d1d6;
+  border-radius: 8px;
+  font-size: 16px;
+}
+
+.input-password button.toggle {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: url('eye-icon.svg') no-repeat center;
+  cursor: pointer;
+}
+
+.input-password button.toggle.show {
+  background-image: url('eye-off-icon.svg');
+}
+```
+
+### 4. 数字输入框
+
+```css
+.input-number {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.input-number input {
+  width: 120px;
+  height: 36px;
+  padding: 0 36px;
+  text-align: center;
+  border: 1px solid #d1d1d6;
+  border-radius: 6px;
+  font-size: 14px;
+  /* 移除浏览器默认箭头 */
+  -moz-appearance: textfield;
+}
+
+.input-number input::-webkit-inner-spin-button,
+.input-number input::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+.input-number button {
+  position: absolute;
+  width: 28px;
+  height: 28px;
+  border: none;
+  border-radius: 4px;
+  background: #f2f2f7;
+  cursor: pointer;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.input-number button.decrease {
+  left: 4px;
+}
+
+.input-number button.increase {
+  right: 4px;
+}
+
+.input-number button:hover {
+  background: #e5e5ea;
+}
+```
+
+### 5. Checkbox 自定义样式
+
+```css
+.checkbox-wrapper {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.checkbox-wrapper input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.checkbox-wrapper .checkmark {
+  width: 20px;
+  height: 20px;
+  border: 2px solid #d1d1d6;
+  border-radius: 4px;
+  margin-right: 10px;
+  position: relative;
+  transition: all 0.2s;
+}
+
+.checkbox-wrapper input[type="checkbox"]:checked + .checkmark {
+  background: #007aff;
+  border-color: #007aff;
+}
+
+.checkbox-wrapper .checkmark::after {
+  content: '';
+  position: absolute;
+  left: 6px;
+  top: 2px;
+  width: 5px;
+  height: 10px;
+  border: solid white;
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+
+.checkbox-wrapper input[type="checkbox"]:checked + .checkmark::after {
+  opacity: 1;
+}
+
+.checkbox-wrapper:hover .checkmark {
+  border-color: #007aff;
+}
+```
+
+### 6. Radio 自定义样式
+
+```css
+.radio-wrapper {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+  user-select: none;
+}
+
+.radio-wrapper input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.radio-wrapper .radiomark {
+  width: 20px;
+  height: 20px;
+  border: 2px solid #d1d1d6;
+  border-radius: 50%;
+  margin-right: 10px;
+  position: relative;
+  transition: all 0.2s;
+}
+
+.radio-wrapper input[type="radio"]:checked + .radiomark {
+  border-color: #007aff;
+}
+
+.radio-wrapper .radiomark::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%) scale(0);
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #007aff;
+  transition: transform 0.2s;
+}
+
+.radio-wrapper input[type="radio"]:checked + .radiomark::after {
+  transform: translate(-50%, -50%) scale(1);
+}
+
+.radio-wrapper:hover .radiomark {
+  border-color: #007aff;
+}
+```
+
+### 7. Switch/Toggle 开关
+
+```css
+.switch-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+.switch-wrapper input[type="checkbox"] {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.switch {
+  width: 51px;
+  height: 31px;
+  background: #e9e9eb;
+  border-radius: 16px;
+  position: relative;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+
+.switch::after {
+  content: '';
+  position: absolute;
+  left: 2px;
+  top: 2px;
+  width: 27px;
+  height: 27px;
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  transition: transform 0.3s;
+}
+
+.switch-wrapper input[type="checkbox"]:checked + .switch {
+  background: #34c759;
+}
+
+.switch-wrapper input[type="checkbox"]:checked + .switch::after {
+  transform: translateX(20px);
+}
+```
+
+### 8. Range/Slider 滑块
+
+```css
+.range-wrapper {
+  width: 100%;
+  max-width: 300px;
+}
+
+input[type="range"] {
+  width: 100%;
+  height: 4px;
+  background: #e5e5ea;
+  border-radius: 2px;
+  outline: none;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+input[type="range"]::-webkit-slider-thumb {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 24px;
+  height: 24px;
+  background: #007aff;
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 122, 255, 0.4);
+  transition: transform 0.1s;
+}
+
+input[type="range"]::-webkit-slider-thumb:hover {
+  transform: scale(1.1);
+}
+
+input[type="range"]::-webkit-slider-thumb:active {
+  transform: scale(0.95);
+}
+
+/* Firefox */
+input[type="range"]::-moz-range-thumb {
+  width: 24px;
+  height: 24px;
+  background: #007aff;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+}
+```
+
+### 9. Select 下拉框
+
+```css
+.select-wrapper {
+  position: relative;
+  width: 200px;
+}
+
+.select-wrapper select {
+  width: 100%;
+  height: 40px;
+  padding: 0 36px 0 12px;
+  border: 1px solid #d1d1d6;
+  border-radius: 8px;
+  background: #fff;
+  font-size: 14px;
+  cursor: pointer;
+  appearance: none;
+  -webkit-appearance: none;
+}
+
+.select-wrapper::after {
+  content: '';
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-left: 5px solid transparent;
+  border-right: 5px solid transparent;
+  border-top: 6px solid #8e8e93;
+  pointer-events: none;
+}
+
+.select-wrapper select:focus {
+  border-color: #007aff;
+  outline: none;
+}
+```
+
+### 10. Textarea 多行文本
+
+```css
+textarea {
+  width: 100%;
+  min-height: 120px;
+  padding: 12px 16px;
+  border: 1px solid #d1d1d6;
+  border-radius: 8px;
+  font-size: 14px;
+  font-family: inherit;
+  line-height: 1.5;
+  resize: vertical; /* 允许垂直调整大小 */
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+textarea:hover {
+  border-color: #b1b1b6;
+}
+
+textarea:focus {
+  border-color: #007aff;
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.15);
+}
+
+/* 禁止调整大小 */
+textarea.no-resize {
+  resize: none;
+}
+
+/* 只允许水平调整 */
+textarea.horizontal-resize {
+  resize: horizontal;
+}
+
+/* 只允许垂直调整（默认） */
+textarea.vertical-resize {
+  resize: vertical;
+}
+```
+
+## File Input 自定义
+
+### 方法一：包装 + 隐藏原生 input
+
+```css
+.file-wrapper {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.file-wrapper input[type="file"] {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+}
+
+.file-wrapper .file-label {
+  display: inline-flex;
+  align-items: center;
+  padding: 10px 20px;
+  background: #007aff;
+  color: #fff;
+  border-radius: 8px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.file-wrapper .file-label:hover {
+  background: #0056cc;
+}
+
+.file-wrapper .file-name {
+  color: #666;
+  font-size: 14px;
+}
+```
+
+### 方法二：按钮触发
+
+```html
+<div class="upload-area" id="uploadArea">
+  <input type="file" id="fileInput" hidden>
+  <button type="button" id="uploadBtn">选择文件</button>
+  <span id="fileName"></span>
+</div>
+
+<style>
+  .upload-area {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 20px;
+    border: 2px dashed #d1d1d6;
+    border-radius: 12px;
+    transition: border-color 0.2s, background-color 0.2s;
+  }
+
+  .upload-area:hover,
+  .upload-area.dragover {
+    border-color: #007aff;
+    background: rgba(0, 122, 255, 0.05);
+  }
+</style>
+
+<script>
+  const fileInput = document.getElementById('fileInput');
+  const uploadBtn = document.getElementById('uploadBtn');
+  const fileName = document.getElementById('fileName');
+
+  uploadBtn.addEventListener('click', () => fileInput.click());
+
+  fileInput.addEventListener('change', () => {
+    if (fileInput.files.length > 0) {
+      fileName.textContent = fileInput.files[0].name;
+    }
+  });
+</script>
+```
+
+## 高级技巧
+
+### 1. 浮动标签（Floating Label）
+
+```css
+.float-label {
+  position: relative;
+}
+
+.float-label input,
+.float-label textarea {
+  width: 100%;
+  padding: 20px 16px 8px;
+  border: 1px solid #d1d1d6;
+  border-radius: 8px;
+  font-size: 16px;
+}
+
+.float-label label {
+  position: absolute;
+  left: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 16px;
+  color: #8e8e93;
+  pointer-events: none;
+  transition: all 0.2s;
+}
+
+.float-label textarea ~ label {
+  top: 24px;
+}
+
+.float-label input:focus ~ label,
+.float-label input:not(:placeholder-shown) ~ label,
+.float-label textarea:focus ~ label,
+.float-label textarea:not(:placeholder-shown) ~ label {
+  top: 8px;
+  transform: none;
+  font-size: 12px;
+  color: #007aff;
+}
+```
+
+### 2. 输入框添加图标
+
+```css
+.input-with-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.input-with-icon input {
+  padding-left: 40px;
+}
+
+.input-with-icon .icon {
+  position: absolute;
+  left: 12px;
+  width: 20px;
+  height: 20px;
+  color: #8e8e93;
+  pointer-events: none;
+}
+
+.input-with-icon input:focus ~ .icon {
+  color: #007aff;
+}
+```
+
+### 3. 渐进式显示密码
+
+```html
+<div class="password-field">
+  <input type="password" id="password" placeholder="请输入密码">
+  <button type="button" class="toggle" aria-label="切换密码可见性">
+    <svg class="icon-show" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+      <circle cx="12" cy="12" r="3"/>
+    </svg>
+    <svg class="icon-hide" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none">
+      <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/>
+      <line x1="1" y1="1" x2="23" y2="23"/>
+    </svg>
+  </button>
+</div>
+
+<style>
+.password-field {
+  position: relative;
+}
+.password-field input {
+  padding-right: 48px;
+}
+.password-field .toggle {
+  position: absolute;
+  right: 8px;
+  top: 50%;
+  transform: translateY(-50%);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 8px;
+}
+.password-field input[type="text"] ~ .toggle .icon-show { display: none; }
+.password-field input[type="text"] ~ .toggle .icon-hide { display: block; }
+</style>
+
+<script>
+document.querySelector('.toggle').addEventListener('click', function() {
+  const input = document.getElementById('password');
+  if (input.type === 'password') {
+    input.type = 'text';
+  } else {
+    input.type = 'password';
+  }
+});
+</script>
+```
+
+### 4. 验证反馈动画
+
+```css
+.input-wrapper {
+  position: relative;
+}
+
+.input-wrapper input {
+  transition: border-color 0.3s;
+}
+
+.input-wrapper input.valid {
+  border-color: #34c759;
+  animation: shake 0.3s;
+}
+
+.input-wrapper input.invalid {
+  border-color: #ff3b30;
+  animation: shake 0.3s;
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  25% { transform: translateX(-4px); }
+  75% { transform: translateX(4px); }
+}
+
+.input-wrapper .validation-icon {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 18px;
+}
+
+.input-wrapper input.valid ~ .validation-icon::after {
+  content: '✓';
+  color: #34c759;
+}
+
+.input-wrapper input.invalid ~ .validation-icon::after {
+  content: '✗';
+  color: #ff3b30;
+}
+```
+
+## 无障碍性（Accessibility）
+
+### 1. 确保足够的对比度
+
+```css
+/* 对比度至少 4.5:1（普通文本）或 3:1（大文本） */
+input {
+  color: #333; /* 浅灰色文字在白色背景上对比度约 12:1 */
+  background: #fff;
+}
+
+/* 避免使用纯灰色文字 */
+input::placeholder {
+  color: #767676; /* 符合 WCAG AA */
+}
+```
+
+### 2. 聚焦样式
+
+```css
+/* 始终为:focus 提供可见样式 */
+input:focus {
+  outline: 2px solid #007aff;
+  outline-offset: 2px;
+}
+
+/* :focus-visible 仅在键盘导航时显示聚焦样式 */
+input:focus:not(:focus-visible) {
+  outline: none;
+}
+
+input:focus-visible {
+  outline: 2px solid #007aff;
+  outline-offset: 2px;
+}
+```
+
+### 3. 标签关联
+
+```html
+<!-- 方法一：label 的 for 属性 -->
+<label for="username">用户名</label>
+<input type="text" id="username">
+
+<!-- 方法二：包装 -->
+<label>
+  用户名
+  <input type="text">
+</label>
+
+<!-- 方法三：aria-label -->
+<input type="text" aria-label="用户名">
+```
+
+### 4. 错误提示
+
+```html
+<label for="email">邮箱地址</label>
+<input type="email" id="email" aria-describedby="email-hint email-error">
+<span id="email-hint">请输入有效的邮箱地址</span>
+<span id="email-error" role="alert" style="color: #ff3b30;">
+  请输入有效的邮箱地址
+</span>
+
+<style>
+input[aria-invalid="true"] {
+  border-color: #ff3b30;
+}
+</style>
+```
+
+## 浏览器兼容性
+
+| 特性 | Chrome | Firefox | Safari | Edge |
+|------|--------|--------|--------|------|
+| `appearance: none` | ✅ | ✅ | ✅ | ✅ |
+| `::placeholder` | ✅ | ✅ | ✅ | ✅ |
+| `:focus-visible` | ✅ 119+ | ✅ 4+ | ✅ | ✅ 119+ |
+| `:indeterminate` | ✅ | ✅ | ✅ | ✅ |
+| `::-webkit-slider-thumb` | ✅ | ❌ | ✅ | ✅ |
+| `::selection` | ✅ | ✅ | ✅ | ✅ |
+| `:autofill` | ✅ | ✅ | ✅ | ✅ |
+
+### 前缀兼容性写法
+
+```css
+input {
+  /* 移除默认样式 */
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+}
+
+/* Placeholder */
+input::-webkit-input-placeholder {
+  color: #999;
+}
+input:-moz-placeholder {
+  color: #999;
+}
+input::-moz-placeholder {
+  color: #999;
+}
+
+/* Range Slider */
+input[type="range"] {
+  -webkit-appearance: none;
+}
+input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+}
+```
+
+## 性能注意事项
+
+### 1. 避免过度重绘
+
+```css
+/* 差：每次输入都触发重绘 */
+input {
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  transition: box-shadow 0.3s, border-color 0.3s;
+}
+
+/* 好：只改变需要改变的属性 */
+input {
+  border: 1px solid #ccc;
+  transition: border-color 0.2s;
+}
+
+input:focus {
+  border-color: #007aff;
+  box-shadow: 0 0 0 3px rgba(0,122,255,0.15);
+}
+```
+
+### 2. 使用 `will-change` 优化动画
+
+```css
+.switch {
+  will-change: background-color;
+  transition: background-color 0.3s;
+}
+
+.switch::after {
+  will-change: transform;
+  transition: transform 0.3s;
+}
+```
+
+### 3. 减少复杂选择器
+
+```css
+/* 差：复杂选择器 */
+form.main-form div.container div.input-group input[type="text"].form-control:focus {
+  border-color: #007aff;
+}
+
+/* 好：简洁选择器 */
+.form-input:focus {
+  border-color: #007aff;
+}
+```
+
+## 常见问题
+
+### 1. iOS 圆角和阴影
+
+```css
+input {
+  -webkit-appearance: none;
+  border-radius: 8px;
+}
+
+/* iOS 上的 input 可能不会继承父元素字体 */
+input {
+  font-family: inherit;
+}
+```
+
+### 2. Chrome 自动填充背景色
+
+```css
+input:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 100px #fff inset;
+  -webkit-text-fill-color: #000;
+}
+
+/* 过渡效果 */
+input {
+  transition: background-color 0.25s, color 0.25s;
+}
+input:-webkit-autofill {
+  -webkit-box-shadow: 0 0 0 100px #fff inset;
+  -webkit-text-fill-color: #000;
+  transition: background-color 5000s ease-in-out;
+}
+```
+
+### 3. 移动端点击高亮
+
+```css
+input, textarea, select {
+  -webkit-tap-highlight-color: transparent;
+}
+```
+
+### 4. 禁用 iOS 样式缩放
+
+```html
+<!-- 在 head 中添加 viewport meta -->
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+```
+
+## 总结
+
+| 类别 | 关键点 |
+|------|--------|
+| **重置样式** | 使用 `appearance: none` 清除默认样式 |
+| **交互状态** | `:hover`, `:focus`, `:disabled` 提供视觉反馈 |
+| **验证状态** | `:valid`, `:invalid`, `:required` 显示输入验证结果 |
+| **伪元素** | `::placeholder`, `::selection` 自定义特定部分样式 |
+| **自定义控件** | Checkbox、Radio、Switch 使用包装器 + 隐藏原生元素 |
+| **无障碍** | 足够的对比度、键盘可聚焦、ARIA 标签 |
+| **兼容性** | 使用前缀 `-webkit-`, `-moz-` 确保跨浏览器支持 |
+
+## 参考资源
+
+- [MDN: <input>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input)
+- [CSS Input Styling Guide](https://moderncss.dev/)
+- [Customizing Checkboxes and Radio Buttons](https://coder-coder.com/custom-checkbox-radio-input/)

--- a/docs/topics/interactive-learning/euismod-liascript-analysis.md
+++ b/docs/topics/interactive-learning/euismod-liascript-analysis.md
@@ -1,0 +1,200 @@
+---
+title: 交互式学习改造方案分析
+category: 方法论
+tags: [交互式学习, LiaScript, Markdown, Euismod]
+description: 分析将交互式 CSS Grid 学习工具 Euismod 改造为 LiaScript Markdown 的可行性与方案
+keywords: Euismod, LiaScript, CSS Grid, 交互式学习, Markdown
+---
+
+# 交互式学习改造方案分析
+
+## 1. 任务背景
+
+### 1.1 Euismod 项目简介
+
+[Euismod](https://github.com/Etesam913/euismod) 是一个 React + Vite 构建的交互式 CSS Grid 学习网站，其核心特点：
+
+- **技术栈**：React + Vite + TypeScript
+- **交互方式**：可视化界面操控 CSS Grid 属性，实时预览效果
+- **主要功能**：
+  - Grid Creation（网格创建）
+  - Item Placement（元素放置）
+  - Grid Areas（网格区域）
+  - Grid Gap/fr unit（间距和 fr 单位）
+  - Quiz（测验）
+
+### 1.2 改造目标
+
+将 Euismod 的交互式学习体验，迁移到轻量级的 Markdown 格式，使内容更易分享、编辑和版本管理。
+
+## 2. LiaScript 方案分析
+
+### 2.1 什么是 LiaScript
+
+[LiaScript](https://liascript.github.io/) 是一个开源的 Markdown 方言，通过简单的文本语法创建交互式在线课程。
+
+**核心特点**：
+- 纯文本格式，易于版本管理
+- 浏览器端实时解析，无需构建步骤
+- 支持多媒体、测验、代码执行
+- 可嵌入任何 iframe
+
+### 2.2 LiaScript 语法示例
+
+```markdown
+# 我的课程
+
+## 文本和代码
+
+可以通过 @[code](javascript:alert("Hello");) 执行 JavaScript 代码
+
+## 测验示例
+
+// 多选题
+[( )] 选项 A
+[(X)] 选项 B (正确)
+[( )] 选项 C
+
+// 单选题
+[(X)] 正确答案
+[( )] 错误答案
+```
+
+### 2.3 LiaScript 支持的交互形式
+
+| 功能 | 语法 | 说明 |
+|------|------|------|
+| 代码执行 | `@[code](language:code)` | 可执行 JavaScript 代码 |
+| 嵌入式 iframe | `@[iframe](url)` | 嵌入外部交互工具 |
+| 测验 | `[( )]` `[(X)]` | 选择题 |
+| 动画 | `--> comment` | 渐进式展示 |
+| 音频 | `@[audio](url)` | 嵌入音频 |
+| 视频 | `@[video](url)` | 嵌入视频 |
+
+## 3. 转换方案对比
+
+### 3.1 方案对比
+
+| 维度 | Euismod（React） | LiaScript | MDX（现有方案） |
+|------|------------------|-----------|----------------|
+| 交互深度 | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ |
+| 可维护性 | ⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ |
+| 版本控制 | ⭐⭐ | ⭐⭐⭐⭐⭐ | ⭐⭐⭐ |
+| 学习成本 | 高 | 低 | 中 |
+| 依赖 | React/Vite | 无 | MDX/Vite |
+| 移动端适配 | ⭐⭐⭐⭐ | ⭐⭐⭐ | ⭐⭐⭐ |
+
+### 3.2 推荐方案：混合策略
+
+**核心思路**：保留现有的 MDX 内容 + 新增 LiaScript 格式作为轻量替代
+
+#### 策略一：LiaScript 嵌入式 Demo
+
+将现有的交互式 Demo 以 iframe 形式嵌入 LiaScript：
+
+```markdown
+## Grid Gap 属性
+
+通过滑块调整 grid-gap 观察间距变化。
+
+@[iframe](https://your-demo-url?gap=10)
+```
+
+#### 策略二：代码执行演示
+
+利用 LiaScript 的 JavaScript 执行能力：
+
+```markdown
+## fr 单位计算
+
+```javascript
+// 尝试修改下面的 grid-template-columns 值
+const columns = "1fr 2fr 1fr";
+const containerWidth = 600;
+const fractions = [1, 2, 1];
+const total = fractions.reduce((a, b) => a + b, 0);
+const result = fractions.map(f => (f / total) * containerWidth);
+console.log(result); // [100, 200, 100]
+```
+```
+
+#### 策略三：LiaScript Quiz 替代方案
+
+```markdown
+## Grid Quiz
+
+下面哪个属性用于设置列之间的间距？
+[( )] grid-row-gap
+[(X)] grid-column-gap (正确)
+[( )] margin
+[( )] padding
+```
+
+## 4. 实施步骤
+
+### 4.1 短期（1-2 周）
+
+1. **建立 LiaScript 仓库**
+   - 创建 `learn-css-liascript` 目录
+   - 配置 LiaScript VSCode 插件
+   - 编写入门文档
+
+2. **迁移基础内容**
+   - Grid 基础概念（可直接迁移现有 MDX）
+   - 创建交互式 Demo iframe 链接
+   - 编写 Quiz 测验
+
+### 4.2 中期（1 个月）
+
+1. **完善交互 Demo 库**
+   - 将现有 HTML Demo 部署为独立页面
+   - 生成 iframe 嵌入链接
+   - 添加响应式适配
+
+2. **建立 Quiz 题库**
+   - 覆盖 Grid/Flexbox/CSS 核心概念
+   - 添加难度分级
+   - 实现自动评分
+
+### 4.3 长期（持续迭代）
+
+1. **社区共建**
+   - 通过 GitHub 开放协作
+   - 收集用户反馈
+   - 持续优化内容
+
+2. **多语言支持**
+   - LiaScript 原生支持多语言
+   - 扩展英文版本
+
+## 5. 风险与应对
+
+| 风险 | 影响 | 应对措施 |
+|------|------|----------|
+| iframe 依赖外部服务 | 链接失效 | 定期检查、镜像备份 |
+| 交互深度受限 | 功能单一 | 保持 MDX 版本作为完整参考 |
+| 用户习惯改变 | 学习成本 | 提供两套入口，引导用户 |
+
+## 6. 结论
+
+**不建议完全替换 Euismod**，原因：
+1. Euismod 的交互体验无法在纯 Markdown 中复现
+2. 现有 MDX 内容已足够完善
+3. 维护多套格式增加成本
+
+**推荐方案**：
+- 保留现有 MDX 内容作为权威版本
+- 创建轻量级 LiaScript 版本作为补充
+- 重点开发独立的交互 Demo 库，通过 iframe 嵌入
+
+## 7. 参考资源
+
+- [Euismod GitHub](https://github.com/Etesam913/euismod)
+- [LiaScript 官方文档](https://liascript.github.io/course/?https://raw.githubusercontent.com/liaScript/docs/master/README.md)
+- [LiaScript VSCode 插件](https://marketplace.visualstudio.com/items?itemName=LiaScript.liascript)
+- [LiaScript 模板库](https://github.com/topics/liascript-template)
+
+---
+
+*文档创建时间：2026-03-28*
+*任务来源：Reminders UUID: 2C23E656-99FE-4383-B9D2-921A774483EE*

--- a/docs/topics/mongodb-test-data/README.md
+++ b/docs/topics/mongodb-test-data/README.md
@@ -1,0 +1,53 @@
+# MongoDB 测试数据存储指南
+
+## 目标
+
+为 learn-css 仓库添加 MongoDB 测试数据存储的学习文档和交互式演示，帮助开发者掌握：
+
+1. MongoDB 测试数据创建方法（insert/factory/seeding）
+2. @shelf/jest-mongodb 等测试工具集成
+3. 常用工具：mongofill（测试数据生成）、mongo-seeding（JSON/JS文件播种）
+4. Node.js + MongoDB 完整示例代码
+
+## 验收标准
+
+### 文档要求
+
+- [x] 创建 `docs/topics/mongodb-test-data/index.md` 完整技术文档
+- [x] 包含 MongoDB 测试数据创建方法（insert/factory/seeding）
+- [x] 包含 @shelf/jest-mongodb 集成示例
+- [x] 包含 mongofill 和 mongo-seeding 工具介绍
+- [x] 包含 Node.js + MongoDB 完整示例代码
+- [x] 包含性能优化和最佳实践
+
+### 示例要求
+
+- [x] 创建 `examples/css/demos/mongodb-test-data/index.html` 交互式演示页
+- [x] 演示 Factory 模式创建测试数据
+- [x] 演示 mongo-seeding 数据播种流程
+- [x] 包含实时操作界面和结果展示
+- [x] 响应式设计，移动端友好
+
+### Git 要求
+
+- [x] 提交到 `feature/mongodb-test-data` 分支
+- [x] 创建 PR 到 `master` 分支
+- [x] PR 标题格式：`docs: 添加 MongoDB 测试数据存储指南`
+
+## 文档结构
+
+```
+docs/topics/mongodb-test-data/
+└── index.md          # 技术文档
+
+examples/css/demos/mongodb-test-data/
+└── index.html        # 交互式演示
+```
+
+## 技术栈
+
+- MongoDB
+- Node.js
+- jest / @shelf/jest-mongodb
+- mongofill
+- mongo-seeding

--- a/docs/topics/mongodb-test-data/index.md
+++ b/docs/topics/mongodb-test-data/index.md
@@ -1,0 +1,618 @@
+# MongoDB 测试数据存储指南
+
+## 概述
+
+MongoDB 作为文档数据库，灵活的数据模型使其成为存储测试数据（fixtures）的理想选择。本指南介绍多种创建和管理测试数据的方法。
+
+## 目录
+
+- [基础插入](#基础插入)
+- [Factory 模式](#factory-模式)
+- [数据播种工具](#数据播种工具)
+- [Jest 集成](#jest-集成)
+- [最佳实践](#最佳实践)
+
+---
+
+## 基础插入
+
+### 单条插入
+
+```javascript
+// 使用 MongoDB Native Driver
+const { MongoClient } = require('mongodb');
+
+async function insertOneUser() {
+  const client = await MongoClient.connect('mongodb://localhost:27017');
+  const db = client.db('test');
+  
+  const user = {
+    name: '张三',
+    email: 'zhangsan@example.com',
+    age: 25,
+    tags: ['测试', '开发'],
+    createdAt: new Date()
+  };
+  
+  const result = await db.collection('users').insertOne(user);
+  console.log('插入的文档 ID:', result.insertedId);
+  
+  await client.close();
+}
+```
+
+### 批量插入
+
+```javascript
+async function insertManyUsers() {
+  const client = await MongoClient.connect('mongodb://localhost:27017');
+  const db = client.db('test');
+  
+  const users = [
+    { name: '用户1', email: 'user1@example.com', age: 20 },
+    { name: '用户2', email: 'user2@example.com', age: 21 },
+    { name: '用户3', email: 'user3@example.com', age: 22 }
+  ];
+  
+  const result = await db.collection('users').insertMany(users);
+  console.log('插入数量:', result.insertedCount);
+  
+  await client.close();
+}
+```
+
+### 插入后查询
+
+```javascript
+async function insertAndFind() {
+  const client = await MongoClient.connect('mongodb://localhost:27017');
+  const db = client.db('test');
+  
+  // 插入
+  const { insertedId } = await db.collection('posts').insertOne({
+    title: '测试文章',
+    content: '这是测试内容',
+    author: '作者',
+    views: 0,
+    published: true
+  });
+  
+  // 立即查询
+  const doc = await db.collection('posts').findOne({ _id: insertedId });
+  console.log('插入的文档:', doc);
+  
+  await client.close();
+}
+```
+
+---
+
+## Factory 模式
+
+Factory 模式用于生成结构化的测试数据，避免手动创建每个文档。
+
+### 基础 Factory
+
+```javascript
+// factories/userFactory.js
+class UserFactory {
+  static create(data = {}) {
+    return {
+      name: data.name || this.randomName(),
+      email: data.email || this.randomEmail(),
+      age: data.age || this.randomAge(),
+      avatar: data.avatar || `https://i.pravatar.cc/150?u=${Date.now()}`,
+      bio: data.bio || this.randomBio(),
+      createdAt: data.createdAt || new Date(),
+      updatedAt: data.updatedAt || new Date(),
+      ...data
+    };
+  }
+  
+  static randomName() {
+    const names = ['张三', '李四', '王五', '赵六', '钱七'];
+    return names[Math.floor(Math.random() * names.length)];
+  }
+  
+  static randomEmail() {
+    return `user${Date.now()}@example.com`;
+  }
+  
+  static randomAge() {
+    return Math.floor(Math.random() * 50) + 18; // 18-67岁
+  }
+  
+  static randomBio() {
+    const bios = [
+      '热爱编程',
+      '喜欢音乐',
+      '运动爱好者',
+      '阅读爱好者'
+    ];
+    return bios[Math.floor(Math.random() * bios.length)];
+  }
+  
+  // 生成多个用户
+  static createMany(count, baseData = {}) {
+    return Array.from({ length: count }, () => this.create(baseData));
+  }
+}
+
+module.exports = UserFactory;
+```
+
+### 使用 Factory 生成数据
+
+```javascript
+const UserFactory = require('./factories/userFactory');
+
+async function generateTestData() {
+  const client = await MongoClient.connect('mongodb://localhost:27017');
+  const db = client.db('test');
+  
+  // 生成 10 个用户
+  const users = UserFactory.createMany(10, { age: 25 });
+  
+  await db.collection('users').insertMany(users);
+  console.log(`已插入 ${users.length} 个用户`);
+  
+  await client.close();
+}
+```
+
+### 带关联的 Factory
+
+```javascript
+// factories/orderFactory.js
+const UserFactory = require('./userFactory');
+
+class OrderFactory {
+  static create(data = {}) {
+    const now = new Date();
+    return {
+      orderNo: data.orderNo || `ORD${Date.now()}${Math.random().toString(36).substr(2, 6)}`,
+      userId: data.userId, // 外部传入或关联
+      items: data.items || this.randomItems(),
+      totalAmount: data.totalAmount || this.calcTotal(data.items),
+      status: data.status || 'pending',
+      createdAt: data.createdAt || now,
+      shippedAt: data.shippedAt || null,
+      completedAt: data.completedAt || null,
+      ...data
+    };
+  }
+  
+  static randomItems() {
+    const items = [];
+    const count = Math.floor(Math.random() * 5) + 1;
+    for (let i = 0; i < count; i++) {
+      items.push({
+        productId: `PROD${Math.random().toString(36).substr(2, 8)}`,
+        name: `商品${i + 1}`,
+        price: Math.floor(Math.random() * 100) + 10,
+        quantity: Math.floor(Math.random() * 5) + 1
+      });
+    }
+    return items;
+  }
+  
+  static calcTotal(items) {
+    return items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  }
+  
+  static createMany(count, baseData = {}) {
+    return Array.from({ length: count }, () => this.create(baseData));
+  }
+}
+
+module.exports = OrderFactory;
+```
+
+---
+
+## 数据播种工具
+
+### mongo-seeding
+
+[mongo-seeding](https://github.com/CACERSMARCIN/mongo-seeding) 从 JSON/JS 文件播种数据。
+
+#### 安装
+
+```bash
+npm install mongo-seeding
+```
+
+#### 配置
+
+```javascript
+// seed.config.js
+const { Seeder } = require('mongo-seeding');
+
+const config = {
+  mongodb: {
+    host: 'localhost',
+    port: 27017,
+    database: 'test'
+  },
+  dropDatabase: false
+};
+
+const seeder = new Seeder(config);
+```
+
+#### 定义数据
+
+```json
+// data/users.json
+[
+  {
+    "_id": "user-1",
+    "name": "张三",
+    "email": "zhangsan@example.com",
+    "age": 25
+  },
+  {
+    "_id": "user-2", 
+    "name": "李四",
+    "email": "lisi@example.com",
+    "age": 30
+  }
+]
+```
+
+```javascript
+// data/orders.js
+module.exports = [
+  {
+    _id: 'order-1',
+    userId: 'user-1',
+    items: [
+      { productId: 'PROD001', name: '商品A', price: 99.9, quantity: 2 }
+    ],
+    totalAmount: 199.8,
+    status: 'completed'
+  }
+];
+```
+
+#### 执行播种
+
+```javascript
+const { Seeder } = require('mongo-seeding');
+const path = require('path');
+
+const seeder = new Seeder({
+  mongodb: {
+    host: 'localhost',
+    port: 27017,
+    database: 'test'
+  }
+});
+
+const collections = seeder.readCollectionsFromPath(
+  path.resolve('./data'),
+  { extensions: ['js', 'json'] }
+);
+
+seeder
+  .import(collections)
+  .then(() => console.log('数据播种完成'))
+  .catch(err => console.error('播种失败:', err));
+```
+
+### mongofill
+
+[mongofill](https://github.com/felipecaputo/mongofill) 提供 Faker 风格的测试数据生成。
+
+#### 安装
+
+```bash
+npm install mongofill faker
+```
+
+#### 使用示例
+
+```javascript
+const MongoFill = require('mongofill').default;
+const Faker = require('faker');
+
+const mongoFill = new MongoFill({
+  seed: true, // 固定种子，可复现
+  seedNumber: 12345
+});
+
+// 生成用户数据
+const users = mongoFill.generate('users', {
+  name: () => Faker.name.findName(),
+  email: () => Faker.internet.email(),
+  avatar: () => Faker.internet.avatar(),
+  address: {
+    city: () => Faker.address.city(),
+    country: () => Faker.address.country(),
+    zipCode: () => Faker.address.zipCode()
+  }
+}, 10); // 生成 10 条
+
+console.log(users);
+```
+
+---
+
+## Jest 集成
+
+### @shelf/jest-mongodb
+
+[@shelf/jest-mongodb](https://github.com/shelfio/jest-mongodb) 提供完整的 MongoDB 测试环境。
+
+#### 安装
+
+```bash
+npm install --save-dev @shelf/jest-mongodb
+```
+
+#### 配置 jest.config.js
+
+```javascript
+module.exports = {
+  preset: '@shelf/jest-mongodb'
+};
+```
+
+#### 编写测试
+
+```javascript
+// user.test.js
+const { MongoClient } = require('mongodb');
+
+describe('用户 CRUD 测试', () => {
+  let client;
+  let db;
+  
+  // 所有测试前连接
+  beforeAll(async () => {
+    client = await MongoClient.connect(global.__MONGO_URI__);
+    db = client.db(global.__MONGO_DB_NAME__);
+  });
+  
+  // 每个测试前清理
+  beforeEach(async () => {
+    await db.collection('users').deleteMany({});
+  });
+  
+  // 所有测试后关闭
+  afterAll(async () => {
+    await client.close();
+  });
+  
+  test('创建用户', async () => {
+    const user = {
+      name: '测试用户',
+      email: 'test@example.com',
+      age: 25
+    };
+    
+    const result = await db.collection('users').insertOne(user);
+    
+    expect(result.insertedId).toBeDefined();
+    expect(result.acknowledged).toBe(true);
+  });
+  
+  test('查询用户', async () => {
+    // 插入测试数据
+    await db.collection('users').insertOne({
+      name: '张三',
+      email: 'zhangsan@example.com'
+    });
+    
+    // 查询
+    const user = await db.collection('users').findOne({ name: '张三' });
+    
+    expect(user).toBeDefined();
+    expect(user.email).toBe('zhangsan@example.com');
+  });
+  
+  test('更新用户', async () => {
+    const { insertedId } = await db.collection('users').insertOne({
+      name: '李四',
+      age: 20
+    });
+    
+    await db.collection('users').updateOne(
+      { _id: insertedId },
+      { $set: { age: 25 } }
+    );
+    
+    const updated = await db.collection('users').findOne({ _id: insertedId });
+    expect(updated.age).toBe(25);
+  });
+  
+  test('删除用户', async () => {
+    const { insertedId } = await db.collection('users').insertOne({
+      name: '王五'
+    });
+    
+    await db.collection('users').deleteOne({ _id: insertedId });
+    
+    const deleted = await db.collection('users').findOne({ _id: insertedId });
+    expect(deleted).toBeNull();
+  });
+});
+```
+
+### 使用 Factory 的完整示例
+
+```javascript
+// userWithFactory.test.js
+const UserFactory = require('../factories/userFactory');
+
+describe('UserFactory 测试', () => {
+  let client;
+  let db;
+  
+  beforeAll(async () => {
+    client = await MongoClient.connect(global.__MONGO_URI__);
+    db = client.db(global.__MONGO_DB_NAME__);
+  });
+  
+  beforeEach(async () => {
+    await db.collection('users').deleteMany({});
+  });
+  
+  afterAll(async () => {
+    await client.close();
+  });
+  
+  test('批量创建用户', async () => {
+    const users = UserFactory.createMany(5);
+    
+    const result = await db.collection('users').insertMany(users);
+    
+    expect(result.insertedCount).toBe(5);
+  });
+  
+  test('创建带关联的订单', async () => {
+    // 创建用户
+    const user = UserFactory.create({ name: '订单测试用户' });
+    const { insertedId: userId } = await db.collection('users').insertOne(user);
+    
+    // 创建订单
+    const OrderFactory = require('../factories/orderFactory');
+    const order = OrderFactory.create({ userId });
+    
+    await db.collection('orders').insertOne(order);
+    
+    // 验证关联
+    const savedOrder = await db.collection('orders').findOne({ _id: order._id });
+    expect(savedOrder.userId.toString()).toBe(userId.toString());
+  });
+});
+```
+
+---
+
+## 性能优化
+
+### 批量操作
+
+```javascript
+// 坏的写法 - 逐条插入
+for (const user of users) {
+  await db.collection('users').insertOne(user);
+}
+
+// 好的写法 - 批量插入
+await db.collection('users').insertMany(users);
+
+// 更好的写法 - 分批批量插入
+async function bulkInsert(collection, documents, batchSize = 1000) {
+  for (let i = 0; i < documents.length; i += batchSize) {
+    const batch = documents.slice(i, i + batchSize);
+    await collection.insertMany(batch, { ordered: false });
+  }
+}
+```
+
+### 索引优化
+
+```javascript
+// 测试前创建索引
+await db.collection('users').createIndex({ email: 1 }, { unique: true });
+await db.collection('orders').createIndex({ userId: 1, createdAt: -1 });
+
+// 测试后删除索引
+await db.collection('users').dropIndex('email_1');
+```
+
+### 假删除模式
+
+```javascript
+// 使用 deletedAt 字段代替物理删除
+await db.collection('users').updateOne(
+  { _id: userId },
+  { $set: { deletedAt: new Date() } }
+);
+
+// 查询时排除已删除
+const activeUsers = await db.collection('users').find({
+  deletedAt: { $exists: false }
+});
+```
+
+---
+
+## 最佳实践
+
+### 1. 数据隔离
+
+```javascript
+// 每个测试使用唯一数据库
+beforeAll(async () => {
+  const { MongoClient } = require('mongodb');
+  const crypto = require('crypto');
+  
+  const uniqueDbName = `test_${crypto.randomBytes(8).toString('hex')}`;
+  client = await MongoClient.connect('mongodb://localhost:27017');
+  db = client.db(uniqueDbName);
+});
+
+afterAll(async () => {
+  await db.dropDatabase();
+  await client.close();
+});
+```
+
+### 2. 可复现数据
+
+```javascript
+// 使用固定种子
+function createSeededFaker(seed) {
+  const Faker = require('faker');
+  Faker.seed(seed);
+  return Faker;
+}
+
+// 每次测试使用相同数据
+const faker = createSeededFaker(12345);
+const user = { name: faker.name.findName() };
+```
+
+### 3. 数据清理
+
+```javascript
+// 使用 afterEach 清理每个测试的数据
+afterEach(async () => {
+  const collections = await db.listCollections().toArray();
+  for (const coll of collections) {
+    await db.collection(coll.name).deleteMany({});
+  }
+});
+```
+
+### 4. 异步工厂
+
+```javascript
+// 对于需要数据库操作的工厂
+class AsyncUserFactory {
+  static async create(db, data = {}) {
+    const user = UserFactory.create(data);
+    const result = await db.collection('users').insertOne(user);
+    return { ...user, _id: result.insertedId };
+  }
+  
+  static async createMany(db, count, baseData = {}) {
+    const users = UserFactory.createMany(count, baseData);
+    const result = await db.collection('users').insertMany(users);
+    return users.map((u, i) => ({ ...u, _id: result.insertedIds[i] }));
+  }
+}
+```
+
+---
+
+## 相关资源
+
+- [MongoDB Node.js Driver](https://mongodb.github.io/node-mongodb-native/)
+- [@shelf/jest-mongodb](https://github.com/shelfio/jest-mongodb)
+- [mongo-seeding](https://github.com/CACERSMARCIN/mongo-seeding)
+- [mongofill](https://github.com/felipecaputo/mongofill)
+- [Faker.js](https://fakerjs.dev/)

--- a/docs/topics/selector-escape/index.md
+++ b/docs/topics/selector-escape/index.md
@@ -1,0 +1,375 @@
+# CSS 选择器转义 (Selector Escape)
+
+## 概述
+
+当元素的 ID 以数字开头时，`document.querySelector()` 无法直接使用 `#+id` 的方式选取元素。本文档详细解释这一问题的原因、解决方案及最佳实践。
+
+## 问题描述
+
+### CSS ID 选择器语法
+
+在 CSS 中，`#` 符号是 ID 选择器的标识符，用于匹配 `id` 属性。例如：
+
+```css
+#myElement { color: red; }
+#header { font-weight: bold; }
+```
+
+### 核心问题
+
+**HTML 规范** 允许 ID 包含数字开头：
+
+```html
+<div id="1">第一行</div>
+<div id="2">第二行</div>
+<div id="3item">以数字开头但包含字母</div>
+```
+
+但 **CSS 选择器语法** 不允许 ID 选择器直接以数字开头：
+
+```javascript
+// ❌ 错误写法 - 会抛出 DOMException
+document.querySelector('#1');
+
+// ✅ 正确写法 - 使用 CSS 转义
+document.querySelector('#\\31');
+
+// ✅ 正确写法 - 使用 6 位十六进制转义
+document.querySelector('#\\000031');
+
+// ✅ 正确写法 - 使用 getElementById
+document.getElementById('1');
+```
+
+### 错误演示
+
+```javascript
+// 在浏览器控制台执行以下代码会报错
+try {
+  document.querySelector('#1');
+} catch (e) {
+  console.error(e);
+  // DOMException: '#1' is not a valid selector
+}
+```
+
+## 解决方案
+
+### 方案一：getElementById（推荐）
+
+最简单直接的方式，绕过 CSS 选择器语法限制：
+
+```javascript
+// 获取 id 为 "1" 的元素
+const element = document.getElementById('1');
+console.log(element.textContent); // "第一行"
+
+// 获取 id 为 "123" 的元素
+const el123 = document.getElementById('123');
+```
+
+**优点**：
+- 语法简单，代码易读
+- 性能与 `querySelector` 相当
+- 不需要了解转义规则
+
+**缺点**：
+- 只能获取单个元素
+- 不能使用复杂选择器
+
+### 方案二：CSS 转义
+
+`querySelector` 支持 CSS 转义序列来匹配特殊字符。
+
+#### 3 位十六进制转义
+
+将数字转换为 3 位十六进制（不够前面补 0）：
+
+```javascript
+// 数字 1 → \31 (hex: 1 = 0x1, 补零后: 001 → 31)
+document.querySelector('#\\31');
+
+// 数字 2 → \32
+document.querySelector('#\\32');
+
+// 数字 12 → \31 32 (每个数字分别转义)
+document.querySelector('#\\31\\32');
+
+// 数字 123 → \31 32 33
+document.querySelector('#\\31\\32\\33');
+```
+
+#### 6 位十六进制转义
+
+更明确的方式，使用 6 位十六进制（不够前面补 0）：
+
+```javascript
+// 数字 1 → \000031
+document.querySelector('#\\000031');
+
+// 数字 2 → \000032
+document.querySelector('#\\000032');
+
+// 数字 12 → \000031 32
+document.querySelector('#\\000031\\32');
+
+// 数字 123 → \000031 32 33
+document.querySelector('#\\000031\\32\\33');
+```
+
+#### 转义对照表
+
+| 字符 | 3 位转义 | 6 位转义 |
+|------|---------|---------|
+| 0 | `\30` | `\000030` |
+| 1 | `\31` | `\000031` |
+| 2 | `\32` | `\000032` |
+| 3 | `\33` | `\000033` |
+| ... | ... | ... |
+| 9 | `\39` | `\000039` |
+
+### 方案三：属性选择器（间接方式）
+
+使用属性选择器绕过 ID 选择器语法限制：
+
+```javascript
+// ⚠️ 注意：引号内是字面字符串，不是 CSS 选择器
+document.querySelector('[id="1"]');
+document.querySelector('[id="123"]');
+```
+
+**注意**：这种方式会匹配所有具有该 ID 属性的元素，而不是仅限于 ID 选择器（ID 在 HTML 中应该是唯一的）。
+
+## 深入说明
+
+### CSS 语法 vs HTML 规范
+
+| 方面 | CSS 选择器语法 | HTML ID 属性 |
+|------|--------------|-------------|
+| 数字开头 | ❌ 不允许 | ✅ 允许 |
+| 规范来源 | W3C CSS Selectors | W3C HTML |
+| 特殊字符处理 | 需要转义 | 直接使用（部分除外） |
+
+### 为什么 querySelector 受 CSS 语法限制？
+
+`document.querySelector()` 和 `querySelectorAll()` 接受的是 **CSS 选择器字符串**，遵循 CSS 规范。这意味着：
+
+1. 选择器字符串首先被解析为 CSS 语法
+2. 未转义的数字开头会被视为无效选择器
+3. 抛出 `DOMException: '#1' is not a valid selector`
+
+### getElementById 为什么可以？
+
+`getElementById()` 方法直接接受 **字符串参数**，不经过 CSS 选择器解析器：
+
+1. 参数被直接用于在文档中查找元素
+2. 遵循 HTML 规范，而非 CSS 选择器语法
+3. 允许数字开头的 ID
+
+### 转义规则详解
+
+CSS 转义使用反斜杠 `\` 后跟十六进制数字：
+
+```
+\<hex>{1,6}
+```
+
+- **1-6 位**：可以是 1 到 6 个十六进制数字
+- **分隔符**：6 位转义后需要空格或其他分隔符（除非后面是空格）
+- **字符类别**：几乎所有 Unicode 字符都可以转义
+
+**示例**：
+
+```javascript
+// 获取 id="a1" 的元素
+document.querySelector('#a\\31');
+// a → a (不变)
+// 1 → \31
+
+// 获取 id="1a" 的元素
+document.querySelector('#\\31a');
+// 1 → \31
+// a → a (不变)
+
+// 获取 id="-" 的元素
+document.querySelector('#\\-');
+```
+
+## 常见场景
+
+### 场景一：动态生成表格行 ID
+
+```javascript
+// 动态生成表格行
+function createTable() {
+  const rows = [
+    { id: '1', name: '张三' },
+    { id: '2', name: '李四' },
+    { id: '3', name: '王五' }
+  ];
+  
+  const tbody = document.getElementById('table-body');
+  rows.forEach(row => {
+    const tr = document.createElement('tr');
+    tr.id = row.id;  // id = "1", "2", "3"
+    tr.innerHTML = `<td>${row.id}</td><td>${row.name}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+// ❌ 错误获取方式
+// const firstRow = document.querySelector('#1'); // 报错！
+
+// ✅ 正确获取方式 1：getElementById
+const firstRow = document.getElementById('1');
+
+// ✅ 正确获取方式 2：CSS 转义
+const firstRow = document.querySelector('#\\31');
+
+// ✅ 正确获取方式 3：属性选择器
+const firstRow = document.querySelector('[id="1"]');
+```
+
+### 场景二：列表索引
+
+```javascript
+// 渲染列表，索引作为 ID 前缀（推荐）
+const items = ['苹果', '香蕉', '橙子'];
+items.forEach((item, index) => {
+  const li = document.createElement('li');
+  li.id = `item-${index + 1}`;  // id = "item-1", "item-2", "item-3"
+  li.textContent = item;
+  document.getElementById('list').appendChild(li);
+});
+
+// 获取时直接使用
+const secondItem = document.getElementById('item-2'); // ✅ 无需转义
+```
+
+### 场景三：处理用户输入的 ID
+
+```javascript
+// 处理用户可能输入的各种 ID 格式
+function findElement(inputId) {
+  // 尝试直接获取（字母开头）
+  let el = document.getElementById(inputId);
+  if (el) return el;
+  
+  // 如果是数字开头的 ID
+  if (/^\d/.test(inputId)) {
+    // 方式 1：getElementById
+    return document.getElementById(inputId);
+    
+    // 方式 2：转换为 CSS 转义
+    // const escaped = inputId.split('').map(c => {
+    //   if (c.charCodeAt(0) < 128) { // ASCII 范围
+    //     return '\\' + c.charCodeAt(0).toString(16).padStart(2, '0');
+    //   }
+    //   return '\\' + c.charCodeAt(0).toString(16).padStart(4, '0');
+    // }).join('');
+    // return document.querySelector('#' + escaped);
+  }
+  
+  return null;
+}
+```
+
+## 最佳实践
+
+### 1. 避免数字开头的 ID
+
+```html
+<!-- ❌ 不推荐 -->
+<div id="1">...</div>
+<div id="2">...</div>
+
+<!-- ✅ 推荐 -->
+<div id="item-1">...</div>
+<div id="item-2">...</div>
+```
+
+### 2. 使用有意义的字母前缀
+
+```html
+<!-- ❌ 无意义前缀 -->
+<div id="a1">用户信息</div>
+
+<!-- ✅ 有意义前缀 -->
+<div id="user-1">用户信息</div>
+<div id="product-123">商品信息</div>
+```
+
+### 3. 统一 ID 命名规范
+
+```javascript
+// 推荐的 ID 格式
+const idPrefix = {
+  user: 'user-',
+  product: 'product-',
+  order: 'order-',
+  row: 'row-'
+};
+
+// 生成 ID
+function generateId(type, index) {
+  return `${idPrefix[type]}${index}`;
+}
+
+// 使用
+const userId = generateId('user', 1); // "user-1"
+const element = document.getElementById(userId); // ✅
+```
+
+### 4. 封装工具函数
+
+```javascript
+// 选择器工具函数
+const $ = {
+  /**
+   * 根据 ID 获取元素（支持数字开头）
+   */
+  byId(id) {
+    return document.getElementById(id);
+  },
+  
+  /**
+   * 根据 CSS 选择器获取元素（支持特殊字符）
+   */
+  query(selector) {
+    try {
+      return document.querySelector(selector);
+    } catch (e) {
+      console.warn('无效选择器:', selector);
+      return null;
+    }
+  },
+  
+  /**
+   * 将任意字符串转换为有效的 CSS 选择器 ID
+   */
+  escapeId(id) {
+    return id.replace(/[^\w-]/g, char => {
+      const code = char.charCodeAt(0);
+      if (code < 0xFFFF) {
+        return '\\' + code.toString(16).toUpperCase() + ' ';
+      }
+      return '\\' + code.toString(16).toUpperCase() + ' ';
+    });
+  }
+};
+
+// 使用
+const el = $.byId('1');                    // ✅
+const escaped = $.escapeId('my-id');      // "my\\-id"
+```
+
+## 总结
+
+| 场景 | 推荐方案 |
+|------|---------|
+| 新项目 | 使用字母前缀命名 ID，避免问题 |
+| 已有数字开头 ID | `getElementById()` 是最简单可靠的方式 |
+| 必须用 `querySelector` | 使用 CSS 转义（如 `#\\31`） |
+| 动态生成选择器 | 属性选择器 `[id="值"]` 可作为备选 |
+
+**记住**：`getElementById` 遵循 HTML 规范，`querySelector` 遵循 CSS 语法。当两者冲突时，优先使用 `getElementById`。

--- a/docs/topics/stacking-context-debug/index.md
+++ b/docs/topics/stacking-context-debug/index.md
@@ -1,0 +1,301 @@
+# CSS 层叠上下文调试指南 (Stacking Context Debug)
+
+## 概述
+
+CSS 层叠上下文（Stacking Context）是 CSS 渲染模型的核心概念。理解层叠上下文对于调试 z-index 问题、解决元素遮挡、实现复杂图层效果至关重要。
+
+## 一、Chrome DevTools Layers 面板调试方法
+
+### 1.1 如何打开 Layers 面板
+
+1. 打开 Chrome DevTools（`F12` 或 `Cmd+Option+I`）
+2. 点击右上角的 `⋮` 菜单
+3. 选择 `More tools` → `Layers`
+4. 或者使用快捷键：`Cmd+Shift+P` 打开命令面板，输入 "Layers"
+
+### 1.2 查看图层结构
+
+Layers 面板显示当前页面的所有图层：
+
+- **图层列表**：按深度排序，显示每个图层的名称、尺寸和内存占用
+- **图层信息**：悬停时可查看图层的详细信息
+- **缩放控制**：使用底部滑块缩放图层视图
+
+### 1.3 使用 Rendering → Layer borders 显示层边界
+
+1. 打开命令面板（`Cmd+Shift+P`）
+2. 输入 "Rendering"
+3. 选择 "Show Layer Borders"
+4. 页面上的每个图层会显示彩色边框：
+   - 橙色边框：合成图层（Compositor Layer）
+   - 蓝色边框：GBD 纹理图层
+
+### 1.4 Elements 面板检查 z-index 和 position
+
+1. 在 Elements 面板中选中目标元素
+2. 查看右侧 Styles 面板：
+   - `position` 属性（`static`/`relative`/`absolute`/`fixed`/`sticky`）
+   - `z-index` 值
+   - `opacity` 值
+   - `transform` 属性
+   - `filter` 属性
+3. 勾选 `:hov` → `Force element state` 可强制显示状态
+
+---
+
+## 二、CSS 层叠上下文（Stacking Context）触发条件
+
+### 2.1 根元素
+
+根元素 `<html>` 本身就是一个层叠上下文，所有其他元素都在它之上层叠。
+
+### 2.2 position + z-index
+
+```css
+/* 当 z-index 不为 auto 时，position 为 relative/absolute/fixed/sticky 的元素会创建新层叠上下文 */
+.element {
+  position: relative;
+  z-index: 1; /* 创建层叠上下文 */
+}
+```
+
+### 2.3 opacity < 1
+
+```css
+/* opacity 小于 1 时触发新层叠上下文 */
+.element {
+  opacity: 0.9; /* 创建层叠上下文 */
+}
+```
+
+### 2.4 transform / filter / backdrop-filter
+
+```css
+/* 任何非 none 的 transform 值 */
+.element {
+  transform: translateZ(0); /* 创建层叠上下文 */
+}
+
+/* 任何非 none 的 filter 值 */
+.element {
+  filter: blur(1px); /* 创建层叠上下文 */
+}
+
+/* backdrop-filter */
+.element {
+  backdrop-filter: blur(10px); /* 创建层叠上下文 */
+}
+```
+
+### 2.5 CSS Grid / Flex + z-index
+
+```css
+/* Flex 或 Grid 容器中，z-index 不为 auto 的子元素 */
+.container {
+  display: flex;
+}
+.container > .item {
+  z-index: 1; /* 即使父元素没有创建层叠上下文，子元素也会创建 */
+}
+```
+
+### 触发条件汇总表
+
+| 条件 | 示例 | 说明 |
+|------|------|------|
+| 根元素 | `<html>` | 默认创建 |
+| position + z-index | `position: relative; z-index: 1` | z-index 不为 auto |
+| opacity | `opacity: 0.9` | 值小于 1 |
+| transform | `transform: translateZ(0)` | 非 none |
+| filter | `filter: blur(1px)` | 非 none |
+| backdrop-filter | `backdrop-filter: blur(10px)` | 非 none |
+| -webkit-overflow-scrolling | `-webkit-overflow-scrolling: touch` | iOS 特有 |
+| contain | `contain: layout` | 布局包含 |
+| opacity | `opacity: 0.99` | 值小于 1 |
+
+---
+
+## 三、调试步骤流程
+
+### 步骤 1：打开 DevTools Elements 面板
+
+按 `F12` 打开 Chrome DevTools，切换到 Elements 面板。
+
+### 步骤 2：定位问题元素，检查 z-index
+
+1. 使用选择工具（左上角箭头）点击问题元素
+2. 在 Styles 面板中检查：
+   - `position` 属性
+   - `z-index` 值
+   - 是否设置了 `transform`、`filter` 等属性
+
+### 步骤 3：检查父元素的层叠上下文
+
+1. 在 Elements 面板中向上遍历父元素
+2. 检查每个父元素是否创建了层叠上下文：
+   - 是否有 `position` + `z-index`
+   - 是否有 `transform`
+   - 是否有 `opacity < 1`
+   - 是否有 `filter`
+3. 找到最近的层叠上下文祖先
+
+### 步骤 4：使用 Layers 面板验证图层顺序
+
+1. 打开 Layers 面板（`Cmd+Shift+P` → "Layers"）
+2. 找到问题元素所在的图层
+3. 验证图层的堆叠顺序是否正确
+4. 使用 "Show Layer Borders" 可视化图层边界
+
+### 调试流程图
+
+```
+发现问题元素层级异常
+        ↓
+    检查 z-index
+        ↓
+    检查 position
+        ↓
+是否有 transform/filter/opacity？
+    ↓ YES           ↓ NO
+查找父元素层叠上下文    检查是否在根层叠上下文中
+        ↓
+    确认层叠上下文边界
+        ↓
+    验证图层顺序
+```
+
+---
+
+## 四、常见踩坑点
+
+### 4.1 transform 导致层叠上下文
+
+**问题**：给元素添加 `transform` 后，其子元素的 `z-index` 不再相对于根层叠上下文。
+
+**示例**：
+
+```html
+<div class="parent" style="position: relative;">
+  <div class="child" style="position: absolute; z-index: 100;">
+    我在 parent 内部
+  </div>
+</div>
+<div class="target" style="position: relative; z-index: 50;">
+  我想盖住上面的元素
+</div>
+```
+
+**问题**：如果 `.parent` 有 `transform`，则 `.child` 的 `z-index: 100` 只相对于 `.parent` 内部。
+
+**解决**：
+
+```css
+.parent {
+  transform: none; /* 移除不必要的 transform */
+}
+/* 或 */
+.parent {
+  transform: translateZ(0); /* 明确创建新的层叠上下文 */
+}
+```
+
+### 4.2 z-index 在不同层叠上下文中的相对性
+
+**问题**：`z-index: 100` 在一个层叠上下文中可能比 `z-index: 1` 在另一个层叠上下文中更低。
+
+**示例**：
+
+```html
+<div style="position: relative; z-index: 1; transform: scale(1);">
+  <!-- 创建层叠上下文 A -->
+  <div style="position: absolute; z-index: 1000;">
+    层叠上下文 A 内的元素
+  </div>
+</div>
+<div style="position: relative; z-index: 2;">
+  <!-- 层叠上下文 B -->
+</div>
+```
+
+**解释**：
+- 层叠上下文 A 的根 `z-index: 1`
+- 层叠上下文 B 的根 `z-index: 2`
+- 层叠上下文 A 内的 `z-index: 1000` 元素，永远在层叠上下文 B 之下
+- 因为 **层叠上下文之间的比较只看根的 z-index**
+
+**解决**：将需要比较的元素放在同一个层叠上下文中。
+
+---
+
+## 五、实战调试案例
+
+### 案例 1：模态框被背景遮挡
+
+**症状**：模态框弹出后，部分内容被背景元素遮挡。
+
+**排查**：
+
+1. 检查模态框的 `z-index` 是否足够高
+2. 检查模态框父元素是否创建了层叠上下文
+3. 检查背景元素的 `z-index` 和层叠上下文
+
+**解决**：
+
+```css
+.modal-overlay {
+  position: fixed;
+  z-index: 1000;
+}
+.modal-content {
+  position: relative;
+  z-index: 1001; /* 比 overlay 高 */
+}
+/* 确保 modal-overlay 的父元素没有创建层叠上下文 */
+```
+
+### 案例 2：下拉菜单被其他内容覆盖
+
+**症状**：下拉菜单展开时，被页面上其他元素遮挡。
+
+**排查**：
+
+1. 检查下拉菜单容器的 `position` 和 `z-index`
+2. 检查父元素的层叠上下文
+3. 检查是否有 `transform` 属性
+
+**解决**：
+
+```css
+.dropdown {
+  position: relative;
+  z-index: 100; /* 足够高的 z-index */
+}
+/* 避免父元素的 transform */
+```
+
+---
+
+## 六、最佳实践
+
+1. **避免不必要的 transform**：仅在需要动画或 3D 效果时使用
+2. **明确层级结构**：使用清晰的 z-index 值（100, 200, 300...）
+3. **限制层叠上下文数量**：过多层叠上下文影响渲染性能
+4. **使用 CSS 变量管理 z-index**：便于统一调整
+
+```css
+:root {
+  --z-dropdown: 100;
+  --z-modal: 1000;
+  --z-tooltip: 1100;
+}
+.dropdown { z-index: var(--z-dropdown); }
+.modal { z-index: var(--z-modal); }
+```
+
+---
+
+## 七、相关资源
+
+- [MDN: Stacking Context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)
+- [Chrome DevTools Layers Panel](https://developer.chrome.com/docs/devtools/css/layers/)
+- [What No One Told You About Z-Index](https://philipwalton.com/articles/what-no-one-told-you-about-z-index/)

--- a/docs/topics/typical-css-layouts/index.md
+++ b/docs/topics/typical-css-layouts/index.md
@@ -1,0 +1,501 @@
+# 典型 CSS 布局 (Typical CSS Layouts)
+
+## 概述
+
+CSS 布局是前端开发的核心技能。本文系统梳理常用布局模式，从传统方案到现代方案，帮助开发者根据场景选择最优实现。
+
+## 布局方案演进
+
+| 时代 | 方案 | 特点 |
+|------|------|------|
+| 上古 | Table 布局 | 简单但语义差 |
+| 古典 | Float + Margin | 浮动闭合问题 |
+| 过渡 | Flexbox | 一维布局神器 |
+| 现代 | CSS Grid | 二维布局王者 |
+| 新潮 | Container Queries | 组件自适应 |
+
+## 一、单栏布局 (Single Column)
+
+最基础的布局，内容居中显示。
+
+### 方案一：Flexbox（推荐）
+
+```html
+<div class="single-column">
+  <header>头部</header>
+  <main>主内容</main>
+  <footer>底部</footer>
+</div>
+```
+
+```css
+.single-column {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+.single-column main {
+  flex: 1; /* 主内容区自动撑满 */
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 20px;
+}
+```
+
+### 方案二：Grid
+
+```css
+.single-column {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  min-height: 100vh;
+}
+```
+
+**适用场景**：博客、文档、简单页面
+
+---
+
+## 二、两栏布局 (Two Column)
+
+左侧边栏 + 右侧内容。
+
+### 方案一：Flexbox（推荐）
+
+```html
+<div class="two-column">
+  <aside class="sidebar">侧边栏</aside>
+  <main class="content">主内容</main>
+</div>
+```
+
+```css
+.two-column {
+  display: flex;
+}
+.sidebar {
+  width: 250px;
+  flex-shrink: 0; /* 防止压缩 */
+}
+.content {
+  flex: 1; /* 自动填充剩余空间 */
+}
+```
+
+### 方案二：Float（传统）
+
+```css
+.sidebar {
+  float: left;
+  width: 250px;
+}
+.content {
+  margin-left: 250px;
+}
+```
+
+### 方案三：Grid
+
+```css
+.two-column {
+  display: grid;
+  grid-template-columns: 250px 1fr;
+}
+```
+
+**适用场景**：管理后台、博客侧边栏、产品列表
+
+---
+
+## 三、三栏布局 (Three Column)
+
+左右侧栏 + 中间主内容。
+
+### 方案一：Flexbox
+
+```css
+.three-column {
+  display: flex;
+}
+.left-sidebar, .right-sidebar {
+  width: 200px;
+  flex-shrink: 0;
+}
+.main {
+  flex: 1;
+}
+```
+
+### 方案二：Grid（最简洁）
+
+```css
+.three-column {
+  display: grid;
+  grid-template-columns: 200px 1fr 200px;
+}
+```
+
+### 方案三：圣杯布局（Float 传统）
+
+```css
+.container {
+  padding: 0 200px; /* 为左右栏预留空间 */
+}
+.main {
+  float: left;
+  width: 100%;
+}
+.left-sidebar {
+  float: left;
+  width: 200px;
+  margin-left: -100%;
+  position: relative;
+  left: -200px;
+}
+.right-sidebar {
+  float: left;
+  width: 200px;
+  margin-left: -200px;
+  position: relative;
+  right: -200px;
+}
+```
+
+**适用场景**：门户网站、邮件客户端、仪表盘
+
+---
+
+## 四、圣杯布局 (Holy Grail)
+
+经典五区域布局：头、主、尾 + 左右侧栏。
+
+```html
+<div class="holy-grail">
+  <header>Header</header>
+  <div class="body">
+    <aside class="left">Left</aside>
+    <main>Main</main>
+    <aside class="right">Right</aside>
+  </div>
+  <footer>Footer</footer>
+</div>
+```
+
+```css
+.holy-grail {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+.holy-grail .body {
+  display: flex;
+  flex: 1;
+}
+.holy-grail main {
+  flex: 1;
+}
+.holy-grail .left, .holy-grail .right {
+  width: 200px;
+  flex-shrink: 0;
+}
+```
+
+---
+
+## 五、双飞翼布局 (Double Wing)
+
+圣杯布局的改进版，解决内容区域 padding 问题。
+
+```html
+<div class="double-wing">
+  <header>Header</header>
+  <div class="bd">
+    <main class="main-wrap">
+      <div class="main">Main Content</div>
+    </main>
+    <aside class="left">Left</aside>
+    <aside class="right">Right</aside>
+  </div>
+  <footer>Footer</footer>
+</div>
+```
+
+```css
+.double-wing .bd {
+  display: flex;
+}
+.double-wing .main-wrap {
+  flex: 1;
+}
+.double-wing .main {
+  margin: 0 200px; /* 左右边距避免被侧栏遮挡 */
+}
+.double-wing .left,
+.double-wing .right {
+  width: 200px;
+  flex-shrink: 0;
+}
+.double-wing .left { order: -1; } /* Flex 改变顺序 */
+```
+
+---
+
+## 六、Flex Box 布局
+
+现代 Flexbox 是最强大的布局方案。
+
+### 常用属性
+
+| 属性 | 说明 |
+|------|------|
+| `display: flex` | 启用 Flex 容器 |
+| `flex-direction` | 主轴方向 |
+| `justify-content` | 主轴对齐 |
+| `align-items` | 交叉轴对齐 |
+| `flex-wrap` | 换行控制 |
+| `gap` | 间距 |
+
+### 典型场景
+
+#### 导航栏
+
+```css
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: 60px;
+  background: #333;
+  padding: 0 20px;
+}
+.nav-links {
+  display: flex;
+  gap: 20px;
+}
+```
+
+#### 居中布局
+
+```css
+.center-box {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 300px;
+  background: #f5f5f5;
+}
+```
+
+#### 底部固定
+
+```css
+.page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+.content {
+  flex: 1;
+}
+footer {
+  height: 60px;
+}
+```
+
+---
+
+## 七、Grid 布局
+
+CSS Grid 是二维布局的终极方案。
+
+### 基础语法
+
+```css
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr); /* 3列等宽 */
+  grid-template-rows: auto 1fr auto;
+  gap: 20px;
+  min-height: 100vh;
+}
+```
+
+### 常用模板
+
+#### 响应式网格
+
+```css
+.responsive-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 20px;
+}
+```
+
+#### 圣杯布局（Grid 版）
+
+```css
+.holy-grail {
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  grid-template-columns: 200px 1fr 200px;
+  min-height: 100vh;
+}
+header { grid-column: 1 / -1; }
+footer { grid-column: 1 / -1; }
+```
+
+#### 瀑布流
+
+```css
+.masonry {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-auto-rows: 10px;
+  grid-auto-flow: dense; /* 填充空隙 */
+}
+.masonry-item:nth-child(odd) {
+  grid-row: span 20;
+}
+.masonry-item:nth-child(even) {
+  grid-row: span 15;
+}
+```
+
+### Grid vs Flexbox
+
+| 维度 | Flexbox | Grid |
+|------|---------|------|
+| 维度 | 一维（行或列） | 二维（行和列） |
+| 控制粒度 | 子元素分布 | 容器轨道定义 |
+| 适用场景 | 导航、列表、卡片 | 页面整体布局、复杂网格 |
+| 学习曲线 | 较平缓 | 较陡 |
+
+---
+
+## 八、容器查询 (Container Queries)
+
+新一代布局技术，让组件根据容器尺寸自适应。
+
+### 基础用法
+
+```css
+.card-container {
+  container-type: inline-size;
+  container-name: card;
+}
+.card {
+  display: flex;
+  flex-direction: column;
+}
+/* 容器宽度 > 400px 时，切换为水平布局 */
+@container card (min-width: 400px) {
+  .card {
+    flex-direction: row;
+  }
+}
+```
+
+### 与 Media Query 的区别
+
+| 维度 | Container Queries | Media Queries |
+|------|-------------------|---------------|
+| 参照物 | 父容器宽度 | 视口宽度 |
+| 适用场景 | 可复用组件 | 页面整体响应式 |
+| 灵活性 | 更高 | 较低 |
+
+---
+
+## 九、常见布局技巧
+
+### 1. 等宽多列（平均分布）
+
+```css
+.equal-columns {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+/* 或 Flexbox */
+.equal-columns {
+  display: flex;
+}
+.equal-columns > * {
+  flex: 1;
+}
+```
+
+### 2. 最后一个元素靠右
+
+```css
+.flex-row {
+  display: flex;
+  gap: 10px;
+}
+.spacer {
+  flex: 1;
+}
+```
+
+### 3. 固定宽度 + 自适应
+
+```css
+.layout {
+  display: flex;
+}
+.fixed {
+  width: 200px;
+  flex-shrink: 0;
+}
+.auto {
+  flex: 1;
+}
+```
+
+### 4. Sticky Footer（页脚固定底部）
+
+```css
+.page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+.content {
+  flex: 1;
+}
+```
+
+---
+
+## 十、布局方案选择指南
+
+| 场景 | 推荐方案 |
+|------|----------|
+| 简单页面/博客 | Flexbox 单栏 |
+| 后台管理侧边栏 | Flexbox 两栏 |
+| 门户网站 | CSS Grid 三栏 |
+| 卡片网格 | Grid auto-fit |
+| 导航栏 | Flexbox |
+| 居中弹窗 | Flexbox 或 Grid |
+| 组件内部布局 | Container Queries |
+| 复杂二维布局 | CSS Grid |
+
+---
+
+## 十一、现代布局最佳实践
+
+1. **优先 Flexbox**：简单一维布局首选
+2. **复杂布局用 Grid**：二维布局毫无疑问选 Grid
+3. **避免 Float**：现代浏览器无需 Float 做布局
+4. **使用 gap**：Flexbox/Grid 的 gap 比手动 margin 更优雅
+5. **响应式优先 Grid**：使用 `auto-fit/minmax` 实现自适应
+6. **组件化思维**：用 Container Queries 替代部分 Media Queries
+7. **性能考虑**：避免嵌套过深的 Flex/Grid
+
+---
+
+## 相关资源
+
+- [CSS Flexbox 完全指南](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
+- [CSS Grid 完全指南](https://css-tricks.com/snippets/css/complete-guide-grid/)
+- [Container Queries 介绍](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_container_queries)

--- a/examples/css/demos/backdrop-filter/index.html
+++ b/examples/css/demos/backdrop-filter/index.html
@@ -1,0 +1,597 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>backdrop-filter 交互演示</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0a0a0f;
+      color: #e0e0e0;
+      min-height: 100vh;
+      padding: 20px;
+    }
+    h1 {
+      text-align: center;
+      font-size: 1.8rem;
+      margin-bottom: 20px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .tab-nav {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .tab-btn {
+      padding: 10px 20px;
+      background: #1a1a2e;
+      border: 1px solid #333;
+      border-radius: 8px;
+      color: #888;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: all 0.2s;
+    }
+    .tab-btn:hover { background: #252540; color: #fff; }
+    .tab-btn.active {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      border-color: transparent;
+    }
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+    .demo-area {
+      background: #1a1a2e;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 16px;
+    }
+    .demo-section { margin-bottom: 20px; }
+    .demo-title {
+      font-size: 1rem;
+      color: #888;
+      margin-bottom: 12px;
+    }
+    .scene {
+      position: relative;
+      height: 300px;
+      background: linear-gradient(135deg, #1a1a2e 0%, #2d1b4e 100%);
+      border-radius: 12px;
+      overflow: hidden;
+    }
+    .bg-shapes {
+      position: absolute;
+      inset: 0;
+      overflow: hidden;
+    }
+    .shape {
+      position: absolute;
+      border-radius: 50%;
+      opacity: 0.6;
+    }
+    .shape-1 {
+      width: 200px; height: 200px;
+      background: linear-gradient(135deg, #ff6b6b, #feca57);
+      top: -50px; left: -50px;
+    }
+    .shape-2 {
+      width: 150px; height: 150px;
+      background: linear-gradient(135deg, #48dbfb, #ff9ff3);
+      top: 50px; right: -30px;
+    }
+    .shape-3 {
+      width: 180px; height: 180px;
+      background: linear-gradient(135deg, #1dd1a1, #5f27cd);
+      bottom: -60px; left: 30%;
+    }
+    .glass-panel {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 280px;
+      padding: 24px;
+      background: rgba(255, 255, 255, 0.1);
+      border-radius: 16px;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      color: white;
+      text-align: center;
+      backdrop-filter: var(--backdrop-filter, blur(20px));
+      -webkit-backdrop-filter: var(--backdrop-filter, blur(20px));
+    }
+    .glass-panel h3 { margin-bottom: 8px; font-weight: 500; }
+    .glass-panel p { font-size: 0.85rem; opacity: 0.8; }
+    .controls {
+      margin-top: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .control-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .control-row label {
+      width: 100px;
+      font-size: 0.85rem;
+      color: #aaa;
+    }
+    .control-row input[type="range"] {
+      flex: 1;
+      height: 4px;
+      background: #333;
+      border-radius: 2px;
+      cursor: pointer;
+    }
+    .control-row span {
+      width: 60px;
+      font-size: 0.85rem;
+      color: #667eea;
+      text-align: right;
+    }
+    .filter-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+      gap: 12px;
+      margin-top: 12px;
+    }
+    .filter-item {
+      background: rgba(255, 255, 255, 0.05);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      border-radius: 8px;
+      padding: 12px;
+      text-align: center;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+    .filter-item:hover {
+      background: rgba(255, 255, 255, 0.1);
+      border-color: #667eea;
+    }
+    .filter-item.active {
+      background: rgba(102, 126, 234, 0.2);
+      border-color: #667eea;
+    }
+    .filter-item .preview {
+      width: 60px;
+      height: 60px;
+      margin: 0 auto 8px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      border-radius: 8px;
+      backdrop-filter: var(--preview-filter);
+      -webkit-backdrop-filter: var(--preview-filter);
+    }
+    .filter-item .name {
+      font-size: 0.8rem;
+      color: #888;
+    }
+    .filter-value {
+      font-size: 0.75rem;
+      color: #555;
+      margin-top: 4px;
+    }
+    .comparison {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+      margin-top: 12px;
+    }
+    .comparison-item {
+      text-align: center;
+    }
+    .comparison-item h4 {
+      font-size: 0.9rem;
+      color: #888;
+      margin-bottom: 8px;
+    }
+    .comparison-panel {
+      height: 120px;
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #666;
+      font-size: 0.85rem;
+    }
+    .comparison-panel.with-filter {
+      backdrop-filter: blur(15px);
+      -webkit-backdrop-filter: blur(15px);
+      background: rgba(255, 255, 255, 0.1);
+      color: white;
+      border: 1px solid rgba(255, 255, 255, 0.2);
+    }
+    .info-box {
+      background: rgba(102, 126, 234, 0.1);
+      border: 1px solid rgba(102, 126, 234, 0.3);
+      border-radius: 8px;
+      padding: 12px 16px;
+      margin-bottom: 12px;
+      font-size: 0.85rem;
+      line-height: 1.6;
+    }
+    .info-box.warning {
+      background: rgba(255, 186, 0, 0.1);
+      border-color: rgba(255, 186, 0, 0.3);
+    }
+    .code-block {
+      background: #0d0d15;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 12px;
+      font-family: 'Monaco', 'Menlo', monospace;
+      font-size: 0.8rem;
+      overflow-x: auto;
+      color: #a8a8a8;
+    }
+    .code-block .keyword { color: #c678dd; }
+    .code-block .property { color: #e06c75; }
+    .code-block .value { color: #98c379; }
+    .quiz {
+      margin-top: 16px;
+    }
+    .quiz-item {
+      background: rgba(255, 255, 255, 0.03);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 12px;
+    }
+    .quiz-item h4 {
+      font-size: 0.9rem;
+      color: #ddd;
+      margin-bottom: 8px;
+    }
+    .quiz-item label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 0;
+      cursor: pointer;
+      font-size: 0.85rem;
+      color: #aaa;
+    }
+    .quiz-item input[type="radio"] {
+      accent-color: #667eea;
+    }
+    .quiz-item.correct label:nth-child(1) { color: #1dd1a1; }
+    .quiz-item.wrong label:nth-child(1) { color: #ff6b6b; }
+  </style>
+</head>
+<body>
+  <h1>backdrop-filter 交互演示</h1>
+
+  <div class="tab-nav">
+    <button class="tab-btn active" data-tab="demo">概念总览</button>
+    <button class="tab-btn" data-tab="functions">滤镜函数</button>
+    <button class="tab-btn" data-tab="glassmorphism">玻璃拟态</button>
+    <button class="tab-btn" data-tab="comparison">对比实验</button>
+    <button class="tab-btn" data-tab="quiz">自测题</button>
+  </div>
+
+  <!-- 概念总览 -->
+  <div id="demo" class="tab-content active">
+    <div class="demo-area">
+      <div class="info-box">
+        <strong>backdrop-filter</strong> 允许你对元素<strong>后方</strong>的内容应用视觉效果（如模糊、颜色变换）。
+        与 <code>filter</code> 影响元素自身不同，backdrop-filter 影响的是元素背后的内容。
+      </div>
+
+      <div class="scene">
+        <div class="bg-shapes">
+          <div class="shape shape-1"></div>
+          <div class="shape shape-2"></div>
+          <div class="shape shape-3"></div>
+        </div>
+        <div class="glass-panel" id="glassPanel">
+          <h3>玻璃面板</h3>
+          <p>调整下方滑块，体验不同的 backdrop-filter 效果</p>
+        </div>
+      </div>
+
+      <div class="controls">
+        <div class="control-row">
+          <label>模糊 blur()</label>
+          <input type="range" id="blurSlider" min="0" max="30" value="20">
+          <span id="blurValue">20px</span>
+        </div>
+        <div class="control-row">
+          <label>亮度 brightness()</label>
+          <input type="range" id="brightnessSlider" min="50" max="200" value="100">
+          <span id="brightnessValue">100%</span>
+        </div>
+        <div class="control-row">
+          <label>饱和度 saturate()</label>
+          <input type="range" id="saturateSlider" min="0" max="200" value="100">
+          <span id="saturateValue">100%</span>
+        </div>
+        <div class="control-row">
+          <label>对比度 contrast()</label>
+          <input type="range" id="contrastSlider" min="50" max="200" value="100">
+          <span id="contrastValue">100%</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 滤镜函数 -->
+  <div id="functions" class="tab-content">
+    <div class="demo-area">
+      <div class="info-box">
+        backdrop-filter 支持多种滤镜函数，可以组合使用以创建丰富的视觉效果。
+      </div>
+
+      <div class="filter-grid">
+        <div class="filter-item" data-filter="blur(0px)" onclick="selectFilter(this)">
+          <div class="preview" style="--preview-filter: blur(0px);"></div>
+          <div class="name">无效果</div>
+          <div class="filter-value">none</div>
+        </div>
+        <div class="filter-item" data-filter="blur(10px)" onclick="selectFilter(this)">
+          <div class="preview" style="--preview-filter: blur(10px);"></div>
+          <div class="name">模糊</div>
+          <div class="filter-value">blur(10px)</div>
+        </div>
+        <div class="filter-item" data-filter="brightness(1.5)" onclick="selectFilter(this)">
+          <div class="preview" style="--preview-filter: brightness(1.5);"></div>
+          <div class="name">亮度</div>
+          <div class="filter-value">brightness(1.5)</div>
+        </div>
+        <div class="filter-item" data-filter="contrast(1.5)" onclick="selectFilter(this)">
+          <div class="preview" style="--preview-filter: contrast(1.5);"></div>
+          <div class="name">对比度</div>
+          <div class="filter-value">contrast(1.5)</div>
+        </div>
+        <div class="filter-item" data-filter="grayscale(100%)" onclick="selectFilter(this)">
+          <div class="preview" style="--preview-filter: grayscale(100%);"></div>
+          <div class="name">灰度</div>
+          <div class="filter-value">grayscale(100%)</div>
+        </div>
+        <div class="filter-item" data-filter="hue-rotate(90deg)" onclick="selectFilter(this)">
+          <div class="preview" style="--preview-filter: hue-rotate(90deg);"></div>
+          <div class="name">色相旋转</div>
+          <div class="filter-value">hue-rotate(90deg)</div>
+        </div>
+        <div class="filter-item" data-filter="invert(100%)" onclick="selectFilter(this)">
+          <div class="preview" style="--preview-filter: invert(100%);"></div>
+          <div class="name">反转</div>
+          <div class="filter-value">invert(100%)</div>
+        </div>
+        <div class="filter-item" data-filter="opacity(0.5)" onclick="selectFilter(this)">
+          <div class="preview" style="--preview-filter: opacity(0.5);"></div>
+          <div class="name">透明度</div>
+          <div class="filter-value">opacity(0.5)</div>
+        </div>
+        <div class="filter-item" data-filter="saturate(2)" onclick="selectFilter(this)">
+          <div class="preview" style="--preview-filter: saturate(2);"></div>
+          <div class="name">饱和度</div>
+          <div class="filter-value">saturate(2)</div>
+        </div>
+        <div class="filter-item" data-filter="sepia(100%)" onclick="selectFilter(this)">
+          <div class="preview" style="--preview-filter: sepia(100%);"></div>
+          <div class="name">棕褐色</div>
+          <div class="filter-value">sepia(100%)</div>
+        </div>
+      </div>
+
+      <div class="code-block">
+        <span class="keyword">.glass</span> {
+          <span class="property">backdrop-filter</span>: <span class="value" id="codePreview">blur(20px) brightness(100%) saturate(100%)</span>;
+          <span class="property">-webkit-backdrop-filter</span>: <span class="value" id="codePreview2">blur(20px) brightness(100%) saturate(100%)</span>;
+        }
+      </div>
+    </div>
+  </div>
+
+  <!-- 玻璃拟态 -->
+  <div id="glassmorphism" class="tab-content">
+    <div class="demo-area">
+      <div class="info-box">
+        <strong>玻璃拟态（Glassmorphism）</strong>是 modern UI 的热门风格，核心就是 backdrop-filter: blur()。模糊效果让背景内容隐约可见，营造出玻璃的质感。
+      </div>
+
+      <div class="scene" style="height: 400px;">
+        <div class="bg-shapes">
+          <div class="shape shape-1" style="width: 300px; height: 300px;"></div>
+          <div class="shape-2" style="width: 250px; height: 250px; top: 100px; right: -80px;"></div>
+          <div class="shape-3" style="width: 280px; height: 280px; bottom: -80px;"></div>
+        </div>
+
+        <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); text-align: center; color: white;">
+          <h2 style="margin-bottom: 24px; font-weight: 300;">Glassmorphism 示例</h2>
+
+          <div style="display: flex; gap: 16px; flex-wrap: wrap; justify-content: center;">
+            <div class="glass-panel" style="width: 180px; backdrop-filter: blur(10px); -webkit-backdrop-filter: blur(10px);">
+              <h4>模糊 10px</h4>
+              <p style="font-size: 0.75rem;">轻微模糊效果</p>
+            </div>
+            <div class="glass-panel" style="width: 180px; backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);">
+              <h4>模糊 20px</h4>
+              <p style="font-size: 0.75rem;">中等模糊效果</p>
+            </div>
+            <div class="glass-panel" style="width: 180px; backdrop-filter: blur(30px); -webkit-backdrop-filter: blur(30px);">
+              <h4>模糊 30px</h4>
+              <p style="font-size: 0.75rem;">强烈模糊效果</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="code-block">
+        <span class="comment">/* 玻璃拟态基础样式 */</span><br>
+        <span class="keyword">.glass</span> {<br>
+        &nbsp;&nbsp;<span class="property">background</span>: <span class="value">rgba(255, 255, 255, 0.1)</span>;<br>
+        &nbsp;&nbsp;<span class="property">backdrop-filter</span>: <span class="value">blur(20px)</span>;<br>
+        &nbsp;&nbsp;<span class="property">-webkit-backdrop-filter</span>: <span class="value">blur(20px)</span>;<br>
+        &nbsp;&nbsp;<span class="property">border</span>: <span class="value">1px solid rgba(255, 255, 255, 0.2)</span>;<br>
+        &nbsp;&nbsp;<span class="property">border-radius</span>: <span class="value">16px</span>;<br>
+        }
+      </div>
+    </div>
+  </div>
+
+  <!-- 对比实验 -->
+  <div id="comparison" class="tab-content">
+    <div class="demo-area">
+      <div class="info-box">
+        <strong>filter vs backdrop-filter</strong>：两者都会影响视觉呈现，但作用对象不同。
+      </div>
+
+      <div class="scene" style="height: 200px; margin-bottom: 16px;">
+        <div class="bg-shapes">
+          <div class="shape shape-1" style="width: 120px; height: 120px; top: 20px; left: 20px;"></div>
+          <div class="shape-2" style="width: 100px; height: 100px; top: 30px; right: 30px;"></div>
+        </div>
+
+        <div style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); display: flex; gap: 20px;">
+          <div style="text-align: center;">
+            <div class="comparison-panel">
+              <span>filter: blur(15px)<br>（影响自身）</span>
+            </div>
+          </div>
+          <div style="text-align: center;">
+            <div class="comparison-panel with-filter">
+              <span>backdrop-filter: blur(15px)<br>（影响后方）</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="info-box warning">
+        <strong>注意</strong>：backdrop-filter 需要元素有背景（即使是半透明）才能看到效果。如果背景是完全透明的，则看不到任何模糊效果。
+      </div>
+
+      <div class="comparison">
+        <div class="comparison-item">
+          <h4>filter</h4>
+          <div style="width: 100%; height: 100px; background: linear-gradient(135deg, #667eea, #764ba2); display: flex; align-items: center; justify-content: center; border-radius: 8px;">
+            <div style="width: 60px; height: 60px; background: white; border-radius: 8px; filter: blur(5px);"></div>
+          </div>
+          <p style="font-size: 0.75rem; color: #666; margin-top: 8px;">白色方块自身模糊</p>
+        </div>
+        <div class="comparison-item">
+          <h4>backdrop-filter</h4>
+          <div style="width: 100%; height: 100px; background: linear-gradient(135deg, #667eea, #764ba2); display: flex; align-items: center; justify-content: center; border-radius: 8px;">
+            <div style="width: 60px; height: 60px; background: rgba(255,255,255,0.3); border-radius: 8px; backdrop-filter: blur(5px); -webkit-backdrop-filter: blur(5px);"></div>
+          </div>
+          <p style="font-size: 0.75rem; color: #666; margin-top: 8px;">半透明方块后方背景模糊</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 自测题 -->
+  <div id="quiz" class="tab-content">
+    <div class="demo-area">
+      <div class="quiz">
+        <div class="quiz-item" data-correct="2">
+          <h4>1. backdrop-filter 和 filter 的主要区别是什么？</h4>
+          <label><input type="radio" name="q1" value="1"> 没有区别</label>
+          <label><input type="radio" name="q1" value="2"> filter 影响自身，backdrop-filter 影响后方内容</label>
+          <label><input type="radio" name="q1" value="3"> backdrop-filter 性能更好</label>
+        </div>
+        <div class="quiz-item" data-correct="3">
+          <h4>2. 以下哪个浏览器不需要前缀？</h4>
+          <label><input type="radio" name="q2" value="1"> Safari 9+</label>
+          <label><input type="radio" name="q2" value="2"> Chrome 76+</label>
+          <label><input type="radio" name="q2" value="3"> Firefox 103+</label>
+        </div>
+        <div class="quiz-item" data-correct="1">
+          <h4>3. 创建玻璃拟态效果最常用的函数是？</h4>
+          <label><input type="radio" name="q3" value="1"> blur()</label>
+          <label><input type="radio" name="q3" value="2"> grayscale()</label>
+          <label><input type="radio" name="q3" value="3"> invert()</label>
+        </div>
+        <div class="quiz-item" data-correct="2">
+          <h4>4. backdrop-filter 在什么情况下可能不生效？</h4>
+          <label><input type="radio" name="q4" value="1"> 元素有背景色</label>
+          <label><input type="radio" name="q4" value="2"> 元素背景完全透明</label>
+          <label><input type="radio" name="q4" value="3"> 元素有 border</label>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // Tab navigation
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById(btn.dataset.tab).classList.add('active');
+      });
+    });
+
+    // Sliders
+    const glassPanel = document.getElementById('glassPanel');
+
+    function updateFilter() {
+      const blur = document.getElementById('blurSlider').value;
+      const brightness = document.getElementById('brightnessSlider').value;
+      const saturate = document.getElementById('saturateSlider').value;
+      const contrast = document.getElementById('contrastSlider').value;
+
+      document.getElementById('blurValue').textContent = blur + 'px';
+      document.getElementById('brightnessValue').textContent = brightness + '%';
+      document.getElementById('saturateValue').textContent = saturate + '%';
+      document.getElementById('contrastValue').textContent = contrast + '%';
+
+      const filter = `blur(${blur}px) brightness(${brightness}%) saturate(${saturate}%) contrast(${contrast}%)`;
+      glassPanel.style.setProperty('--backdrop-filter', filter);
+
+      document.getElementById('codePreview').textContent = filter;
+      document.getElementById('codePreview2').textContent = filter;
+    }
+
+    document.getElementById('blurSlider').addEventListener('input', updateFilter);
+    document.getElementById('brightnessSlider').addEventListener('input', updateFilter);
+    document.getElementById('saturateSlider').addEventListener('input', updateFilter);
+    document.getElementById('contrastSlider').addEventListener('input', updateFilter);
+
+    // Filter selection
+    function selectFilter(el) {
+      document.querySelectorAll('.filter-item').forEach(item => item.classList.remove('active'));
+      el.classList.add('active');
+
+      const filter = el.dataset.filter;
+      glassPanel.style.setProperty('--backdrop-filter', filter);
+      document.getElementById('codePreview').textContent = filter;
+      document.getElementById('codePreview2').textContent = filter;
+
+      // Update slider to match
+      if (filter.includes('blur')) {
+        const match = filter.match(/blur\(([\d.]+)px\)/);
+        if (match) document.getElementById('blurSlider').value = parseInt(match[1]);
+      }
+      updateFilter();
+    }
+
+    // Quiz
+    document.querySelectorAll('.quiz-item').forEach(item => {
+      item.querySelectorAll('input').forEach(input => {
+        input.addEventListener('change', () => {
+          const correct = item.dataset.correct;
+          item.classList.remove('correct', 'wrong');
+          if (input.value === correct) {
+            item.classList.add('correct');
+          } else {
+            item.classList.add('wrong');
+            setTimeout(() => {
+              item.classList.remove('wrong');
+            }, 1000);
+          }
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/collision-detection/index.html
+++ b/examples/css/demos/collision-detection/index.html
@@ -1,0 +1,971 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>碰撞检测交互演示</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0a0a0f;
+      color: #e0e0e0;
+      min-height: 100vh;
+      padding: 20px;
+    }
+    h1 {
+      text-align: center;
+      font-size: 1.8rem;
+      margin-bottom: 20px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .tab-nav {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .tab-btn {
+      padding: 10px 20px;
+      background: #1a1a2e;
+      border: 1px solid #333;
+      border-radius: 8px;
+      color: #888;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: all 0.2s;
+    }
+    .tab-btn:hover { background: #252540; color: #fff; }
+    .tab-btn.active {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      border-color: transparent;
+    }
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+    .demo-area {
+      background: #1a1a2e;
+      border: 1px solid #333;
+      border-radius: 12px;
+      padding: 20px;
+      margin-bottom: 20px;
+    }
+    .demo-area h3 {
+      color: #667eea;
+      margin-bottom: 12px;
+      font-size: 1.1rem;
+    }
+    canvas {
+      background: #0f0f1a;
+      border-radius: 8px;
+      display: block;
+      margin: 0 auto;
+      cursor: crosshair;
+    }
+    .controls {
+      display: flex;
+      gap: 12px;
+      margin-top: 12px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    button {
+      padding: 10px 20px;
+      background: #252540;
+      border: 1px solid #444;
+      border-radius: 6px;
+      color: #e0e0e0;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: all 0.2s;
+    }
+    button:hover { background: #333355; border-color: #667eea; }
+    button.primary {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      border: none;
+    }
+    .info-box {
+      background: #15152a;
+      border: 1px solid #333;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 16px;
+    }
+    .info-box h4 { color: #667eea; margin-bottom: 8px; }
+    .info-box p { color: #aaa; font-size: 0.9rem; line-height: 1.6; }
+    code {
+      background: #252540;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 0.85em;
+      color: #667eea;
+    }
+    .result-box {
+      background: #0f0f1a;
+      border-radius: 8px;
+      padding: 12px;
+      margin-top: 12px;
+      font-family: 'Fira Code', monospace;
+      font-size: 0.85rem;
+      color: #888;
+      min-height: 60px;
+    }
+    .collision { color: #e74c3c; }
+    .no-collision { color: #2ecc71; }
+    .legend {
+      display: flex;
+      gap: 20px;
+      justify-content: center;
+      margin-top: 12px;
+      font-size: 0.85rem;
+    }
+    .legend-item { display: flex; align-items: center; gap: 6px; }
+    .legend-color {
+      width: 16px;
+      height: 16px;
+      border-radius: 4px;
+    }
+    .stats {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 12px;
+      margin-top: 12px;
+    }
+    .stat-card {
+      background: #15152a;
+      border-radius: 8px;
+      padding: 12px;
+      text-align: center;
+    }
+    .stat-value {
+      font-size: 1.5rem;
+      font-weight: bold;
+      color: #667eea;
+    }
+    .stat-label { color: #666; font-size: 0.8rem; margin-top: 4px; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 12px;
+    }
+    th, td {
+      padding: 10px;
+      text-align: left;
+      border-bottom: 1px solid #333;
+    }
+    th { color: #667eea; font-weight: 600; }
+    td { color: #aaa; }
+    .formula {
+      background: #0f0f1a;
+      padding: 12px;
+      border-radius: 8px;
+      font-family: 'Fira Code', monospace;
+      margin-top: 8px;
+      overflow-x: auto;
+    }
+    .comparison-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 16px;
+      margin-top: 16px;
+    }
+    .comparison-card {
+      background: #15152a;
+      border-radius: 8px;
+      padding: 16px;
+    }
+    .comparison-card h4 {
+      color: #667eea;
+      margin-bottom: 8px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .badge {
+      background: #667eea;
+      color: white;
+      font-size: 0.7rem;
+      padding: 2px 8px;
+      border-radius: 10px;
+    }
+    .badge.fast { background: #2ecc71; }
+    .badge.medium { background: #f39c12; }
+    .badge.slow { background: #e74c3c; }
+  </style>
+</head>
+<body>
+  <h1>🎮 碰撞检测交互演示</h1>
+
+  <div class="tab-nav">
+    <button class="tab-btn active" data-tab="aabb">AABB 矩形碰撞</button>
+    <button class="tab-btn" data-tab="circle">圆形碰撞</button>
+    <button class="tab-btn" data-tab="point">点与矩形</button>
+    <button class="tab-btn" data-tab="grid">空间网格分区</button>
+    <button class="tab-btn" data-tab="game">综合游戏演示</button>
+  </div>
+
+  <div id="tab-aabb" class="tab-content active">
+    <div class="demo-area">
+      <h3>🔲 AABB (Axis-Aligned Bounding Box) 矩形碰撞</h3>
+      <canvas id="canvas-aabb" width="600" height="350"></canvas>
+      <div class="controls">
+        <button class="primary" id="btn-add-rect">添加矩形</button>
+        <button id="btn-clear-rects">清空</button>
+        <button id="btn-drag-aabb">拖拽模式</button>
+      </div>
+      <div class="legend">
+        <div class="legend-item"><div class="legend-color" style="background:#3498db"></div>矩形</div>
+        <div class="legend-item"><div class="legend-color" style="background:#e74c3c"></div>碰撞中</div>
+        <div class="legend-item"><div class="legend-color" style="background:#f39c12"></div>检测点</div>
+      </div>
+      <div class="result-box" id="result-aabb"></div>
+    </div>
+    <div class="info-box">
+      <h4>📚 AABB 碰撞原理</h4>
+      <p>两个矩形不碰撞的条件是：其中一个矩形在另一个的左侧、右侧、上方或下方。只要不满足这四个条件之一，就发生碰撞。</p>
+      <div class="formula">
+        <strong>不碰撞条件：</strong><br>
+        rect1.x + rect1.width ≤ rect2.x (左)<br>
+        rect2.x + rect2.width ≤ rect1.x (右)<br>
+        rect1.y + rect1.height ≤ rect2.y (上)<br>
+        rect2.y + rect2.height ≤ rect1.y (下)<br>
+        <strong>碰撞 = 以上都不满足</strong>
+      </div>
+    </div>
+  </div>
+
+  <div id="tab-circle" class="tab-content">
+    <div class="demo-area">
+      <h3>⭕ 圆形碰撞检测</h3>
+      <canvas id="canvas-circle" width="600" height="350"></canvas>
+      <div class="controls">
+        <button class="primary" id="btn-add-circle">添加圆形</button>
+        <button id="btn-clear-circles">清空</button>
+      </div>
+      <div class="legend">
+        <div class="legend-item"><div class="legend-color" style="background:#9b59b6"></div>圆形</div>
+        <div class="legend-item"><div class="legend-color" style="background:#e74c3c"></div>碰撞中</div>
+        <div class="legend-item"><div class="legend-color" style="background:#2ecc71"></div>圆心距</div>
+      </div>
+      <div class="result-box" id="result-circle"></div>
+    </div>
+    <div class="info-box">
+      <h4>📚 圆形碰撞原理</h4>
+      <p>圆形碰撞通过计算两个圆心之间的距离来判断。如果距离小于两圆半径之和，则发生碰撞。</p>
+      <div class="formula">
+        <strong>碰撞条件：</strong><br>
+        distance = √((x₂-x₁)² + (y₂-y₁)²)<br>
+        <strong>碰撞 = distance &lt; radius₁ + radius₂</strong>
+      </div>
+    </div>
+  </div>
+
+  <div id="tab-point" class="tab-content">
+    <div class="demo-area">
+      <h3>📍 鼠标点击检测</h3>
+      <canvas id="canvas-point" width="600" height="350"></canvas>
+      <div class="controls">
+        <button id="btn-add-target">添加目标</button>
+        <button id="btn-clear-targets">清空</button>
+        <span style="color:#666;font-size:0.9rem;align-self:center;">点击画布检测</span>
+      </div>
+      <div class="legend">
+        <div class="legend-item"><div class="legend-color" style="background:#3498db"></div>目标矩形</div>
+        <div class="legend-item"><div class="legend-color" style="background:#2ecc71"></div>点击命中</div>
+        <div class="legend-item"><div class="legend-color" style="background:#e74c3c"></div>点击未命中</div>
+      </div>
+      <div class="result-box" id="result-point">点击画布任意位置进行检测...</div>
+    </div>
+    <div class="info-box">
+      <h4>📚 点与矩形碰撞原理</h4>
+      <p>最简单的碰撞检测之一。只需检查点的坐标是否在矩形范围内即可。</p>
+      <div class="formula">
+        <strong>命中条件：</strong><br>
+        px ≥ rect.x AND px ≤ rect.x + rect.width<br>
+        py ≥ rect.y AND py ≤ rect.y + rect.height
+      </div>
+    </div>
+  </div>
+
+  <div id="tab-grid" class="tab-content">
+    <div class="demo-area">
+      <h3>🔲 空间网格分区优化</h3>
+      <canvas id="canvas-grid" width="600" height="350"></canvas>
+      <div class="controls">
+        <button class="primary" id="btn-add-many">添加100个对象</button>
+        <button id="btn-clear-many">清空</button>
+        <button id="btn-check-grid">检测碰撞</button>
+      </div>
+      <div class="stats">
+        <div class="stat-card">
+          <div class="stat-value" id="stat-count">0</div>
+          <div class="stat-label">对象数量</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-value" id="stat-checks">0</div>
+          <div class="stat-label">碰撞检测次数</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-value" id="stat-pairs">0</div>
+          <div class="stat-label">碰撞对数</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-value" id="stat-time">0ms</div>
+          <div class="stat-label">检测耗时</div>
+        </div>
+      </div>
+    </div>
+    <div class="info-box">
+      <h4>📚 空间分区优化</h4>
+      <p>当有大量对象时，O(n²) 的两两检测会变得很慢。空间分区通过将画布划分为网格，只检测同一格子或相邻格子中的对象，大幅减少检测次数。</p>
+      <div class="comparison-grid">
+        <div class="comparison-card">
+          <h4>暴力检测 <span class="badge slow">O(n²)</span></h4>
+          <p>100个对象需 100×100 = 10,000 次检测</p>
+        </div>
+        <div class="comparison-card">
+          <h4>网格分区 <span class="badge fast">O(n)</span></h4>
+          <p>每格平均 5 个对象，仅需约 500 次检测</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div id="tab-game" class="tab-content">
+    <div class="demo-area">
+      <h3>🎮 综合游戏演示：弹珠台</h3>
+      <canvas id="canvas-game" width="600" height="400"></canvas>
+      <div class="controls">
+        <button class="primary" id="btn-start-game">开始游戏</button>
+        <button id="btn-pause-game">暂停</button>
+        <span style="color:#666;font-size:0.9rem;align-self:center;">点击画布发射小球</span>
+      </div>
+      <div class="stats">
+        <div class="stat-card">
+          <div class="stat-value" id="stat-score">0</div>
+          <div class="stat-label">得分</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-value" id="stat-balls">0</div>
+          <div class="stat-label">活跃球数</div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-value" id="stat-bounces">0</div>
+          <div class="stat-label">弹跳次数</div>
+        </div>
+      </div>
+    </div>
+    <div class="info-box">
+      <h4>📚 碰撞检测在游戏中的应用</h4>
+      <p>弹珠台游戏综合使用了多种碰撞检测算法：</p>
+      <table>
+        <tr><th>场景</th><th>算法</th></tr>
+        <tr><td>球与墙壁边界</td><td>AABB 矩形碰撞</td></tr>
+        <tr><td>球与圆形障碍物</td><td>圆形碰撞</td></tr>
+        <tr><td>球与球碰撞</td><td>圆形碰撞</td></tr>
+        <tr><td>球与挡板</td><td>AABB + 圆形组合</td></tr>
+      </table>
+    </div>
+  </div>
+
+<script>
+// ==================== AABB 矩形碰撞 ====================
+(function() {
+  const canvas = document.getElementById('canvas-aabb');
+  const ctx = canvas.getContext('2d');
+  let rects = [];
+  let dragRect = null;
+  let isDragging = false;
+  let isDragMode = false;
+  let mousePos = { x: 0, y: 0 };
+  let rectIdCounter = 0;
+
+  function rectIntersect(r1, r2) {
+    return !(
+      r1.x + r1.width <= r2.x ||
+      r2.x + r2.width <= r1.x ||
+      r1.y + r1.height <= r2.y ||
+      r2.y + r2.height <= r1.y
+    );
+  }
+
+  function draw() {
+    ctx.fillStyle = '#0f0f1a';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    
+    ctx.strokeStyle = '#1a1a2e';
+    for (let x = 0; x < canvas.width; x += 50) {
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, canvas.height);
+      ctx.stroke();
+    }
+    for (let y = 0; y < canvas.height; y += 50) {
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(canvas.width, y);
+      ctx.stroke();
+    }
+    
+    ctx.fillStyle = '#f39c12';
+    ctx.beginPath();
+    ctx.arc(mousePos.x, mousePos.y, 5, 0, Math.PI * 2);
+    ctx.fill();
+    
+    rects.forEach(function(r) {
+      const colliding = rects.some(function(other) { return other !== r && rectIntersect(r, other); });
+      ctx.fillStyle = colliding ? 'rgba(231,76,60,0.3)' : 'rgba(52,152,219,0.3)';
+      ctx.fillRect(r.x, r.y, r.width, r.height);
+      ctx.strokeStyle = colliding ? '#e74c3c' : '#3498db';
+      ctx.lineWidth = 2;
+      ctx.strokeRect(r.x, r.y, r.width, r.height);
+      ctx.fillStyle = '#fff';
+      ctx.font = '14px sans-serif';
+      ctx.fillText(r.id, r.x + 5, r.y + 20);
+    });
+    
+    const collisions = [];
+    rects.forEach(function(r, i) {
+      rects.forEach(function(r2, j) {
+        if (i < j && rectIntersect(r, r2)) {
+          collisions.push(r.id + ' ∩ ' + r2.id);
+        }
+      });
+    });
+    document.getElementById('result-aabb').innerHTML = collisions.length > 0
+      ? '<span class="collision">⚠️ 碰撞检测:</span> ' + collisions.join(', ')
+      : '<span class="no-collision">✅ 无碰撞</span>';
+  }
+
+  canvas.addEventListener('mousemove', function(e) {
+    const rect = canvas.getBoundingClientRect();
+    mousePos = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    if (isDragging && dragRect) {
+      dragRect.x = mousePos.x - dragRect.width / 2;
+      dragRect.y = mousePos.y - dragRect.height / 2;
+    }
+    draw();
+  });
+
+  canvas.addEventListener('click', function(e) {
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const clicked = rects.find(function(r) { return x >= r.x && x <= r.x + r.width && y >= r.y && y <= r.y + r.height; });
+    if (!clicked && !isDragMode) {
+      rects.push({
+        id: 'R' + (++rectIdCounter),
+        x: x - 30,
+        y: y - 25,
+        width: 60,
+        height: 50
+      });
+      draw();
+    }
+  });
+
+  canvas.addEventListener('mousedown', function(e) {
+    if (!isDragMode) return;
+    const rect = canvas.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const clicked = rects.find(function(r) { return x >= r.x && x <= r.x + r.width && y >= r.y && y <= r.y + r.height; });
+    if (clicked) {
+      dragRect = clicked;
+      isDragging = true;
+    }
+  });
+
+  canvas.addEventListener('mouseup', function() {
+    isDragging = false;
+    dragRect = null;
+  });
+
+  document.getElementById('btn-add-rect').addEventListener('click', function() {
+    rects.push({
+      id: 'R' + (++rectIdCounter),
+      x: Math.random() * 500,
+      y: Math.random() * 250,
+      width: 60 + Math.random() * 40,
+      height: 50 + Math.random() * 30
+    });
+    draw();
+  });
+
+  document.getElementById('btn-clear-rects').addEventListener('click', function() {
+    rects = [];
+    rectIdCounter = 0;
+    draw();
+  });
+
+  document.getElementById('btn-drag-aabb').addEventListener('click', function() {
+    isDragMode = !isDragMode;
+    this.style.background = isDragMode ? '#667eea' : '#252540';
+  });
+
+  draw();
+})();
+
+// ==================== 圆形碰撞 ====================
+(function() {
+  const canvas = document.getElementById('canvas-circle');
+  const ctx = canvas.getContext('2d');
+  let circles = [];
+  let circleIdCounter = 0;
+
+  function circleIntersect(c1, c2) {
+    return Math.hypot(c1.x - c2.x, c1.y - c2.y) < c1.radius + c2.radius;
+  }
+
+  function draw() {
+    ctx.fillStyle = '#0f0f1a';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    
+    circles.forEach(function(c) {
+      const colliding = circles.some(function(other) { return other !== c && circleIntersect(c, other); });
+      
+      circles.forEach(function(c2) {
+        if (c !== c2) {
+          const dist = Math.hypot(c.x - c2.x, c.y - c2.y);
+          if (dist < c.radius + c2.radius + 50) {
+            ctx.strokeStyle = dist < c.radius + c2.radius ? 'rgba(46,204,113,0.5)' : 'rgba(100,100,100,0.2)';
+            ctx.lineWidth = dist < c.radius + c2.radius ? 2 : 1;
+            ctx.beginPath();
+            ctx.moveTo(c.x, c.y);
+            ctx.lineTo(c2.x, c2.y);
+            ctx.stroke();
+          }
+        }
+      });
+      
+      ctx.beginPath();
+      ctx.arc(c.x, c.y, c.radius, 0, Math.PI * 2);
+      ctx.fillStyle = colliding ? 'rgba(231,76,60,0.4)' : 'rgba(155,89,182,0.4)';
+      ctx.fill();
+      ctx.strokeStyle = colliding ? '#e74c3c' : '#9b59b6';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+      
+      ctx.fillStyle = colliding ? '#e74c3c' : '#2ecc71';
+      ctx.font = '11px sans-serif';
+      ctx.fillText(c.id, c.x - 8, c.y + 4);
+    });
+    
+    const pairs = [];
+    circles.forEach(function(c, i) {
+      circles.forEach(function(c2, j) {
+        if (i < j && circleIntersect(c, c2)) {
+          pairs.push(c.id + ' ∩ ' + c2.id);
+        }
+      });
+    });
+    document.getElementById('result-circle').innerHTML = pairs.length > 0
+      ? '<span class="collision">⚠️ 碰撞:</span> ' + pairs.join(', ')
+      : '<span class="no-collision">✅ 无碰撞</span>';
+  }
+
+  canvas.addEventListener('click', function(e) {
+    const rect = canvas.getBoundingClientRect();
+    circles.push({
+      id: 'C' + (++circleIdCounter),
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+      radius: 25 + Math.random() * 25
+    });
+    draw();
+  });
+
+  document.getElementById('btn-add-circle').addEventListener('click', function() {
+    circles.push({
+      id: 'C' + (++circleIdCounter),
+      x: 50 + Math.random() * 500,
+      y: 50 + Math.random() * 250,
+      radius: 25 + Math.random() * 25
+    });
+    draw();
+  });
+
+  document.getElementById('btn-clear-circles').addEventListener('click', function() {
+    circles = [];
+    circleIdCounter = 0;
+    draw();
+  });
+  draw();
+})();
+
+// ==================== 点与矩形 ====================
+(function() {
+  const canvas = document.getElementById('canvas-point');
+  const ctx = canvas.getContext('2d');
+  let targets = [];
+  let targetIdCounter = 0;
+  let clickPos = null;
+
+  function pointInRect(px, py, rect) {
+    return px >= rect.x && px <= rect.x + rect.width && py >= rect.y && py <= rect.y + rect.height;
+  }
+
+  function draw() {
+    ctx.fillStyle = '#0f0f1a';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    
+    targets.forEach(function(t) {
+      ctx.fillStyle = 'rgba(52,152,219,0.4)';
+      ctx.fillRect(t.x, t.y, t.width, t.height);
+      ctx.strokeStyle = '#3498db';
+      ctx.lineWidth = 2;
+      ctx.strokeRect(t.x, t.y, t.width, t.height);
+      ctx.fillStyle = '#fff';
+      ctx.font = '14px sans-serif';
+      ctx.fillText(t.id, t.x + 5, t.y + 20);
+      ctx.font = '11px sans-serif';
+      ctx.fillText(t.width + 'x' + t.height, t.x + 5, t.y + 35);
+    });
+    
+    if (clickPos) {
+      const hit = targets.find(function(t) { return pointInRect(clickPos.x, clickPos.y, t); });
+      ctx.fillStyle = hit ? '#2ecc71' : '#e74c3c';
+      ctx.beginPath();
+      ctx.arc(clickPos.x, clickPos.y, 8, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = hit ? '#2ecc71' : '#e74c3c';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      ctx.moveTo(clickPos.x - 15, clickPos.y);
+      ctx.lineTo(clickPos.x + 15, clickPos.y);
+      ctx.moveTo(clickPos.x, clickPos.y - 15);
+      ctx.lineTo(clickPos.x, clickPos.y + 15);
+      ctx.stroke();
+      document.getElementById('result-point').innerHTML = hit
+        ? '<span class="no-collision">✅ 命中: ' + hit.id + '</span><br>坐标: (' + Math.round(clickPos.x) + ', ' + Math.round(clickPos.y) + ')'
+        : '<span class="collision">❌ 未命中</span><br>坐标: (' + Math.round(clickPos.x) + ', ' + Math.round(clickPos.y) + ')';
+    }
+  }
+
+  canvas.addEventListener('click', function(e) {
+    const rect = canvas.getBoundingClientRect();
+    clickPos = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    draw();
+  });
+
+  canvas.addEventListener('mousemove', function(e) {
+    const rect = canvas.getBoundingClientRect();
+    clickPos = { x: e.clientX - rect.left, y: e.clientY - rect.top };
+    draw();
+  });
+
+  document.getElementById('btn-add-target').addEventListener('click', function() {
+    targets.push({
+      id: 'T' + (++targetIdCounter),
+      x: Math.random() * 400,
+      y: Math.random() * 250,
+      width: 80 + Math.random() * 60,
+      height: 60 + Math.random() * 40
+    });
+    draw();
+  });
+
+  document.getElementById('btn-clear-targets').addEventListener('click', function() {
+    targets = [];
+    targetIdCounter = 0;
+    draw();
+  });
+  draw();
+})();
+
+// ==================== 空间网格分区 ====================
+(function() {
+  const canvas = document.getElementById('canvas-grid');
+  const ctx = canvas.getContext('2d');
+  let manyObjects = [];
+  let objIdCounter = 0;
+  const CELL_SIZE = 50;
+
+  function SpatialGrid(cellSize) {
+    this.cellSize = cellSize;
+    this.cells = new Map();
+  }
+  SpatialGrid.prototype.getKey = function(x, y) {
+    return Math.floor(x / this.cellSize) + ',' + Math.floor(y / this.cellSize);
+  };
+  SpatialGrid.prototype.insert = function(obj) {
+    var key = this.getKey(obj.x, obj.y);
+    if (!this.cells.has(key)) this.cells.set(key, []);
+    this.cells.get(key).push(obj);
+  };
+  SpatialGrid.prototype.query = function(x, y, radius) {
+    var results = [];
+    var checked = new Set();
+    var cellRadius = Math.ceil(radius / this.cellSize);
+    var cx = Math.floor(x / this.cellSize);
+    var cy = Math.floor(y / this.cellSize);
+    for (var dx = -cellRadius; dx <= cellRadius; dx++) {
+      for (var dy = -cellRadius; dy <= cellRadius; dy++) {
+        var key = (cx + dx) + ',' + (cy + dy);
+        var cell = this.cells.get(key);
+        if (cell) {
+          cell.forEach(function(obj) {
+            if (!checked.has(obj.id)) {
+              checked.add(obj.id);
+              var dist = Math.hypot(obj.x - x, obj.y - y);
+              if (dist <= radius + obj.radius) {
+                results.push(obj);
+              }
+            }
+          });
+        }
+      }
+    }
+    return results;
+  };
+  SpatialGrid.prototype.clear = function() { this.cells.clear(); };
+
+  var grid = new SpatialGrid(CELL_SIZE);
+
+  function draw() {
+    ctx.fillStyle = '#0f0f1a';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.strokeStyle = '#252540';
+    ctx.lineWidth = 1;
+    for (var x = 0; x <= canvas.width; x += CELL_SIZE) {
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, canvas.height);
+      ctx.stroke();
+    }
+    for (var y = 0; y <= canvas.height; y += CELL_SIZE) {
+      ctx.beginPath();
+      ctx.moveTo(0, y);
+      ctx.lineTo(canvas.width, y);
+      ctx.stroke();
+    }
+    manyObjects.forEach(function(obj) {
+      ctx.fillStyle = obj.colliding ? '#e74c3c' : '#3498db';
+      ctx.beginPath();
+      ctx.arc(obj.x, obj.y, obj.radius, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.fillStyle = '#fff';
+      ctx.font = '10px sans-serif';
+      ctx.fillText(obj.id, obj.x - 5, obj.y + 3);
+    });
+    document.getElementById('stat-count').textContent = manyObjects.length;
+  }
+
+  function checkCollisions() {
+    grid.clear();
+    manyObjects.forEach(function(obj) { obj.colliding = false; grid.insert(obj); });
+    var checks = 0;
+    var pairs = 0;
+    var startTime = performance.now();
+    manyObjects.forEach(function(obj) {
+      var nearby = grid.query(obj.x, obj.y, obj.radius * 2);
+      nearby.forEach(function(other) {
+        if (obj.id < other.id) {
+          checks++;
+          var dist = Math.hypot(obj.x - other.x, obj.y - other.y);
+          if (dist < obj.radius + other.radius) {
+            obj.colliding = true;
+            other.colliding = true;
+            pairs++;
+          }
+        }
+      });
+    });
+    var endTime = performance.now();
+    document.getElementById('stat-checks').textContent = checks;
+    document.getElementById('stat-pairs').textContent = pairs;
+    document.getElementById('stat-time').textContent = (endTime - startTime).toFixed(2) + 'ms';
+    draw();
+  }
+
+  document.getElementById('btn-add-many').addEventListener('click', function() {
+    for (var i = 0; i < 100; i++) {
+      manyObjects.push({
+        id: 'O' + (++objIdCounter),
+        x: Math.random() * 550 + 25,
+        y: Math.random() * 300 + 25,
+        radius: 8 + Math.random() * 8,
+        colliding: false
+      });
+    }
+    draw();
+  });
+
+  document.getElementById('btn-clear-many').addEventListener('click', function() {
+    manyObjects = [];
+    objIdCounter = 0;
+    document.getElementById('stat-checks').textContent = '0';
+    document.getElementById('stat-pairs').textContent = '0';
+    document.getElementById('stat-time').textContent = '0ms';
+    draw();
+  });
+
+  document.getElementById('btn-check-grid').addEventListener('click', checkCollisions);
+  draw();
+})();
+
+// ==================== 综合游戏演示 ====================
+(function() {
+  var canvas = document.getElementById('canvas-game');
+  var ctx = canvas.getContext('2d');
+  var gameRunning = false;
+  var balls = [];
+  var obstacles = [];
+  var paddle = { x: 250, y: 360, width: 100, height: 15 };
+  var score = 0;
+  var bounces = 0;
+  var gameLoopId = null;
+
+  function initGame() {
+    balls = [];
+    obstacles = [];
+    score = 0;
+    bounces = 0;
+    var colors = ['#e74c3c', '#3498db', '#2ecc71', '#f39c12', '#9b59b6', '#1abc9c'];
+    for (var i = 0; i < 8; i++) {
+      obstacles.push({
+        type: 'circle',
+        x: 80 + Math.random() * 440,
+        y: 80 + Math.random() * 200,
+        radius: 20 + Math.random() * 20,
+        color: colors[i % colors.length]
+      });
+    }
+    updateStats();
+  }
+
+  function updateStats() {
+    document.getElementById('stat-score').textContent = score;
+    document.getElementById('stat-balls').textContent = balls.length;
+    document.getElementById('stat-bounces').textContent = bounces;
+  }
+
+  function circleRectCollide(ball, rect) {
+    var closestX = Math.max(rect.x, Math.min(ball.x, rect.x + rect.width));
+    var closestY = Math.max(rect.y, Math.min(ball.y, rect.y + rect.height));
+    var dx = ball.x - closestX;
+    var dy = ball.y - closestY;
+    return (dx * dx + dy * dy) < (ball.radius * ball.radius);
+  }
+
+  function drawGame() {
+    ctx.fillStyle = '#0f0f1a';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    
+    obstacles.forEach(function(obs) {
+      if (obs.type === 'circle') {
+        ctx.beginPath();
+        ctx.arc(obs.x, obs.y, obs.radius, 0, Math.PI * 2);
+        ctx.fillStyle = obs.color;
+        ctx.fill();
+        ctx.strokeStyle = 'rgba(255,255,255,0.3)';
+        ctx.stroke();
+      }
+    });
+    
+    ctx.fillStyle = '#667eea';
+    ctx.fillRect(paddle.x, paddle.y, paddle.width, paddle.height);
+    
+    balls.forEach(function(ball) {
+      ctx.beginPath();
+      ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
+      ctx.fillStyle = '#fff';
+      ctx.fill();
+    });
+  }
+
+  function update() {
+    balls.forEach(function(ball) {
+      ball.x += ball.vx;
+      ball.y += ball.vy;
+      
+      if (ball.x - ball.radius <= 0 || ball.x + ball.radius >= canvas.width) {
+        ball.vx *= -1;
+        bounces++;
+      }
+      if (ball.y - ball.radius <= 0) {
+        ball.vy *= -1;
+        bounces++;
+      }
+      if (ball.y + ball.radius >= canvas.height) {
+        ball.vy *= -1;
+        bounces++;
+        score = Math.max(0, score - 10);
+      }
+      
+      if (circleRectCollide(ball, paddle)) {
+        ball.vy = -Math.abs(ball.vy);
+        ball.vx += (ball.x - (paddle.x + paddle.width / 2)) * 0.1;
+        bounces++;
+        score += 10;
+      }
+      
+      obstacles.forEach(function(obs) {
+        if (obs.type === 'circle') {
+          var dx = ball.x - obs.x;
+          var dy = ball.y - obs.y;
+          var dist = Math.sqrt(dx * dx + dy * dy);
+          if (dist < ball.radius + obs.radius) {
+            var nx = dx / dist;
+            var ny = dy / dist;
+            var dvx = ball.vx - 0;
+            var dvy = ball.vy - 0;
+            var dvn = dvx * nx + dvy * ny;
+            ball.vx = ball.vx - 2 * dvn * nx;
+            ball.vy = ball.vy - 2 * dvn * ny;
+            bounces++;
+            score += 5;
+          }
+        }
+      });
+    });
+    
+    updateStats();
+    drawGame();
+  }
+
+  function gameLoop() {
+    if (!gameRunning) return;
+    update();
+    gameLoopId = requestAnimationFrame(gameLoop);
+  }
+
+  initGame();
+  drawGame();
+  
+  canvas.addEventListener('click', function(e) {
+    if (!gameRunning) return;
+    var rect = canvas.getBoundingClientRect();
+    balls.push({
+      x: e.clientX - rect.left,
+      y: 340,
+      vx: (Math.random() - 0.5) * 4,
+      vy: -5 - Math.random() * 3,
+      radius: 8
+    });
+  });
+
+  document.getElementById('btn-start-game').addEventListener('click', function() {
+    gameRunning = true;
+    gameLoop();
+  });
+
+  document.getElementById('btn-pause-game').addEventListener('click', function() {
+    gameRunning = false;
+    if (gameLoopId) cancelAnimationFrame(gameLoopId);
+  });
+})();
+
+// ==================== Tab 切换 ====================
+document.querySelectorAll('.tab-btn').forEach(function(btn) {
+  btn.addEventListener('click', function() {
+    document.querySelectorAll('.tab-btn').forEach(function(b) { b.classList.remove('active'); });
+    document.querySelectorAll('.tab-content').forEach(function(c) { c.classList.remove('active'); });
+    btn.classList.add('active');
+    document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+  });
+});

--- a/examples/css/demos/cssom-demo/index.html
+++ b/examples/css/demos/cssom-demo/index.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSSOM 操作方法演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f0f1e; color: #e0e0e0; min-height: 100vh; padding: 24px; }
+    h1 { text-align: center; color: #fff; margin-bottom: 8px; font-size: 1.6rem; }
+    .subtitle { text-align: center; color: #888; margin-bottom: 24px; font-size: 0.9rem; }
+
+    .tabs { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 16px; justify-content: center; }
+    .tab-btn { background: #1a1a2e; border: 1px solid #333; color: #aaa; padding: 8px 16px; border-radius: 8px; cursor: pointer; font-size: 0.85rem; transition: all 0.2s; }
+    .tab-btn:hover { background: #252540; color: #fff; }
+    .tab-btn.active { background: #4f46e5; color: #fff; border-color: #4f46e5; }
+
+    .tab-content { display: none; background: #1a1a2e; border: 1px solid #333; border-radius: 12px; padding: 20px; margin-bottom: 16px; }
+    .tab-content.active { display: block; }
+
+    .section-title { color: #a78bfa; margin-bottom: 12px; font-size: 0.95rem; }
+    .desc { color: #888; font-size: 0.82rem; margin-bottom: 12px; line-height: 1.5; }
+    .code-snippet { background: #111; border: 1px solid #333; border-radius: 8px; padding: 10px 14px; font-family: 'Fira Code', monospace; font-size: 0.78rem; color: #9dffcc; margin-bottom: 12px; overflow-x: auto; white-space: pre; }
+
+    .demo-box { background: #2d2d4a; border-radius: 12px; padding: 20px; margin-bottom: 12px; display: flex; align-items: center; justify-content: center; min-height: 120px; color: #fff; font-weight: 500; transition: all 0.3s; }
+    .demo-box.small { width: 80px; height: 80px; padding: 8px; font-size: 0.75rem; text-align: center; }
+
+    .btn-row { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 12px; }
+    .btn { background: #4f46e5; color: #fff; border: none; padding: 7px 14px; border-radius: 7px; cursor: pointer; font-size: 0.8rem; transition: background 0.2s; }
+    .btn:hover { background: #6366f1; }
+    .btn.secondary { background: #333; }
+    .btn.secondary:hover { background: #444; }
+    .btn.danger { background: #dc2626; }
+    .btn.danger:hover { background: #ef4444; }
+
+    .output-box { background: #0d0d1a; border: 1px solid #333; border-radius: 8px; padding: 10px; max-height: 140px; overflow-y: auto; font-family: 'Fira Code', monospace; font-size: 0.75rem; color: #9dffcc; }
+    .output-box .entry { padding: 2px 0; border-bottom: 1px solid #222; }
+    .output-box .entry:last-child { border-bottom: none; }
+
+    .input-row { display: flex; gap: 8px; margin-bottom: 8px; flex-wrap: wrap; align-items: center; }
+    .input-row input[type="text"] { background: #111; border: 1px solid #444; border-radius: 6px; color: #fff; padding: 6px 10px; font-size: 0.8rem; width: 140px; }
+    .input-row input[type="checkbox"] { width: 16px; height: 16px; }
+    .input-row label { font-size: 0.8rem; color: #aaa; }
+
+    .info-tag { display: inline-block; background: #333; color: #fbbf24; padding: 3px 10px; border-radius: 20px; font-size: 0.75rem; margin-bottom: 8px; }
+
+    .grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .computed-item { background: #111; border-radius: 8px; padding: 8px 12px; }
+    .computed-item .label { color: #888; font-size: 0.75rem; }
+    .computed-item .value { color: #a3e635; font-family: monospace; font-size: 0.8rem; }
+
+    #rect-viewport { position: relative; width: 100%; height: 160px; background: #111; border: 1px solid #333; border-radius: 8px; overflow: hidden; }
+    #demo-rect-box { position: absolute; width: 60px; height: 60px; background: linear-gradient(135deg, #4f46e5, #a78bfa); border-radius: 8px; cursor: move; display: flex; align-items: center; justify-content: center; font-size: 0.7rem; color: #fff; user-select: none; box-shadow: 0 4px 12px rgba(79,70,229,0.4); }
+
+    .rect-info { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; margin-bottom: 8px; }
+    .rect-info-item { background: #111; border-radius: 6px; padding: 6px 8px; text-align: center; }
+    .rect-info-item .label { font-size: 0.7rem; color: #888; }
+    .rect-info-item .value { font-size: 0.85rem; color: #a3e635; font-family: monospace; }
+
+    @media (max-width: 600px) { .grid-2 { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <h1>CSSOM 操作方法演示</h1>
+  <p class="subtitle">JavaScript CSS 样式编程接口实战</p>
+
+  <div class="tabs">
+    <button class="tab-btn active" data-tab="style">style.property</button>
+    <button class="tab-btn" data-tab="csstext">cssText</button>
+    <button class="tab-btn" data-tab="setproperty">setProperty</button>
+    <button class="tab-btn" data-tab="getproperty">getPropertyValue</button>
+    <button class="tab-btn" data-tab="removeproperty">removeProperty</button>
+    <button class="tab-btn" data-tab="computed">getComputedStyle</button>
+    <button class="tab-btn" data-tab="rect">getBoundingClientRect</button>
+  </div>
+
+  <!-- style.property -->
+  <div class="tab-content active" id="tab-style">
+    <div class="section-title">1.1 直接属性访问</div>
+    <p class="desc">通过点符号直接读写 CSS 属性，属性名使用驼峰命名法。</p>
+    <div class="code-snippet">element.style.backgroundColor = '#2ecc71';
+element.style.fontSize = '16px';</div>
+    <div class="demo-box" id="demo-style-box">演示盒子</div>
+    <div class="btn-row">
+      <button class="btn" onclick="setColor()">设置颜色</button>
+      <button class="btn" onclick="setSize()">设置尺寸</button>
+      <button class="btn secondary" onclick="resetStyle()">重置</button>
+    </div>
+    <div class="input-row">
+      <input type="text" id="input-bg" value="#e74c3c" placeholder="背景色">
+      <input type="text" id="input-fs" value="20px" placeholder="字号">
+      <button class="btn" onclick="applyCustomStyle()">应用自定义</button>
+    </div>
+    <div class="output-box" id="output-style"></div>
+  </div>
+
+  <!-- cssText -->
+  <div class="tab-content" id="tab-csstext">
+    <div class="section-title">1.2 cssText 批量设置</div>
+    <p class="desc">一次性设置或读取整个行内样式字符串，等效于操作 HTML style 属性内容。</p>
+    <div class="code-snippet">element.style.cssText = 'width:200px; height:200px; background:red;';
+console.log(element.style.cssText);</div>
+    <div class="demo-box" id="demo-csstext-box">演示盒子</div>
+    <div class="btn-row">
+      <button class="btn" onclick="setCssTextBatch()">批量设置样式</button>
+      <button class="btn secondary" onclick="getCssText()">获取当前 cssText</button>
+      <button class="btn secondary" onclick="resetStyle2()">重置</button>
+    </div>
+    <div class="input-row">
+      <input type="text" id="csstext-input" value="width:150px;height:150px;background:#f39c12;color:#fff;border-radius:12px;" style="width:300px;">
+      <button class="btn" onclick="applyCssText()">应用 cssText</button>
+    </div>
+    <div class="output-box" id="output-csstext"></div>
+  </div>
+
+  <!-- setProperty -->
+  <div class="tab-content" id="tab-setproperty">
+    <div class="section-title">1.3 setProperty() 设置带优先级的属性</div>
+    <p class="desc">以编程方式设置 CSS 属性，可选添加 <code>!important</code> 优先级标记。</p>
+    <div class="code-snippet">element.style.setProperty('color', '#fff');
+element.style.setProperty('opacity', '0.5', 'important');</div>
+    <span class="info-tag" id="setproperty-info">Click buttons to compare</span>
+    <div class="demo-box" id="demo-setproperty-box">演示盒子</div>
+    <div class="btn-row">
+      <button class="btn" onclick="setPropertyDemo()">普通设置</button>
+      <button class="btn" onclick="setPropertyImportant()">设置 !important</button>
+      <button class="btn secondary" onclick="resetStyle3()">重置</button>
+    </div>
+    <div class="input-row">
+      <input type="text" id="prop-name" value="background-color" placeholder="属性名">
+      <input type="text" id="prop-value" value="#e67e22" placeholder="属性值">
+      <label><input type="checkbox" id="prop-important"> !important</label>
+      <button class="btn" onclick="applySetProperty()">应用</button>
+    </div>
+    <div class="output-box" id="output-setproperty"></div>
+  </div>
+
+  <!-- getPropertyValue -->
+  <div class="tab-content" id="tab-getproperty">
+    <div class="section-title">1.4 getPropertyValue() 获取属性值</div>
+    <p class="desc">从行内样式中读取指定属性的值，返回字符串。注意：只能读取行内样式，无法读取计算样式。</p>
+    <div class="code-snippet">var val = element.style.getPropertyValue('color');
+console.log(val);</div>
+    <div class="demo-box small" id="demo-getproperty-box" style="background:#3498db;color:#fff;font-size:14px;">box</div>
+    <div class="btn-row">
+      <button class="btn" onclick="getPropertyDemo()">遍历行内属性</button>
+      <button class="btn secondary" onclick="getAllProperties()">for...of 遍历</button>
+    </div>
+    <div class="input-row">
+      <input type="text" id="query-prop" value="background-color" placeholder="属性名">
+      <button class="btn" onclick="queryProperty()">查询</button>
+      <button class="btn secondary" onclick="queryPropertyPreset('color')">color</button>
+      <button class="btn secondary" onclick="queryPropertyPreset('width')">width</button>
+      <button class="btn secondary" onclick="queryPropertyPreset('font-size')">font-size</button>
+    </div>
+    <div class="output-box" id="output-getproperty"></div>
+  </div>
+
+  <!-- removeProperty -->
+  <div class="tab-content" id="tab-removeproperty">
+    <div class="section-title">1.5 removeProperty() 移除属性</div>
+    <p class="desc">从元素行内样式中删除指定属性，返回被删除的值。注意：会同时移除该属性的 !important 声明。</p>
+    <div class="code-snippet">var old = element.style.removeProperty('color');
+console.log('removed:', old);</div>
+    <span class="info-tag">待移除属性: <span id="pending-remove">none</span></span>
+    <div class="demo-box" id="demo-removeproperty-box" style="background:#e74c3c;opacity:0.7;color:#fff;padding:20px;border-radius:12px;">演示：opacity:0.7, background:#e74c3c</div>
+    <div class="btn-row">
+      <button class="btn" onclick="removePropertyDemo()">移除 opacity</button>
+      <button class="btn" onclick="removePropertyBg()">移除 background-color</button>
+      <button class="btn secondary" onclick="resetStyle4()">重置</button>
+    </div>
+    <div class="btn-row">
+      <button class="btn secondary" onclick="removePropSelect('opacity')">选中 opacity</button>
+      <button class="btn secondary" onclick="removePropSelect('color')">选中 color</button>
+      <button class="btn secondary" onclick="removePropSelect('border-radius')">选中 border-radius</button>
+      <button class="btn danger" onclick="applyRemoveProperty()">执行移除</button>
+    </div>
+    <div class="output-box" id="output-removeproperty"></div>
+  </div>
+
+  <!-- getComputedStyle -->
+  <div class="tab-content" id="tab-computed">
+    <div class="section-title">2. window.getComputedStyle() 获取计算样式</div>
+    <p class="desc">获取元素经过所有样式表和继承计算后的最终样式（只读）。第二个参数可指定伪元素。</p>
+    <div class="code-snippet">var computed = window.getComputedStyle(element);
+var before = window.getComputedStyle(element, '::before');</div>
+    <div class="demo-box" id="demo-computed-box" style="background:linear-gradient(135deg,#667eea,#764ba2);color:#fff;padding:24px;border-radius:16px;flex-direction:column;gap:8px;">
+      <div style="font-size:1.2em;font-weight:bold;">Computed Style Demo</div>
+      <div style="font-size:0.85em;opacity:0.8;">带渐变背景的盒子</div>
+    </div>
+    <div class="btn-row">
+      <button class="btn" onclick="getComputedDemo()">获取计算样式</button>
+      <button class="btn secondary" onclick="getPseudoElement()">获取 ::before</button>
+    </div>
+    <div id="computed-results" style="display:none;margin-bottom:12px;">
+      <div id="computed-grid" class="grid-2"></div>
+    </div>
+    <div class="output-box" id="output-computed"></div>
+  </div>
+
+  <!-- getBoundingClientRect -->
+  <div class="tab-content" id="tab-rect">
+    <div class="section-title">3. getBoundingClientRect() 元素尺寸与位置</div>
+    <p class="desc">返回元素相对于视口的位置和尺寸信息。拖动下方盒子查看实时数值变化。</p>
+    <div class="code-snippet">var rect = element.getBoundingClientRect();
+console.log(rect.width, rect.height, rect.top, rect.left);</div>
+    <div class="rect-info">
+      <div class="rect-info-item"><div class="label">top</div><div class="value" id="rect-top">0</div></div>
+      <div class="rect-info-item"><div class="label">left</div><div class="value" id="rect-left">0</div></div>
+      <div class="rect-info-item"><div class="label">right</div><div class="value" id="rect-right">0</div></div>
+      <div class="rect-info-item"><div class="label">bottom</div><div class="value" id="rect-bottom">0</div></div>
+      <div class="rect-info-item"><div class="label">width</div><div class="value" id="rect-width">0</div></div>
+      <div class="rect-info-item"><div class="label">height</div><div class="value" id="rect-height">0</div></div>
+    </div>
+    <div id="rect-viewport">
+      <div id="demo-rect-box" style="left:20px;top:20px;">DRAG</div>
+    </div>
+    <div class="btn-row">
+      <button class="btn" onclick="getBoundingDemo()">获取 rect</button>
+      <button class="btn secondary" onclick="resetRect()">重置位置</button>
+      <button class="btn secondary" onclick="startDrag()">启用拖拽</button>
+    </div>
+    <div class="output-box" id="output-rect"></div>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/examples/css/demos/cssom-demo/script.js
+++ b/examples/css/demos/cssom-demo/script.js
@@ -1,0 +1,266 @@
+(function() {
+  document.querySelectorAll('.tab-btn').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      document.querySelectorAll('.tab-btn').forEach(function(b) { b.classList.remove('active'); });
+      document.querySelectorAll('.tab-content').forEach(function(c) { c.classList.remove('active'); });
+      btn.classList.add('active');
+      document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+    });
+  });
+
+  function log(outputId, message) {
+    var box = document.getElementById(outputId);
+    var entry = document.createElement('div');
+    entry.className = 'entry';
+    entry.textContent = message;
+    box.appendChild(entry);
+    box.scrollTop = box.scrollHeight;
+  }
+  function clearLog(outputId) { document.getElementById(outputId).innerHTML = ''; }
+
+  // style.property
+  function setColor() {
+    var box = document.getElementById('demo-style-box');
+    box.style.backgroundColor = '#2ecc71';
+    box.style.color = '#fff';
+    clearLog('output-style');
+    log('output-style', 'set: backgroundColor = #2ecc71, color = #fff');
+  }
+  function setSize() {
+    var box = document.getElementById('demo-style-box');
+    box.style.width = '180px';
+    box.style.height = '180px';
+    clearLog('output-style');
+    log('output-style', 'set: width = 180px, height = 180px');
+  }
+  function resetStyle() {
+    var box = document.getElementById('demo-style-box');
+    box.style.cssText = '';
+    clearLog('output-style');
+    log('output-style', 'reset: cssText cleared');
+  }
+  function applyCustomStyle() {
+    var box = document.getElementById('demo-style-box');
+    var bg = document.getElementById('input-bg').value;
+    var fs = document.getElementById('input-fs').value;
+    box.style.backgroundColor = bg;
+    box.style.fontSize = fs;
+    clearLog('output-style');
+    log('output-style', 'set: backgroundColor = ' + bg + ', fontSize = ' + fs);
+  }
+
+  // cssText
+  function setCssTextBatch() {
+    var box = document.getElementById('demo-csstext-box');
+    box.style.cssText = 'width: 200px; height: 200px; background: linear-gradient(135deg, #667eea, #764ba2); color: white; border-radius: 16px; display: flex; align-items: center; justify-content: center;';
+    clearLog('output-csstext');
+    log('output-csstext', 'batch set via cssText');
+  }
+  function getCssText() {
+    var box = document.getElementById('demo-csstext-box');
+    clearLog('output-csstext');
+    log('output-csstext', 'current cssText:');
+    log('output-csstext', box.style.cssText || '(empty)');
+  }
+  function resetStyle2() {
+    var box = document.getElementById('demo-csstext-box');
+    box.style.cssText = '';
+    clearLog('output-csstext');
+    log('output-csstext', 'reset');
+  }
+  function applyCssText() {
+    var box = document.getElementById('demo-csstext-box');
+    var text = document.getElementById('csstext-input').value;
+    box.style.cssText = text;
+    clearLog('output-csstext');
+    log('output-csstext', 'applied cssText: ' + text.substring(0, 60));
+  }
+
+  // setProperty
+  function setPropertyDemo() {
+    var box = document.getElementById('demo-setproperty-box');
+    box.style.setProperty('background-color', '#9b59b6');
+    box.style.setProperty('color', '#fff');
+    clearLog('output-setproperty');
+    log('output-setproperty', 'setProperty: background-color = #9b59b6');
+    document.getElementById('setproperty-info').textContent = 'Normal set -可以被覆盖';
+  }
+  function setPropertyImportant() {
+    var box = document.getElementById('demo-setproperty-box');
+    box.style.setProperty('opacity', '0.5', 'important');
+    clearLog('output-setproperty');
+    log('output-setproperty', 'setProperty with !important: opacity = 0.5');
+    document.getElementById('setproperty-info').textContent = 'important - 最高优先级';
+  }
+  function resetStyle3() {
+    var box = document.getElementById('demo-setproperty-box');
+    box.style.cssText = '';
+    clearLog('output-setproperty');
+    document.getElementById('setproperty-info').textContent = 'Click buttons to compare';
+  }
+  function applySetProperty() {
+    var box = document.getElementById('demo-setproperty-box');
+    var name = document.getElementById('prop-name').value;
+    var value = document.getElementById('prop-value').value;
+    var important = document.getElementById('prop-important').checked;
+    box.style.setProperty(name, value, important ? 'important' : '');
+    clearLog('output-setproperty');
+    log('output-setproperty', "setProperty('" + name + "', '" + value + "', '" + (important ? 'important' : '') + "')");
+  }
+
+  // getPropertyValue
+  function getPropertyDemo() {
+    var box = document.getElementById('demo-getproperty-box');
+    clearLog('output-getproperty');
+    log('output-getproperty', 'inline properties:');
+    for (var i = 0; i < box.style.length; i++) {
+      var prop = box.style.item(i);
+      log('output-getproperty', prop + ': ' + box.style.getPropertyValue(prop));
+    }
+    if (box.style.length === 0) log('output-getproperty', '(no inline styles)');
+  }
+  function getAllProperties() {
+    var box = document.getElementById('demo-getproperty-box');
+    clearLog('output-getproperty');
+    log('output-getproperty', 'for...of iteration:');
+    for (const prop of box.style) {
+      log('output-getproperty', prop + ': ' + box.style.getPropertyValue(prop));
+    }
+    log('output-getproperty', 'total: ' + box.style.length);
+  }
+  function queryProperty() {
+    var box = document.getElementById('demo-getproperty-box');
+    var prop = document.getElementById('query-prop').value;
+    var val = box.style.getPropertyValue(prop);
+    clearLog('output-getproperty');
+    log('output-getproperty', "getPropertyValue('" + prop + "') = '" + val + "'");
+  }
+  function queryPropertyPreset(p) {
+    document.getElementById('query-prop').value = p;
+    queryProperty();
+  }
+
+  // removeProperty
+  var pendingRemove = '';
+  function removePropertyDemo() {
+    var box = document.getElementById('demo-removeproperty-box');
+    var val = box.style.removeProperty('opacity');
+    clearLog('output-removeproperty');
+    log('output-removeproperty', "removeProperty('opacity') returned: '" + val + "'");
+  }
+  function removePropertyBg() {
+    var box = document.getElementById('demo-removeproperty-box');
+    var val = box.style.removeProperty('background-color');
+    clearLog('output-removeproperty');
+    log('output-removeproperty', "removeProperty('background-color') returned: '" + val + "'");
+  }
+  function resetStyle4() {
+    var box = document.getElementById('demo-removeproperty-box');
+    box.style.cssText = '';
+    pendingRemove = '';
+    document.getElementById('pending-remove').textContent = 'none';
+    clearLog('output-removeproperty');
+  }
+  function removePropSelect(prop) {
+    pendingRemove = prop;
+    document.getElementById('pending-remove').textContent = prop;
+  }
+  function applyRemoveProperty() {
+    if (!pendingRemove) return;
+    var box = document.getElementById('demo-removeproperty-box');
+    var val = box.style.removeProperty(pendingRemove);
+    clearLog('output-removeproperty');
+    log('output-removeproperty', "removeProperty('" + pendingRemove + "') = '" + val + "'");
+    pendingRemove = '';
+    document.getElementById('pending-remove').textContent = 'none';
+  }
+
+  // getComputedStyle
+  function getComputedDemo() {
+    var box = document.getElementById('demo-computed-box');
+    var computed = window.getComputedStyle(box);
+    var grid = document.getElementById('computed-grid');
+    document.getElementById('computed-results').style.display = 'block';
+    grid.innerHTML = '';
+    var props = ['width', 'height', 'backgroundColor', 'color', 'fontSize', 'borderRadius', 'padding', 'display'];
+    props.forEach(function(p) {
+      var item = document.createElement('div');
+      item.className = 'computed-item';
+      item.innerHTML = '<div class="label">' + p + '</div><div class="value">' + computed[p] + '</div>';
+      grid.appendChild(item);
+    });
+    clearLog('output-computed');
+    log('output-computed', 'computed style:');
+    props.forEach(function(p) { log('output-computed', p + ': ' + computed[p]); });
+  }
+  function getPseudoElement() {
+    var box = document.getElementById('demo-computed-box');
+    var computed = window.getComputedStyle(box, '::before');
+    clearLog('output-computed');
+    log('output-computed', '::before pseudo element:');
+    log('output-computed', 'display: ' + computed.display);
+    log('output-computed', 'content: ' + computed.content);
+  }
+
+  // getBoundingClientRect
+  function updateRectDisplay() {
+    var box = document.getElementById('demo-rect-box');
+    var rect = box.getBoundingClientRect();
+    document.getElementById('rect-top').textContent = rect.top.toFixed(1);
+    document.getElementById('rect-left').textContent = rect.left.toFixed(1);
+    document.getElementById('rect-right').textContent = rect.right.toFixed(1);
+    document.getElementById('rect-bottom').textContent = rect.bottom.toFixed(1);
+    document.getElementById('rect-width').textContent = rect.width.toFixed(1);
+    document.getElementById('rect-height').textContent = rect.height.toFixed(1);
+  }
+  function getBoundingDemo() {
+    var box = document.getElementById('demo-rect-box');
+    var rect = box.getBoundingClientRect();
+    clearLog('output-rect');
+    log('output-rect', 'getBoundingClientRect():');
+    log('output-rect', 'top: ' + rect.top + ', left: ' + rect.left);
+    log('output-rect', 'right: ' + rect.right + ', bottom: ' + rect.bottom);
+    log('output-rect', 'width: ' + rect.width + ', height: ' + rect.height);
+    updateRectDisplay();
+  }
+  function resetRect() {
+    var box = document.getElementById('demo-rect-box');
+    box.style.left = '20px';
+    box.style.top = '20px';
+    clearLog('output-rect');
+    log('output-rect', 'position reset to 20px, 20px');
+    updateRectDisplay();
+  }
+  var dragging = false;
+  function startDrag() {
+    var box = document.getElementById('demo-rect-box');
+    var viewport = document.getElementById('rect-viewport');
+    dragging = true;
+    box.style.cursor = 'grabbing';
+    clearLog('output-rect');
+    log('output-rect', 'Drag enabled - drag the box');
+    function onMove(e) {
+      if (!dragging) return;
+      var clientX = e.clientX || (e.touches && e.touches[0].clientX);
+      var clientY = e.clientY || (e.touches && e.touches[0].clientY);
+      var vpRect = viewport.getBoundingClientRect();
+      var boxRect = box.getBoundingClientRect();
+      var newLeft = clientX - vpRect.left - boxRect.width / 2;
+      var newTop = clientY - vpRect.top - boxRect.height / 2;
+      newLeft = Math.max(0, Math.min(newLeft, vpRect.width - boxRect.width));
+      newTop = Math.max(0, Math.min(newTop, vpRect.height - boxRect.height));
+      box.style.left = newLeft + 'px';
+      box.style.top = newTop + 'px';
+      updateRectDisplay();
+    }
+    function onUp() {
+      dragging = false;
+      box.style.cursor = 'move';
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    }
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  }
+  updateRectDisplay();
+})();

--- a/examples/css/demos/img-placeholder/index.html
+++ b/examples/css/demos/img-placeholder/index.html
@@ -1,0 +1,583 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>img 标签背景色占位演示</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f0f0f;
+      color: #fff;
+      min-height: 100vh;
+      padding: 24px;
+    }
+
+    h1 {
+      font-size: 24px;
+      margin-bottom: 8px;
+    }
+
+    .subtitle {
+      color: #888;
+      margin-bottom: 32px;
+      font-size: 14px;
+    }
+
+    .demo-section {
+      margin-bottom: 48px;
+    }
+
+    .demo-title {
+      font-size: 16px;
+      color: #4fc3f7;
+      margin-bottom: 16px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .demo-title::before {
+      content: '';
+      display: block;
+      width: 8px;
+      height: 8px;
+      background: #4fc3f7;
+      border-radius: 50%;
+    }
+
+    .problem-box {
+      background: #1a1a1a;
+      border: 1px solid #333;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 16px;
+    }
+
+    .problem-box h3 {
+      color: #ef5350;
+      font-size: 14px;
+      margin-bottom: 12px;
+    }
+
+    .problem-box p {
+      color: #888;
+      font-size: 13px;
+      line-height: 1.6;
+    }
+
+    /* ========== Demo 1: Direct img bg (wrong) ========== */
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 24px;
+    }
+
+    .demo-card {
+      background: #1a1a1a;
+      border: 1px solid #333;
+      border-radius: 12px;
+      padding: 24px;
+    }
+
+    .demo-card h4 {
+      font-size: 14px;
+      margin-bottom: 12px;
+      color: #aaa;
+    }
+
+    .demo-label {
+      font-size: 12px;
+      color: #666;
+      margin-bottom: 8px;
+    }
+
+    /* Wrong approach */
+    .img-wrong {
+      width: 100%;
+      height: 150px;
+      background-color: #e0e0e0; /* Won't work as expected */
+      border-radius: 8px;
+      margin-bottom: 12px;
+    }
+
+    .img-wrong img {
+      width: 100%;
+      height: 100%;
+    }
+
+    /* Correct approach */
+    .img-correct {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      background-color: #e0e0e0;
+      border-radius: 8px;
+      position: relative;
+      overflow: hidden;
+      margin-bottom: 12px;
+    }
+
+    .img-correct img {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+
+    .img-correct img.loaded {
+      opacity: 1;
+    }
+
+    /* ========== Demo 2: Loading skeleton ========== */
+    .skeleton {
+      background: linear-gradient(
+        90deg,
+        #2a2a2a 0%,
+        #3a3a3a 50%,
+        #2a2a2a 100%
+      );
+      background-size: 200% 100%;
+      animation: shimmer 1.5s infinite;
+      border-radius: 8px;
+    }
+
+    .skeleton-wrapper {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      position: relative;
+      margin-bottom: 12px;
+    }
+
+    .skeleton-img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+
+    .skeleton-img.loaded {
+      opacity: 1;
+    }
+
+    @keyframes shimmer {
+      0% { background-position: 200% 0; }
+      100% { background-position: -200% 0; }
+    }
+
+    /* ========== Demo 3: Avatar placeholder ========== */
+    .avatar-demo {
+      display: flex;
+      gap: 24px;
+      align-items: center;
+    }
+
+    .avatar {
+      width: 80px;
+      height: 80px;
+      border-radius: 50%;
+      background-color: #3a3a3a;
+      overflow: hidden;
+      position: relative;
+      flex-shrink: 0;
+    }
+
+    .avatar img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      opacity: 0;
+      transition: opacity 0.3s ease;
+    }
+
+    .avatar img.loaded {
+      opacity: 1;
+    }
+
+    .avatar.large {
+      width: 120px;
+      height: 120px;
+    }
+
+    .avatar.small {
+      width: 48px;
+      height: 48px;
+    }
+
+    /* ========== Demo 4: Error state ========== */
+    .error-state {
+      position: relative;
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      background-color: #2a2a2a;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    .error-placeholder {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      color: #666;
+    }
+
+    .error-placeholder .icon {
+      font-size: 48px;
+      margin-bottom: 8px;
+    }
+
+    .error-placeholder .text {
+      font-size: 14px;
+    }
+
+    .error-state img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .error-state img.hidden {
+      display: none;
+    }
+
+    /* ========== Demo 5: Hover zoom ========== */
+    .img-hover-wrapper {
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      background-color: #e0e0e0;
+      border-radius: 8px;
+      overflow: hidden;
+      position: relative;
+      margin-bottom: 12px;
+    }
+
+    .img-hover-wrapper img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      opacity: 0;
+      transition: opacity 0.3s ease, transform 0.3s ease;
+    }
+
+    .img-hover-wrapper img.loaded {
+      opacity: 1;
+    }
+
+    .img-hover-wrapper:hover img {
+      transform: scale(1.05);
+    }
+
+    /* ========== Controls ========== */
+    .controls {
+      margin-top: 16px;
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+    }
+
+    .control-btn {
+      padding: 8px 16px;
+      background: #333;
+      border: 1px solid #444;
+      border-radius: 8px;
+      color: #fff;
+      font-size: 13px;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .control-btn:hover {
+      background: #444;
+      border-color: #555;
+    }
+
+    .control-btn.active {
+      background: #4fc3f7;
+      border-color: #4fc3f7;
+      color: #000;
+    }
+
+    .control-btn.danger {
+      background: #c62828;
+      border-color: #c62828;
+    }
+
+    /* ========== Toast ========== */
+    .toast {
+      position: fixed;
+      bottom: 24px;
+      left: 50%;
+      transform: translateX(-50%) translateY(100px);
+      background: #333;
+      border: 1px solid #555;
+      border-radius: 12px;
+      padding: 12px 24px;
+      font-size: 14px;
+      opacity: 0;
+      transition: all 0.3s ease;
+      z-index: 2000;
+    }
+
+    .toast.show {
+      transform: translateX(-50%) translateY(0);
+      opacity: 1;
+    }
+
+    .toast.success {
+      background: #1b5e20;
+      border-color: #2e7d32;
+    }
+
+    .toast.error {
+      background: #b71c1c;
+      border-color: #c62828;
+    }
+
+    .info-box {
+      background: #1a1a1a;
+      border: 1px solid #333;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 16px;
+      font-size: 13px;
+      color: #888;
+    }
+
+    .info-box code {
+      background: #2a2a2a;
+      padding: 2px 6px;
+      border-radius: 4px;
+      color: #4fc3f7;
+      font-size: 12px;
+    }
+  </style>
+</head>
+<body>
+  <div class="toast" id="toast"></div>
+
+  <h1>img 标签无图片时背景色控制</h1>
+  <p class="subtitle">学习如何使用 CSS 控制 img 标签在无图片或加载失败时的背景色占位</p>
+
+  <!-- Demo 1: Wrong vs Correct -->
+  <div class="demo-section">
+    <div class="demo-title">Demo 1: 错误方案 vs 正确方案</div>
+    <div class="problem-box">
+      <h3>⚠️ 问题说明</h3>
+      <p>直接给 img 元素设置 background-color 在图片加载失败时不会显示，
+         因为 img 是替换元素，其渲染由 src 内容决定。需要使用 wrapper 元素来实现背景色占位。</p>
+    </div>
+    
+    <div class="demo-grid">
+      <div class="demo-card">
+        <h4>❌ 错误方案</h4>
+        <div class="demo-label">直接在 img 上设置 background-color</div>
+        <div class="img-wrong">
+          <img src="invalid-url-12345.jpg" alt="无效图片">
+        </div>
+        <div class="info-box">
+          图片加载失败，但背景色未显示。<br>
+          浏览器显示默认破碎图标。
+        </div>
+      </div>
+
+      <div class="demo-card">
+        <h4>✅ 正确方案</h4>
+        <div class="demo-label">使用 wrapper + background-color</div>
+        <div class="img-correct">
+          <img src="invalid-url-12345.jpg" alt="无效图片"
+               onload="this.classList.add('loaded')"
+               onerror="this.style.display='none'">
+        </div>
+        <div class="info-box">
+          使用 wrapper 作为背景色容器，<br>
+          图片绝对定位覆盖。
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Demo 2: Loading Skeleton -->
+  <div class="demo-section">
+    <div class="demo-title">Demo 2: 骨架屏加载动画</div>
+    <div class="demo-grid">
+      <div class="demo-card">
+        <h4>骨架屏效果</h4>
+        <div class="skeleton-wrapper">
+          <div class="skeleton"></div>
+          <img class="skeleton-img" src="https://picsum.photos/800/450?random=1" 
+               alt="加载中..."
+               onload="this.classList.add('loaded')"
+               onerror="this.style.display='none'">
+        </div>
+        <div class="info-box">
+          使用 shimmer 动画模拟加载中状态，<br>
+          图片加载完成后淡入显示。
+        </div>
+      </div>
+
+      <div class="demo-card">
+        <h4>淡入动画</h4>
+        <div class="skeleton-wrapper">
+          <div class="skeleton"></div>
+          <img class="skeleton-img" src="https://picsum.photos/800/450?random=2"
+               alt="加载中..."
+               onload="this.classList.add('loaded'); this.parentElement.querySelector('.skeleton').style.display='none'"
+               onerror="this.style.display='none'">
+        </div>
+        <div class="info-box">
+          点击按钮模拟加载延迟，<br>
+          观察骨架屏到图片的过渡。
+        </div>
+        <div class="controls">
+          <button class="control-btn" onclick="reloadImage(this)">重新加载</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Demo 3: Avatar Placeholder -->
+  <div class="demo-section">
+    <div class="demo-title">Demo 3: 头像占位</div>
+    <div class="demo-card">
+      <div class="avatar-demo">
+        <div class="avatar large">
+          <img src="invalid-avatar.jpg" alt="大头像"
+               onerror="this.style.display='none'">
+        </div>
+        <div class="avatar">
+          <img src="https://picsum.photos/200?random=10" alt="中头像"
+               onload="this.classList.add('loaded')"
+               onerror="this.style.display='none'">
+        </div>
+        <div class="avatar small">
+          <img src="https://picsum.photos/100?random=11" alt="小头像"
+               onload="this.classList.add('loaded')"
+               onerror="this.style.display='none'">
+        </div>
+      </div>
+      <div class="info-box" style="margin-top: 16px;">
+        圆形头像占位：大/中/小三种尺寸。<br>
+        左侧为加载失败的占位效果，右侧为加载成功。
+      </div>
+    </div>
+  </div>
+
+  <!-- Demo 4: Error State -->
+  <div class="demo-section">
+    <div class="demo-title">Demo 4: 自定义错误状态</div>
+    <div class="demo-grid">
+      <div class="demo-card">
+        <h4>图片加载失败</h4>
+        <div class="error-state">
+          <div class="error-placeholder">
+            <div class="icon">🖼️</div>
+            <div class="text">图片加载失败</div>
+          </div>
+          <img src="error-test.jpg" alt="错误图片"
+               onerror="this.classList.add('hidden')">
+        </div>
+        <div class="info-box">
+          使用 ::after 或绝对定位元素显示错误占位，<br>
+          当图片加载失败时显示友好的错误提示。
+        </div>
+      </div>
+
+      <div class="demo-card">
+        <h4>空 src 状态</h4>
+        <div class="error-state">
+          <div class="error-placeholder">
+            <div class="icon">📷</div>
+            <div class="text">暂无图片</div>
+          </div>
+          <img src="" alt="空图片">
+        </div>
+        <div class="info-box">
+          当 src 为空时，浏览器会尝试加载当前页面 URL，<br>
+          导致不必要的请求。建议设置 placeholder。
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Demo 5: Hover Zoom -->
+  <div class="demo-section">
+    <div class="demo-title">Demo 5: 背景色 + Hover 缩放</div>
+    <div class="demo-grid">
+      <div class="demo-card">
+        <h4>Hover 效果</h4>
+        <div class="img-hover-wrapper">
+          <img src="https://picsum.photos/800/450?random=5" alt="示例图片"
+               onload="this.classList.add('loaded')"
+               onerror="this.style.display='none'">
+        </div>
+        <div class="info-box">
+          鼠标悬停时图片放大，wrapper 的背景色<br>
+          作为占位底色，视觉效果流畅。
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function showToast(message, type = '') {
+      const toast = document.getElementById('toast');
+      toast.textContent = message;
+      toast.className = 'toast show ' + type;
+      setTimeout(() => {
+        toast.className = 'toast';
+      }, 2000);
+    }
+
+    function reloadImage(btn) {
+      const wrapper = btn.closest('.demo-card').querySelector('.skeleton-wrapper');
+      const img = wrapper.querySelector('img');
+      const skeleton = wrapper.querySelector('.skeleton');
+      
+      // Reset state
+      skeleton.style.display = 'block';
+      skeleton.style.animation = 'none';
+      skeleton.offsetHeight; // Trigger reflow
+      skeleton.style.animation = 'shimmer 1.5s infinite';
+      img.classList.remove('loaded');
+      img.style.display = 'block';
+      
+      // Randomize src to force reload
+      img.src = 'https://picsum.photos/800/450?random=' + Math.random();
+      
+      img.onload = function() {
+        this.classList.add('loaded');
+        skeleton.style.display = 'none';
+        showToast('✓ 图片加载成功', 'success');
+      };
+      
+      img.onerror = function() {
+        this.style.display = 'none';
+        showToast('✗ 图片加载失败', 'error');
+      };
+    }
+
+    // Initialize loaded images
+    document.querySelectorAll('img[src]').forEach(img => {
+      if (img.complete && img.naturalHeight !== 0) {
+        img.classList.add('loaded');
+      }
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/input-styling/index.html
+++ b/examples/css/demos/input-styling/index.html
@@ -1,0 +1,401 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Input 样式完全指南</title>
+  <style>
+    *{margin:0;padding:0;box-sizing:border-box}
+    body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;line-height:1.6;color:#333;background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);min-height:100vh;padding:20px}
+    .container{max-width:1200px;margin:0 auto}
+    h1{text-align:center;color:#fff;font-size:2rem;margin-bottom:10px}
+    .subtitle{text-align:center;color:rgba(255,255,255,0.9);margin-bottom:30px}
+    .tabs{display:flex;flex-wrap:wrap;gap:8px;background:rgba(255,255,255,0.1);padding:8px;border-radius:12px;margin-bottom:24px}
+    .tab-btn{padding:10px 20px;border:none;background:transparent;color:rgba(255,255,255,0.8);font-size:14px;font-weight:500;border-radius:8px;cursor:pointer;transition:all 0.2s}
+    .tab-btn:hover{background:rgba(255,255,255,0.2);color:#fff}
+    .tab-btn.active{background:#fff;color:#667eea}
+    .tab-content{display:none;background:#fff;border-radius:16px;padding:32px;box-shadow:0 10px 40px rgba(0,0,0,0.2)}
+    .tab-content.active{display:block}
+    .section-title{font-size:1.5rem;color:#333;margin-bottom:20px;padding-bottom:10px;border-bottom:2px solid #667eea}
+    .demo-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:24px;margin-bottom:32px}
+    .demo-card{background:#f8f9fa;border-radius:12px;padding:20px}
+    .demo-card h3{font-size:1rem;color:#666;margin-bottom:16px}
+    .input-group{margin-bottom:16px}
+    .input-group label{display:block;font-size:14px;color:#666;margin-bottom:8px;font-weight:500}
+    .basic-input{width:100%;padding:12px 16px;border:1px solid #d1d1d6;border-radius:8px;font-size:16px;transition:all 0.2s}
+    .basic-input:focus{border-color:#667eea;outline:none;box-shadow:0 0 0 3px rgba(102,126,234,0.2)}
+    .basic-input::placeholder{color:#c7c7cc}
+    .float-label{position:relative}
+    .float-label input,.float-label textarea{width:100%;padding:24px 16px 8px;border:1px solid #d1d1d6;border-radius:8px;font-size:16px;transition:all 0.2s}
+    .float-label textarea{min-height:100px;resize:vertical;padding-top:32px}
+    .float-label label{position:absolute;left:16px;top:50%;transform:translateY(-50%);font-size:16px;color:#8e8e93;pointer-events:none;transition:all 0.2s}
+    .float-label textarea~label{top:24px}
+    .float-label input:focus~label,.float-label input:not(:placeholder-shown)~label,.float-label textarea:focus~label,.float-label textarea:not(:placeholder-shown)~label{top:12px;font-size:12px;color:#667eea;transform:none}
+    .float-label input:focus,.float-label textarea:focus{border-color:#667eea;outline:none}
+    .input-icon-wrapper{position:relative}
+    .input-icon-wrapper input{width:100%;padding:12px 16px 12px 44px;border:1px solid #d1d1d6;border-radius:8px;font-size:16px;transition:all 0.2s}
+    .input-icon-wrapper .icon{position:absolute;left:14px;top:50%;transform:translateY(-50%);width:20px;height:20px;color:#8e8e93;transition:color 0.2s}
+    .input-icon-wrapper input:focus{border-color:#667eea;outline:none}
+    .input-icon-wrapper input:focus~.icon{color:#667eea}
+    .search-input{width:100%;max-width:320px;padding:12px 16px 12px 44px;border:1px solid #e5e5ea;border-radius:24px;font-size:14px;background:#f2f2f7 url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24' stroke='%238e8e93' stroke-width='2'%3E%3Ccircle cx='11' cy='11' r='8'/%3E%3Cpath d='m21 21-4.35-4.35'/%3E%3C/svg%3E") no-repeat 16px center;transition:all 0.2s;appearance:none;-webkit-appearance:none}
+    .search-input:focus{background-color:#fff;border-color:#667eea;outline:none}
+    .password-field{position:relative;width:100%;max-width:320px}
+    .password-field input{width:100%;padding:12px 48px 12px 16px;border:1px solid #d1d1d6;border-radius:8px;font-size:16px;transition:all 0.2s}
+    .password-field input:focus{border-color:#667eea;outline:none}
+    .password-field .toggle-visibility{position:absolute;right:12px;top:50%;transform:translateY(-50%);background:none;border:none;cursor:pointer;padding:4px;color:#8e8e93}
+    .password-field .toggle-visibility:hover{color:#667eea}
+    .password-field .toggle-visibility svg{width:20px;height:20px;display:block}
+    .number-input-wrapper{display:flex;align-items:center;gap:8px;width:fit-content}
+    .number-input-wrapper input{width:100px;height:40px;text-align:center;border:1px solid #d1d1d6;border-radius:8px;font-size:16px;-moz-appearance:textfield}
+    .number-input-wrapper input::-webkit-inner-spin-button,.number-input-wrapper input::-webkit-outer-spin-button{-webkit-appearance:none;margin:0}
+    .number-input-wrapper button{width:36px;height:36px;border:1px solid #d1d1d6;border-radius:8px;background:#fff;font-size:18px;cursor:pointer;transition:all 0.2s}
+    .number-input-wrapper button:hover{background:#f2f2f7;border-color:#667eea;color:#667eea}
+    .checkbox-wrapper{display:flex;align-items:center;gap:12px;cursor:pointer;user-select:none;padding:12px;background:#fff;border-radius:8px;border:1px solid #e5e5ea;transition:all 0.2s}
+    .checkbox-wrapper:hover{border-color:#667eea}
+    .checkbox-wrapper input[type="checkbox"]{position:absolute;opacity:0;width:0;height:0}
+    .checkbox-wrapper .checkmark{width:22px;height:22px;border:2px solid #d1d1d6;border-radius:6px;display:flex;align-items:center;justify-content:center;transition:all 0.2s;flex-shrink:0}
+    .checkbox-wrapper .checkmark svg{width:14px;height:14px;color:#fff;opacity:0;transform:scale(0.5);transition:all 0.2s}
+    .checkbox-wrapper input[type="checkbox"]:checked+.checkmark{background:#667eea;border-color:#667eea}
+    .checkbox-wrapper input[type="checkbox"]:checked+.checkmark svg{opacity:1;transform:scale(1)}
+    .checkbox-wrapper .label-text{font-size:14px;color:#333}
+    .radio-wrapper{display:flex;align-items:center;gap:12px;cursor:pointer;user-select:none;padding:12px;background:#fff;border-radius:8px;border:1px solid #e5e5ea;transition:all 0.2s}
+    .radio-wrapper:hover{border-color:#667eea}
+    .radio-wrapper input[type="radio"]{position:absolute;opacity:0;width:0;height:0}
+    .radio-wrapper .radiomark{width:22px;height:22px;border:2px solid #d1d1d6;border-radius:50%;display:flex;align-items:center;justify-content:center;transition:all 0.2s;flex-shrink:0}
+    .radio-wrapper .radiomark::after{content:'';width:10px;height:10px;border-radius:50%;background:#667eea;transform:scale(0);transition:transform 0.2s}
+    .radio-wrapper input[type="radio"]:checked+.radiomark{border-color:#667eea}
+    .radio-wrapper input[type="radio"]:checked+.radiomark::after{transform:scale(1)}
+    .switch-wrapper{display:flex;align-items:center;gap:12px;cursor:pointer;padding:12px;background:#fff;border-radius:8px;border:1px solid #e5e5ea}
+    .switch-wrapper input[type="checkbox"]{position:absolute;opacity:0;width:0;height:0}
+    .switch{width:52px;height:32px;background:#e5e5ea;border-radius:16px;position:relative;transition:background-color 0.3s;flex-shrink:0}
+    .switch::after{content:'';position:absolute;left:2px;top:2px;width:28px;height:28px;background:#fff;border-radius:50%;box-shadow:0 2px 4px rgba(0,0,0,0.2);transition:transform 0.3s}
+    .switch-wrapper input[type="checkbox"]:checked+.switch{background:#667eea}
+    .switch-wrapper input[type="checkbox"]:checked+.switch::after{transform:translateX(20px)}
+    .range-wrapper{width:100%;max-width:300px}
+    .range-wrapper .range-value{text-align:center;font-size:24px;font-weight:600;color:#667eea;margin-bottom:12px}
+    .range-wrapper input[type="range"]{width:100%;height:6px;background:#e5e5ea;border-radius:3px;outline:none;appearance:none;-webkit-appearance:none}
+    .range-wrapper input[type="range"]::-webkit-slider-thumb{appearance:none;-webkit-appearance:none;width:24px;height:24px;background:linear-gradient(135deg,#667eea 0%,#764ba2 100%);border-radius:50%;cursor:pointer;box-shadow:0 2px 8px rgba(102,126,234,0.4);transition:transform 0.2s}
+    .range-wrapper input[type="range"]::-webkit-slider-thumb:hover{transform:scale(1.1)}
+    .select-wrapper{position:relative;width:100%;max-width:300px}
+    .select-wrapper select{width:100%;height:44px;padding:0 40px 0 16px;border:1px solid #d1d1d6;border-radius:8px;font-size:16px;background:#fff;cursor:pointer;appearance:none;-webkit-appearance:none;transition:all 0.2s}
+    .select-wrapper select:focus{border-color:#667eea;outline:none}
+    .select-wrapper::after{content:'';position:absolute;right:16px;top:50%;transform:translateY(-50%);width:0;height:0;border-left:6px solid transparent;border-right:6px solid transparent;border-top:8px solid #8e8e93;pointer-events:none}
+    .textarea-demo{width:100%;min-height:120px;padding:12px 16px;border:1px solid #d1d1d6;border-radius:8px;font-size:14px;font-family:inherit;line-height:1.5;resize:vertical;transition:all 0.2s}
+    .textarea-demo:focus{border-color:#667eea;outline:none}
+    .file-upload-wrapper{display:flex;flex-direction:column;align-items:center;gap:16px;padding:32px;border:2px dashed #d1d1d6;border-radius:12px;background:#f8f9fa;transition:all 0.2s;cursor:pointer}
+    .file-upload-wrapper:hover,.file-upload-wrapper.dragover{border-color:#667eea;background:rgba(102,126,234,0.05)}
+    .file-upload-wrapper input[type="file"]{display:none}
+    .file-upload-icon{width:48px;height:48px;color:#667eea}
+    .file-upload-text{font-size:14px;color:#666;text-align:center}
+    .file-upload-text strong{color:#667eea}
+    .validation-demo{display:flex;flex-direction:column;gap:16px}
+    .validation-input{width:100%;padding:12px 16px;border:2px solid #d1d1d6;border-radius:8px;font-size:16px;transition:all 0.2s}
+    .validation-input:focus{outline:none}
+    .validation-input.valid{border-color:#34c759;background:rgba(52,199,89,0.05)}
+    .validation-input.invalid{border-color:#ff3b30;background:rgba(255,59,48,0.05)}
+    .validation-message{font-size:13px;display:flex;align-items:center;gap:6px}
+    .validation-message.success{color:#34c759}
+    .validation-message.error{color:#ff3b30}
+    .quiz-container{background:#f8f9fa;border-radius:12px;padding:24px}
+    .quiz-question{font-size:1.1rem;font-weight:600;margin-bottom:16px;color:#333}
+    .quiz-options{display:flex;flex-direction:column;gap:12px}
+    .quiz-option{display:flex;align-items:center;gap:12px;padding:12px 16px;background:#fff;border:2px solid #e5e5ea;border-radius:8px;cursor:pointer;transition:all 0.2s}
+    .quiz-option:hover{border-color:#667eea}
+    .quiz-option.selected{border-color:#667eea;background:rgba(102,126,234,0.1)}
+    .quiz-option.correct{border-color:#34c759;background:rgba(52,199,89,0.1)}
+    .quiz-option.incorrect{border-color:#ff3b30;background:rgba(255,59,48,0.1)}
+    .quiz-submit{margin-top:20px;padding:12px 32px;background:#667eea;color:#fff;border:none;border-radius:8px;font-size:16px;font-weight:500;cursor:pointer;transition:all 0.2s}
+    .quiz-submit:hover{background:#5a67d2}
+    .quiz-submit:disabled{opacity:0.5;cursor:not-allowed}
+    .quiz-result{margin-top:16px;padding:16px;border-radius:8px;font-weight:500}
+    .quiz-result.success{background:rgba(52,199,89,0.1);color:#34c759}
+    .quiz-result.error{background:rgba(255,59,48,0.1);color:#ff3b30}
+    @media(max-width:768px){.container{padding:0 16px}h1{font-size:1.8rem}.tab-content{padding:20px}.demo-grid{grid-template-columns:1fr}.tabs{overflow-x:auto;flex-wrap:nowrap;-webkit-overflow-scrolling:touch}.tab-btn{white-space:nowrap}}
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Input 样式完全指南</h1>
+    <p class="subtitle">交互式演示 - 掌握所有 Input 样式技巧</p>
+    <div class="tabs">
+      <button class="tab-btn active" data-tab="basic">基础样式</button>
+      <button class="tab-btn" data-tab="checkbox-radio">Checkbox & Radio</button>
+      <button class="tab-btn" data-tab="switch-range">Switch & Range</button>
+      <button class="tab-btn" data-tab="select-file">Select & File</button>
+      <button class="tab-btn" data-tab="validation">验证状态</button>
+      <button class="tab-btn" data-tab="quiz">自测题</button>
+    </div>
+
+    <div class="tab-content active" id="basic">
+      <h2 class="section-title">基础 Input 样式</h2>
+      <div class="demo-grid">
+        <div class="demo-card">
+          <h3>文本输入框</h3>
+          <div class="input-group">
+            <label>默认样式</label>
+            <input type="text" class="basic-input" placeholder="请输入文字...">
+          </div>
+          <div class="input-group">
+            <label>禁用状态</label>
+            <input type="text" class="basic-input" placeholder="禁用输入框" disabled>
+          </div>
+        </div>
+        <div class="demo-card">
+          <h3>浮动标签 (Floating Label)</h3>
+          <div class="float-label">
+            <input type="text" id="float1" placeholder=" ">
+            <label for="float1">用户名</label>
+          </div>
+          <br><br>
+          <div class="float-label">
+            <textarea id="float2" placeholder=" "></textarea>
+            <label for="float2">评论</label>
+          </div>
+        </div>
+        <div class="demo-card">
+          <h3>带图标的输入框</h3>
+          <div class="input-icon-wrapper">
+            <input type="text" placeholder="搜索...">
+            <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.35-4.35"/></svg>
+          </div>
+        </div>
+        <div class="demo-card">
+          <h3>搜索框</h3>
+          <input type="search" class="search-input" placeholder="搜索...">
+        </div>
+        <div class="demo-card">
+          <h3>密码输入框</h3>
+          <div class="password-field">
+            <input type="password" id="pwdDemo" placeholder="请输入密码" value="123456">
+            <button type="button" class="toggle-visibility" onclick="togglePwd()">
+              <svg class="icon-show" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+              <svg class="icon-hide" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="display:none"><path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"/><line x1="1" y1="1" x2="23" y2="23"/></svg>
+            </button>
+          </div>
+        </div>
+        <div class="demo-card">
+          <h3>数字输入框</h3>
+          <div class="number-input-wrapper">
+            <button onclick="adjustNum(-1)">-</button>
+            <input type="number" id="numDemo" value="0" min="0" max="100">
+            <button onclick="adjustNum(1)">+</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="tab-content" id="checkbox-radio">
+      <h2 class="section-title">Checkbox 与 Radio 样式</h2>
+      <div class="demo-grid">
+        <div class="demo-card">
+          <h3>Checkbox 多选框</h3>
+          <label class="checkbox-wrapper">
+            <input type="checkbox">
+            <span class="checkmark"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
+            <span class="label-text">同意用户协议</span>
+          </label>
+          <br><br>
+          <label class="checkbox-wrapper">
+            <input type="checkbox" checked>
+            <span class="checkmark"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
+            <span class="label-text">已选中</span>
+          </label>
+          <br><br>
+          <label class="checkbox-wrapper">
+            <input type="checkbox" disabled>
+            <span class="checkmark"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><polyline points="20 6 9 17 4 12"/></svg></span>
+            <span class="label-text">禁用</span>
+          </label>
+        </div>
+        <div class="demo-card">
+          <h3>Radio 单选框</h3>
+          <label class="radio-wrapper">
+            <input type="radio" name="demo" checked>
+            <span class="radiomark"></span>
+            <span class="label-text">选项 A</span>
+          </label>
+          <br><br>
+          <label class="radio-wrapper">
+            <input type="radio" name="demo">
+            <span class="radiomark"></span>
+            <span class="label-text">选项 B</span>
+          </label>
+          <br><br>
+          <label class="radio-wrapper">
+            <input type="radio" name="demo">
+            <span class="radiomark"></span>
+            <span class="label-text">选项 C</span>
+          </label>
+        </div>
+      </div>
+    </div>
+
+    <div class="tab-content" id="switch-range">
+      <h2 class="section-title">Switch 开关与 Range 滑块</h2>
+      <div class="demo-grid">
+        <div class="demo-card">
+          <h3>Switch 开关</h3>
+          <label class="switch-wrapper">
+            <input type="checkbox">
+            <span class="switch"></span>
+            <span class="label-text">接收通知</span>
+          </label>
+          <br><br>
+          <label class="switch-wrapper">
+            <input type="checkbox" checked>
+            <span class="switch"></span>
+            <span class="label-text">深色模式</span>
+          </label>
+        </div>
+        <div class="demo-card">
+          <h3>Range 滑块</h3>
+          <div class="range-wrapper">
+            <div class="range-value" id="rangeVal">50</div>
+            <input type="range" id="rangeDemo" min="0" max="100" value="50">
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="tab-content" id="select-file">
+      <h2 class="section-title">Select 下拉框与 File 文件上传</h2>
+      <div class="demo-grid">
+        <div class="demo-card">
+          <h3>Select 下拉框</h3>
+          <div class="select-wrapper">
+            <select>
+              <option>请选择城市</option>
+              <option>北京</option>
+              <option>上海</option>
+              <option>广州</option>
+              <option>深圳</option>
+            </select>
+          </div>
+        </div>
+        <div class="demo-card">
+          <h3>Textarea 多行文本</h3>
+          <textarea class="textarea-demo" placeholder="请输入评论..."></textarea>
+        </div>
+        <div class="demo-card">
+          <h3>File 文件上传</h3>
+          <div class="file-upload-wrapper" onclick="document.getElementById('fileInput').click()">
+            <input type="file" id="fileInput" onchange="updateFileName()">
+            <svg class="file-upload-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg>
+            <div class="file-upload-text"><strong>点击上传</strong> 或拖拽文件</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="tab-content" id="validation">
+      <h2 class="section-title">验证状态样式</h2>
+      <div class="demo-grid">
+        <div class="demo-card">
+          <h3>邮箱验证</h3>
+          <div class="validation-demo">
+            <input type="email" class="validation-input" id="emailInput" placeholder="请输入邮箱" oninput="validateEmail()">
+            <div class="validation-message" id="emailMsg"></div>
+          </div>
+        </div>
+        <div class="demo-card">
+          <h3>密码强度</h3>
+          <div class="validation-demo">
+            <input type="password" class="validation-input" id="pwdInput" placeholder="请输入密码" oninput="validatePwd()">
+            <div class="validation-message" id="pwdMsg"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="tab-content" id="quiz">
+      <h2 class="section-title">自测题</h2>
+      <div class="quiz-container">
+        <div class="quiz-question">1. 如何完全重置 input 的默认浏览器样式？</div>
+        <div class="quiz-options">
+          <div class="quiz-option" data-correct="true" onclick="selectOpt(this)"><span>A. </span> appearance: none</div>
+          <div class="quiz-option" onclick="selectOpt(this)"><span>B. </span> display: none</div>
+          <div class="quiz-option" onclick="selectOpt(this)"><span>C. </span> visibility: hidden</div>
+          <div class="quiz-option" onclick="selectOpt(this)"><span>D. </span> opacity: 0</div>
+        </div>
+        <button class="quiz-submit" onclick="checkAns()">提交答案</button>
+        <div class="quiz-result" id="quizRes" style="display:none"></div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById(btn.dataset.tab).classList.add('active');
+      });
+    });
+
+    function togglePwd() {
+      const input = document.getElementById('pwdDemo');
+      const show = document.querySelector('.icon-show');
+      const hide = document.querySelector('.icon-hide');
+      if (input.type === 'password') { input.type = 'text'; show.style.display = 'none'; hide.style.display = 'block'; }
+      else { input.type = 'password'; show.style.display = 'block'; hide.style.display = 'none'; }
+    }
+
+    function adjustNum(delta) {
+      const input = document.getElementById('numDemo');
+      let v = parseInt(input.value) || 0;
+      input.value = Math.min(100, Math.max(0, v + delta));
+    }
+
+    document.getElementById('rangeDemo').addEventListener('input', e => {
+      document.getElementById('rangeVal').textContent = e.target.value;
+    });
+
+    function updateFileName() {
+      const f = document.getElementById('fileInput').files[0];
+      if (f) alert('已选择: ' + f.name);
+    }
+
+    function validateEmail() {
+      const input = document.getElementById('emailInput');
+      const msg = document.getElementById('emailMsg');
+      const v = input.value.trim();
+      if (!v) { input.classList.remove('valid','invalid'); msg.innerHTML = ''; return; }
+      const ok = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
+      input.classList.toggle('valid', ok);
+      input.classList.toggle('invalid', !ok);
+      msg.innerHTML = ok ? '✓ 格式正确' : '✗ 请输入有效邮箱';
+      msg.className = 'validation-message ' + (ok ? 'success' : 'error');
+    }
+
+    function validatePwd() {
+      const input = document.getElementById('pwdInput');
+      const msg = document.getElementById('pwdMsg');
+      const v = input.value;
+      if (!v) { input.classList.remove('valid','invalid'); msg.innerHTML = ''; return; }
+      const ok = v.length >= 6;
+      input.classList.toggle('valid', ok);
+      input.classList.toggle('invalid', !ok);
+      msg.innerHTML = ok ? '✓ 密码有效' : '✗ 密码至少6位';
+      msg.className = 'validation-message ' + (ok ? 'success' : 'error');
+    }
+
+    let selectedOpt = null;
+    function selectOpt(el) {
+      document.querySelectorAll('.quiz-option').forEach(o => o.classList.remove('selected'));
+      el.classList.add('selected');
+      selectedOpt = el;
+    }
+
+    function checkAns() {
+      if (!selectedOpt) { alert('请选择答案'); return; }
+      const isCorrect = selectedOpt.dataset.correct === 'true';
+      selectedOpt.classList.add(isCorrect ? 'correct' : 'incorrect');
+      const res = document.getElementById('quizRes');
+      res.style.display = 'block';
+      res.className = 'quiz-result ' + (isCorrect ? 'success' : 'error');
+      res.textContent = isCorrect ? '正确！appearance: none 可移除浏览器默认样式' : '错误，正确答案是 A';
+    }
+  </script>
+</body>
+</html>

--- a/examples/css/demos/mongodb-test-data/index.html
+++ b/examples/css/demos/mongodb-test-data/index.html
@@ -1,0 +1,702 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MongoDB 测试数据存储指南</title>
+  <style>
+    *{margin:0;padding:0;box-sizing:border-box}
+    body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;line-height:1.6;color:#333;background:linear-gradient(135deg,#11998e 0%,#38ef7d 100%);min-height:100vh;padding:20px}
+    .container{max-width:1200px;margin:0 auto}
+    h1{text-align:center;color:#fff;font-size:2rem;margin-bottom:10px;text-shadow:0 2px 4px rgba(0,0,0,0.2)}
+    .subtitle{text-align:center;color:rgba(255,255,255,0.9);margin-bottom:30px}
+    .tabs{display:flex;flex-wrap:wrap;gap:8px;background:rgba(255,255,255,0.1);padding:8px;border-radius:12px;margin-bottom:24px}
+    .tab-btn{padding:10px 20px;border:none;background:transparent;color:rgba(255,255,255,0.8);font-size:14px;font-weight:500;border-radius:8px;cursor:pointer;transition:all 0.2s}
+    .tab-btn:hover{background:rgba(255,255,255,0.2);color:#fff}
+    .tab-btn.active{background:#fff;color:#11998e}
+    .tab-content{display:none;background:#fff;border-radius:16px;padding:32px;box-shadow:0 10px 40px rgba(0,0,0,0.2)}
+    .tab-content.active{display:block}
+    .section-title{font-size:1.5rem;color:#333;margin-bottom:20px;padding-bottom:10px;border-bottom:2px solid #38ef7d}
+    .demo-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:24px;margin-bottom:32px}
+    .demo-card{background:#f8f9fa;border-radius:12px;padding:20px}
+    .demo-card h3{font-size:1rem;color:#666;margin-bottom:16px;display:flex;align-items:center;gap:8px}
+    .demo-card h3 .icon{width:24px;height:24px;color:#11998e}
+    .code-block{background:#1e1e1e;border-radius:8px;padding:16px;overflow-x:auto;margin-bottom:16px}
+    .code-block pre{margin:0;color:#d4d4d4;font-size:13px;line-height:1.5}
+    .code-block .keyword{color:#569cd6}
+    .code-block .string{color:#ce9178}
+    .code-block .function{color:#dcdcaa}
+    .code-block .comment{color:#6a9955}
+    .btn{padding:10px 20px;border:none;border-radius:8px;font-size:14px;font-weight:500;cursor:pointer;transition:all 0.2s}
+    .btn-primary{background:#11998e;color:#fff}
+    .btn-primary:hover{background:#0d7a70;transform:translateY(-1px)}
+    .btn-secondary{background:#e5e5ea;color:#333}
+    .btn-secondary:hover{background:#d1d1d6}
+    .output-area{background:#f8f9fa;border-radius:8px;padding:16px;min-height:100px;max-height:300px;overflow:auto;font-family:'Monaco','Menlo',monospace;font-size:13px;white-space:pre-wrap}
+    .output-area .success{color:#34c759}
+    .output-area .error{color:#ff3b30}
+    .output-area .info{color:#007aff}
+    .output-area .timestamp{color:#8e8e93;font-size:11px}
+    .badge{display:inline-block;padding:4px 8px;border-radius:4px;font-size:11px;font-weight:600}
+    .badge-js{background:#f7df1e;color:#000}
+    .badge-mongo{background:#47a248;color:#fff}
+    .badge-jest{background:#c21325;color:#fff}
+    .form-group{margin-bottom:16px}
+    .form-group label{display:block;font-size:14px;color:#666;margin-bottom:8px;font-weight:500}
+    .form-group input,.form-group select,.form-group textarea{width:100%;padding:10px 12px;border:1px solid #d1d1d6;border-radius:8px;font-size:14px;transition:border-color 0.2s}
+    .form-group input:focus,.form-group select:focus,.form-group textarea:focus{border-color:#11998e;outline:none}
+    .form-row{display:flex;gap:16px;flex-wrap:wrap}
+    .form-row .form-group{flex:1;min-width:200px}
+    .json-viewer{background:#1e1e1e;border-radius:8px;padding:16px;overflow:auto;max-height:400px}
+    .json-viewer pre{margin:0;color:#d4d4d4;font-size:13px}
+    .json-key{color:#9cdcfe}
+    .json-string{color:#ce9178}
+    .json-number{color:#b5cea8}
+    .json-boolean{color:#569cd6}
+    .json-null{color:#569cd6}
+    .quiz-container{background:#f8f9fa;border-radius:12px;padding:24px;margin-top:24px}
+    .quiz-question{font-size:1.1rem;font-weight:600;margin-bottom:16px;color:#333}
+    .quiz-options{display:flex;flex-direction:column;gap:12px}
+    .quiz-option{padding:12px 16px;background:#fff;border:2px solid #e5e5ea;border-radius:8px;cursor:pointer;transition:all 0.2s}
+    .quiz-option:hover{border-color:#11998e}
+    .quiz-option.correct{border-color:#34c759;background:rgba(52,199,89,0.1)}
+    .quiz-option.incorrect{border-color:#ff3b30;background:rgba(255,59,48,0.1)}
+    .quiz-result{margin-top:16px;padding:12px;border-radius:8px;font-weight:500}
+    .quiz-result.pass{background:rgba(52,199,89,0.1);color:#34c759}
+    .quiz-result.fail{background:rgba(255,59,48,0.1);color:#ff3b30}
+    .flex-center{display:flex;align-items:center;justify-content:center;gap:8px}
+    .mt-4{margin-top:16px}
+    .mb-4{margin-bottom:16px}
+    @media(max-width:768px){.container{padding:0 16px} .tab-content{padding:20px} h1{font-size:1.5rem} .demo-grid{grid-template-columns:1fr} }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>🍃 MongoDB 测试数据存储指南</h1>
+    <p class="subtitle">掌握 Factory 模式、数据播种工具与 Jest 集成</p>
+    
+    <div class="tabs">
+      <button class="tab-btn active" data-tab="factory">Factory 模式</button>
+      <button class="tab-btn" data-tab="seeding">数据播种</button>
+      <button class="tab-btn" data-tab="jest">Jest 集成</button>
+      <button class="tab-btn" data-tab="demo">交互演示</button>
+      <button class="tab-btn" data-tab="quiz">小测验</button>
+    </div>
+    
+    <!-- Factory 模式 -->
+    <div class="tab-content active" id="factory">
+      <h2 class="section-title">Factory 模式</h2>
+      <p class="mb-4">Factory 模式用于生成结构化的测试数据，避免手动创建每个文档。</p>
+      
+      <div class="demo-grid">
+        <div class="demo-card">
+          <h3><span class="icon">📦</span> UserFactory</h3>
+          <div class="code-block">
+            <pre><span class="keyword">class</span> <span class="function">UserFactory</span> {
+  <span class="keyword">static</span> <span class="function">create</span>(data = {}) {
+    <span class="keyword">return</span> {
+      name: data.name || <span class="keyword">this</span>.randomName(),
+      email: data.email || <span class="keyword">this</span>.randomEmail(),
+      age: data.age || <span class="keyword">this</span>.randomAge(),
+      createdAt: <span class="keyword">new</span> <span class="function">Date</span>()
+    };
+  }
+  
+  <span class="keyword">static</span> <span class="function">createMany</span>(count) {
+    <span class="keyword">return</span> Array.<span class="function">from</span>(
+      { length: count }, 
+      () => <span class="keyword">this</span>.<span class="function">create</span>()
+    );
+  }
+}</pre>
+          </div>
+          <button class="btn btn-primary" onclick="generateUsers()">生成 5 个用户</button>
+        </div>
+        
+        <div class="demo-card">
+          <h3><span class="icon">🛒</span> OrderFactory</h3>
+          <div class="code-block">
+            <pre><span class="keyword">class</span> <span class="function">OrderFactory</span> {
+  <span class="keyword">static</span> <span class="function">create</span>(data = {}) {
+    <span class="keyword">return</span> {
+      orderNo: <span class="string">`ORD${Date.now()}`</span>,
+      userId: data.userId,
+      items: data.items || [],
+      totalAmount: <span class="keyword">this</span>.<span class="function">calcTotal</span>(),
+      status: data.status || <span class="string">'pending'</span>
+    };
+  }
+}</pre>
+          </div>
+          <button class="btn btn-primary" onclick="generateOrders()">生成 3 个订单</button>
+        </div>
+      </div>
+      
+      <h3 style="margin:24px 0 16px">生成结果</h3>
+      <div class="json-viewer" id="factoryOutput">
+        <pre>点击按钮生成测试数据...</pre>
+      </div>
+    </div>
+    
+    <!-- 数据播种 -->
+    <div class="tab-content" id="seeding">
+      <h2 class="section-title">数据播种工具</h2>
+      <p class="mb-4">使用 mongo-seeding 从 JSON/JS 文件播种数据到 MongoDB。</p>
+      
+      <div class="demo-grid">
+        <div class="demo-card">
+          <h3><span class="icon">📁</span> 数据文件结构</h3>
+          <div class="code-block">
+            <pre><span class="comment">// data/users.json</span>
+[
+  {
+    <span class="json-key">"_id"</span>: <span class="json-string">"user-1"</span>,
+    <span class="json-key">"name"</span>: <span class="json-string">"张三"</span>,
+    <span class="json-key">"email"</span>: <span class="json-string">"zhangsan@example.com"</span>
+  }
+]</pre>
+          </div>
+        </div>
+        
+        <div class="demo-card">
+          <h3><span class="icon">⚙️</span> 播种配置</h3>
+          <div class="code-block">
+            <pre><span class="keyword">const</span> { Seeder } = <span class="function">require</span>(<span class="string">'mongo-seeding'</span>);
+
+<span class="keyword">const</span> seeder = <span class="keyword">new</span> <span class="function">Seeder</span>({
+  mongodb: {
+    host: <span class="string">'localhost'</span>,
+    port: <span class="string">27017</span>,
+    database: <span class="string">'test'</span>
+  }
+});</pre>
+          </div>
+        </div>
+      </div>
+      
+      <h3 style="margin:24px 0 16px">模拟播种流程</h3>
+      <div class="demo-card">
+        <div class="form-row mb-4">
+          <div class="form-group">
+            <label>数据库名称</label>
+            <input type="text" id="dbName" value="test_db" placeholder="数据库名称">
+          </div>
+          <div class="form-group">
+            <label>集合名称</label>
+            <input type="text" id="collectionName" value="users" placeholder="集合名称">
+          </div>
+          <div class="form-group">
+            <label>插入数量</label>
+            <input type="number" id="insertCount" value="10" min="1" max="100">
+          </div>
+        </div>
+        <button class="btn btn-primary" onclick="simulateSeeding()">执行播种</button>
+      </div>
+      
+      <div class="json-viewer mt-4" id="seedingOutput">
+        <pre>配置并点击"执行播种"开始...</pre>
+      </div>
+    </div>
+    
+    <!-- Jest 集成 -->
+    <div class="tab-content" id="jest">
+      <h2 class="section-title">Jest 集成</h2>
+      <p class="mb-4">使用 @shelf/jest-mongodb 进行完整的 MongoDB 集成测试。</p>
+      
+      <div class="demo-grid">
+        <div class="demo-card">
+          <h3><span class="icon">📝</span> jest.config.js</h3>
+          <div class="code-block">
+            <pre><span class="comment">// jest.config.js</span>
+<span class="keyword">module</span>.<span class="keyword">exports</span> = {
+  <span class="json-key">preset</span>: <span class="json-string">'@shelf/jest-mongodb'</span>
+};</pre>
+          </div>
+          <span class="badge badge-jest">Jest</span>
+          <span class="badge badge-mongo">MongoDB</span>
+        </div>
+        
+        <div class="demo-card">
+          <h3><span class="icon">🧪</span> 测试示例</h3>
+          <div class="code-block">
+            <pre><span class="keyword">describe</span>(<span class="string">'CRUD 测试'</span>, () => {
+  <span class="keyword">let</span> db;
+  
+  <span class="function">beforeAll</span>(<span class="keyword">async</span> () => {
+    db = <span class="keyword">await</span> <span class="function">connectToDb</span>();
+  });
+  
+  <span class="function">test</span>(<span class="string">'创建用户'</span>, <span class="keyword">async</span> () => {
+    <span class="keyword">const</span> user = { name: <span class="string">'测试'</span> };
+    <span class="keyword">const</span> result = <span class="keyword">await</span> db.<span class="function">insertOne</span>(user);
+    <span class="function">expect</span>(result.insertedId).<span class="function">toBeDefined</span>();
+  });
+});</pre>
+          </div>
+        </div>
+      </div>
+      
+      <h3 style="margin:24px 0 16px">模拟测试运行</h3>
+      <div class="demo-card">
+        <div class="form-group">
+          <label>选择测试场景</label>
+          <select id="testScenario">
+            <option value="create">创建用户 (create)</option>
+            <option value="read">查询用户 (read)</option>
+            <option value="update">更新用户 (update)</option>
+            <option value="delete">删除用户 (delete)</option>
+            <option value="batch">批量操作 (batch)</option>
+          </select>
+        </div>
+        <button class="btn btn-primary" onclick="runJestTest()">运行测试</button>
+      </div>
+      
+      <div class="output-area mt-4" id="jestOutput">
+        <pre>选择测试场景并点击"运行测试"...</pre>
+      </div>
+    </div>
+    
+    <!-- 交互演示 -->
+    <div class="tab-content" id="demo">
+      <h2 class="section-title">交互式演示</h2>
+      <p class="mb-4">实时体验 MongoDB 测试数据的创建、查询和操作。</p>
+      
+      <div class="demo-grid">
+        <div class="demo-card">
+          <h3><span class="icon">➕</span> 插入文档</h3>
+          <div class="form-group">
+            <label>文档名称</label>
+            <input type="text" id="docName" placeholder="如: 张三">
+          </div>
+          <div class="form-group">
+            <label>文档类型</label>
+            <select id="docType">
+              <option value="user">用户 (User)</option>
+              <option value="order">订单 (Order)</option>
+              <option value="product">产品 (Product)</option>
+            </select>
+          </div>
+          <button class="btn btn-primary" onclick="insertDocument()">插入文档</button>
+        </div>
+        
+        <div class="demo-card">
+          <h3><span class="icon">🔍</span> 查询文档</h3>
+          <div class="form-group">
+            <label>查询条件</label>
+            <input type="text" id="queryCondition" placeholder="如: name='张三'" disabled>
+          </div>
+          <div class="form-group">
+            <label>集合</label>
+            <select id="queryCollection">
+              <option value="users">users</option>
+              <option value="orders">orders</option>
+              <option value="products">products</option>
+            </select>
+          </div>
+          <button class="btn btn-secondary" onclick="queryDocuments()">查询全部</button>
+        </div>
+      </div>
+      
+      <h3 style="margin:24px 0 16px">模拟数据库状态</h3>
+      <div class="json-viewer" id="dbState">
+        <pre id="dbStateContent">数据库为空，点击上方按钮添加数据...</pre>
+      </div>
+      
+      <h3 style="margin:24px 0 16px">操作日志</h3>
+      <div class="output-area" id="opLog" style="max-height:200px">
+        <pre>等待操作...</pre>
+      </div>
+    </div>
+    
+    <!-- 小测验 -->
+    <div class="tab-content" id="quiz">
+      <h2 class="section-title">知识小测验</h2>
+      <p class="mb-4">检验你对 MongoDB 测试数据的理解程度。</p>
+      
+      <div class="quiz-container">
+        <div class="quiz-question" id="quizQuestion">Q1: Factory 模式的主要作用是什么？</div>
+        <div class="quiz-options" id="quizOptions">
+          <div class="quiz-option" onclick="selectAnswer(0, false)">A. 连接到 MongoDB 数据库</div>
+          <div class="quiz-option" onclick="selectAnswer(1, true)">B. 生成结构化的测试数据</div>
+          <div class="quiz-option" onclick="selectAnswer(2, false)">C. 执行数据库备份</div>
+          <div class="quiz-option" onclick="selectAnswer(3, false)">D. 管理数据库用户权限</div>
+        </div>
+        <div class="quiz-result" id="quizResult" style="display:none"></div>
+      </div>
+      
+      <div class="flex-center mt-4">
+        <span class="badge badge-mongo" id="scoreBadge">得分: 0/5</span>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // 模拟数据库
+    const mockDb = {
+      users: [],
+      orders: [],
+      products: []
+    };
+    
+    // 工具函数
+    const utils = {
+      randomName() {
+        const names = ['张三', '李四', '王五', '赵六', '钱七', '孙八', '周九', '吴十'];
+        return names[Math.floor(Math.random() * names.length)];
+      },
+      randomEmail() {
+        return `user${Date.now()}@example.com`;
+      },
+      randomAge() {
+        return Math.floor(Math.random() * 50) + 18;
+      },
+      randomPrice() {
+        return Math.floor(Math.random() * 1000) + 10;
+      },
+      formatJson(obj) {
+        return JSON.stringify(obj, null, 2)
+          .replace(/"([^"]+)":/g, '<span class="json-key">"$1"</span>:')
+          .replace(/: "([^"]+)"/g, ': <span class="json-string">"$1"</span>')
+          .replace(/: (\d+\.?\d*)/g, ': <span class="json-number">$1</span>')
+          .replace(/: (true|false)/g, ': <span class="json-boolean">$1</span>')
+          .replace(/: (null)/g, ': <span class="json-null">$1</span>');
+      },
+      log(message, type = 'info') {
+        const logArea = document.getElementById('opLog') || document.getElementById('factoryOutput');
+        const timestamp = new Date().toLocaleTimeString();
+        const span = document.createElement('span');
+        span.className = type;
+        span.innerHTML = `[${timestamp}] ${message}\n`;
+        logArea.querySelector('pre').prepend(span);
+      }
+    };
+    
+    // Factory 类
+    class UserFactory {
+      static create(data = {}) {
+        return {
+          _id: `user-${Date.now()}-${Math.random().toString(36).substr(2, 6)}`,
+          name: data.name || utils.randomName(),
+          email: data.email || utils.randomEmail(),
+          age: data.age || utils.randomAge(),
+          avatar: `https://i.pravatar.cc/150?u=${Date.now()}`,
+          bio: ['热爱编程', '喜欢音乐', '运动爱好者', '阅读爱好者'][Math.floor(Math.random() * 4)],
+          createdAt: new Date().toISOString()
+        };
+      }
+      static createMany(count) {
+        return Array.from({ length: count }, () => this.create());
+      }
+    }
+    
+    class OrderFactory {
+      static create(data = {}) {
+        const items = Array.from({ length: Math.floor(Math.random() * 5) + 1 }, (_, i) => ({
+          productId: `PROD${Math.random().toString(36).substr(2, 8)}`,
+          name: `商品${i + 1}`,
+          price: utils.randomPrice(),
+          quantity: Math.floor(Math.random() * 5) + 1
+        }));
+        const totalAmount = items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+        return {
+          _id: `order-${Date.now()}-${Math.random().toString(36).substr(2, 6)}`,
+          orderNo: `ORD${Date.now()}`,
+          userId: data.userId || null,
+          items,
+          totalAmount,
+          status: ['pending', 'processing', 'shipped', 'completed'][Math.floor(Math.random() * 4)],
+          createdAt: new Date().toISOString()
+        };
+      }
+      static createMany(count) {
+        return Array.from({ length: count }, () => this.create());
+      }
+    }
+    
+    class ProductFactory {
+      static create(data = {}) {
+        return {
+          _id: `prod-${Date.now()}-${Math.random().toString(36).substr(2, 6)}`,
+          name: data.name || `产品${Math.floor(Math.random() * 1000)}`,
+          price: data.price || utils.randomPrice(),
+          category: ['电子产品', '服装', '食品', '图书'][Math.floor(Math.random() * 4)],
+          stock: Math.floor(Math.random() * 100),
+          createdAt: new Date().toISOString()
+        };
+      }
+      static createMany(count) {
+        return Array.from({ length: count }, () => this.create());
+      }
+    }
+    
+    // Tab 切换
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById(btn.dataset.tab).classList.add('active');
+      });
+    });
+    
+    // 生成用户
+    function generateUsers() {
+      const users = UserFactory.createMany(5);
+      mockDb.users.push(...users);
+      document.getElementById('factoryOutput').innerHTML = 
+        `<pre>${utils.formatJson(users)}</pre>`;
+      utils.log(`✅ 生成了 ${users.length} 个用户`, 'success');
+      updateDbState();
+    }
+    
+    // 生成订单
+    function generateOrders() {
+      const orders = OrderFactory.createMany(3);
+      orders.forEach(order => {
+        order.userId = mockDb.users.length > 0 
+          ? mockDb.users[Math.floor(Math.random() * mockDb.users.length)]._id 
+          : null;
+      });
+      mockDb.orders.push(...orders);
+      document.getElementById('factoryOutput').innerHTML = 
+        `<pre>${utils.formatJson(orders)}</pre>`;
+      utils.log(`✅ 生成了 ${orders.length} 个订单`, 'success');
+      updateDbState();
+    }
+    
+    // 模拟播种
+    function simulateSeeding() {
+      const dbName = document.getElementById('dbName').value;
+      const collectionName = document.getElementById('collectionName').value;
+      const count = parseInt(document.getElementById('insertCount').value) || 10;
+      
+      let data;
+      if (collectionName === 'users') {
+        data = UserFactory.createMany(count);
+        mockDb.users.push(...data);
+      } else if (collectionName === 'orders') {
+        data = OrderFactory.createMany(count);
+        mockDb.orders.push(...data);
+      } else {
+        data = ProductFactory.createMany(count);
+        mockDb.products.push(...data);
+      }
+      
+      const output = {
+        status: 'success',
+        message: `Successfully seeded ${count} documents`,
+        database: dbName,
+        collection: collectionName,
+        insertedCount: count,
+        data: data.slice(0, 3)
+      };
+      
+      document.getElementById('seedingOutput').innerHTML = 
+        `<pre>${utils.formatJson(output)}</pre>`;
+      utils.log(`📥 播种完成: ${dbName}.${collectionName} (${count} 条)`, 'success');
+      updateDbState();
+    }
+    
+    // 运行 Jest 测试
+    function runJestTest() {
+      const scenario = document.getElementById('testScenario').value;
+      const tests = {
+        create: {
+          name: 'create',
+          fullName: '用户创建测试',
+          code: `test('创建用户', async () => {
+  const user = { name: '张三', age: 25 };
+  const result = await db.collection('users').insertOne(user);
+  expect(result.insertedId).toBeDefined();
+});`,
+          result: '✓ PASS'
+        },
+        read: {
+          name: 'read',
+          fullName: '用户查询测试',
+          code: `test('查询用户', async () => {
+  const user = await db.collection('users').findOne({ name: '张三' });
+  expect(user).toBeDefined();
+  expect(user.name).toBe('张三');
+});`,
+          result: '✓ PASS'
+        },
+        update: {
+          name: 'update',
+          fullName: '用户更新测试',
+          code: `test('更新用户', async () => {
+  const result = await db.collection('users').updateOne(
+    { name: '张三' },
+    { $set: { age: 30 } }
+  );
+  expect(result.modifiedCount).toBeGreaterThan(0);
+});`,
+          result: '✓ PASS'
+        },
+        delete: {
+          name: 'delete',
+          fullName: '用户删除测试',
+          code: `test('删除用户', async () => {
+  const result = await db.collection('users').deleteOne({ name: '张三' });
+  expect(result.deletedCount).toBe(1);
+});`,
+          result: '✓ PASS'
+        },
+        batch: {
+          name: 'batch',
+          fullName: '批量操作测试',
+          code: `test('批量插入', async () => {
+  const users = Array.from({ length: 100 }, (_, i) => ({
+    name: \`用户\${i}\`,
+    age: 20 + i
+  }));
+  const result = await db.collection('users').insertMany(users);
+  expect(result.insertedCount).toBe(100);
+});`,
+          result: '✓ PASS'
+        }
+      };
+      
+      const test = tests[scenario];
+      const output = {
+        'PASS': test.result,
+        'Test Suites': '1 passed',
+        'Tests': '1 passed',
+        'Snapshots': '0 total',
+        'Time': '245ms',
+        'Runtime': 'jest-mongodb',
+        'Test Code': test.code
+      };
+      
+      document.getElementById('jestOutput').innerHTML = 
+        `<pre>${utils.formatJson(output)}</pre>`;
+      utils.log(`🧪 运行测试: ${test.fullName} - ${test.result}`, 'success');
+    }
+    
+    // 插入文档
+    function insertDocument() {
+      const docName = document.getElementById('docName').value;
+      const docType = document.getElementById('docType').value;
+      
+      let doc;
+      if (docType === 'user') {
+        doc = UserFactory.create({ name: docName || undefined });
+        mockDb.users.push(doc);
+      } else if (docType === 'order') {
+        doc = OrderFactory.create({ userId: mockDb.users[0]?._id });
+        mockDb.orders.push(doc);
+      } else {
+        doc = ProductFactory.create({ name: docName || undefined });
+        mockDb.products.push(doc);
+      }
+      
+      document.getElementById('dbState').innerHTML = 
+        `<pre>${utils.formatJson({ inserted: doc })}</pre>`;
+      utils.log(`➕ 插入 ${docType}: ${doc._id}`, 'success');
+      updateDbState();
+    }
+    
+    // 查询文档
+    function queryDocuments() {
+      const collection = document.getElementById('queryCollection').value;
+      const data = mockDb[collection] || [];
+      
+      document.getElementById('dbState').innerHTML = 
+        `<pre>${utils.formatJson({ count: data.length, data })}</pre>`;
+      utils.log(`🔍 查询 ${collection}: ${data.length} 条记录`, 'info');
+    }
+    
+    // 更新数据库状态显示
+    function updateDbState() {
+      const state = {
+        users: mockDb.users.length,
+        orders: mockDb.orders.length,
+        products: mockDb.products.length,
+        total: mockDb.users.length + mockDb.orders.length + mockDb.products.length
+      };
+      const content = document.getElementById('dbStateContent');
+      if (content) {
+        content.textContent = JSON.stringify(state, null, 2);
+      }
+    }
+    
+    // 小测验
+    const quizData = [
+      {
+        question: 'Q1: Factory 模式的主要作用是什么？',
+        options: ['连接到 MongoDB 数据库', '生成结构化的测试数据', '执行数据库备份', '管理数据库用户权限'],
+        correct: 1
+      },
+      {
+        question: 'Q2: mongo-seeding 支持哪些文件格式？',
+        options: ['只有 JSON', '只有 CSV', 'JSON 和 JS', 'XML 和 YAML'],
+        correct: 2
+      },
+      {
+        question: 'Q3: @shelf/jest-mongodb 的 preset 配置是什么？',
+        options: ['jest-puppeteer', '@shelf/jest-mongodb', '@jest/mongodb', 'jest-mongodb-preset'],
+        correct: 1
+      },
+      {
+        question: 'Q4: 批量插入数据时，推荐的做法是？',
+        options: ['逐条插入', '使用 insertMany', '使用 insertOne 循环', '直接操作文件'],
+        correct: 1
+      },
+      {
+        question: 'Q5: 为什么测试数据要使用固定种子？',
+        options: ['加快插入速度', '使数据可复现', '减少内存使用', '提高安全性'],
+        correct: 1
+      }
+    ];
+    
+    let currentQuiz = 0;
+    let score = 0;
+    
+    function selectAnswer(index, isCorrect) {
+      const options = document.querySelectorAll('.quiz-option');
+      options.forEach((opt, i) => {
+        opt.classList.remove('correct', 'incorrect');
+        opt.style.pointerEvents = 'none';
+        if (i === quizData[currentQuiz].correct) {
+          opt.classList.add('correct');
+        } else if (i === index && !isCorrect) {
+          opt.classList.add('incorrect');
+        }
+      });
+      
+      if (isCorrect) {
+        score++;
+        document.getElementById('scoreBadge').textContent = `得分: ${score}/${quizData.length}`;
+        document.getElementById('quizResult').style.display = 'block';
+        document.getElementById('quizResult').className = 'quiz-result pass';
+        document.getElementById('quizResult').textContent = '🎉 回答正确！';
+      } else {
+        document.getElementById('quizResult').style.display = 'block';
+        document.getElementById('quizResult').className = 'quiz-result fail';
+        document.getElementById('quizResult').textContent = '❌ 回答错误，正确答案是: ' + 
+          quizData[currentQuiz].options[quizData[currentQuiz].correct];
+      }
+      
+      setTimeout(() => {
+        currentQuiz++;
+        if (currentQuiz < quizData.length) {
+          loadQuiz();
+        }
+      }, 1500);
+    }
+    
+    function loadQuiz() {
+      const q = quizData[currentQuiz];
+      document.getElementById('quizQuestion').textContent = q.question;
+      document.getElementById('quizResult').style.display = 'none';
+      const optionsHtml = q.options.map((opt, i) => 
+        `<div class="quiz-option" onclick="selectAnswer(${i}, ${i === q.correct})">${String.fromCharCode(65 + i)}. ${opt}</div>`
+      ).join('');
+      document.getElementById('quizOptions').innerHTML = optionsHtml;
+    }
+    
+    // 初始化
+    loadQuiz();
+  </script>
+</body>
+</html>

--- a/examples/css/demos/selector-escape/index.html
+++ b/examples/css/demos/selector-escape/index.html
@@ -1,0 +1,839 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS 选择器转义交互演示</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0a0a0f;
+      color: #e0e0e0;
+      min-height: 100vh;
+      padding: 20px;
+      line-height: 1.6;
+    }
+    h1 {
+      text-align: center;
+      font-size: 1.8rem;
+      margin-bottom: 20px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .tab-nav {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .tab-btn {
+      padding: 10px 20px;
+      background: #1a1a2e;
+      border: 1px solid #333;
+      border-radius: 8px;
+      color: #888;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: all 0.2s;
+    }
+    .tab-btn:hover { background: #252540; color: #fff; }
+    .tab-btn.active {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      border-color: transparent;
+    }
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+    .demo-area {
+      background: #1a1a2e;
+      border: 1px solid #333;
+      border-radius: 12px;
+      padding: 20px;
+      margin-bottom: 20px;
+    }
+    .demo-area h3 {
+      color: #667eea;
+      margin-bottom: 12px;
+      font-size: 1.1rem;
+    }
+    .demo-area h4 {
+      color: #888;
+      margin: 16px 0 8px;
+      font-size: 0.95rem;
+    }
+    .test-element {
+      background: #252540;
+      border: 2px solid #667eea;
+      border-radius: 8px;
+      padding: 16px;
+      margin: 12px 0;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .test-element .label {
+      background: #667eea;
+      color: white;
+      padding: 4px 10px;
+      border-radius: 4px;
+      font-size: 0.8rem;
+      font-weight: bold;
+    }
+    .test-element.highlight {
+      border-color: #2ecc71;
+      background: rgba(46, 204, 113, 0.1);
+    }
+    .test-element.highlight .label {
+      background: #2ecc71;
+    }
+    .test-element.error {
+      border-color: #e74c3c;
+      background: rgba(231, 76, 60, 0.1);
+    }
+    .test-element.error .label {
+      background: #e74c3c;
+    }
+    button {
+      padding: 10px 20px;
+      background: #252540;
+      border: 1px solid #444;
+      border-radius: 6px;
+      color: #e0e0e0;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: all 0.2s;
+      margin: 4px;
+    }
+    button:hover { background: #333355; border-color: #667eea; }
+    button.primary {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      border: none;
+    }
+    button.success {
+      background: linear-gradient(135deg, #2ecc71 0%, #27ae60 100%);
+      border: none;
+    }
+    button.danger {
+      background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
+      border: none;
+    }
+    .result-box {
+      background: #0f0f1a;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 12px;
+      font-family: 'Fira Code', 'Consolas', monospace;
+      font-size: 0.85rem;
+      color: #888;
+      min-height: 60px;
+      white-space: pre-wrap;
+    }
+    .result-box.success { color: #2ecc71; }
+    .result-box.error { color: #e74c3c; }
+    .result-box.info { color: #3498db; }
+    code {
+      background: #252540;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 0.85em;
+      color: #667eea;
+      font-family: 'Fira Code', 'Consolas', monospace;
+    }
+    .code-block {
+      background: #0f0f1a;
+      border-radius: 8px;
+      padding: 12px;
+      margin: 12px 0;
+      overflow-x: auto;
+      font-family: 'Fira Code', 'Consolas', monospace;
+      font-size: 0.85rem;
+      border: 1px solid #333;
+    }
+    .code-block .keyword { color: #c678dd; }
+    .code-block .string { color: #98c379; }
+    .code-block .number { color: #d19a66; }
+    .code-block .comment { color: #5c6370; }
+    .info-box {
+      background: #15152a;
+      border: 1px solid #333;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 16px;
+    }
+    .info-box h4 { color: #667eea; margin-bottom: 8px; }
+    .info-box p { color: #aaa; font-size: 0.9rem; line-height: 1.6; }
+    .info-box.warning {
+      border-color: #f39c12;
+      background: rgba(243, 156, 18, 0.1);
+    }
+    .info-box.warning h4 { color: #f39c12; }
+    .info-box.tip {
+      border-color: #2ecc71;
+      background: rgba(46, 204, 113, 0.1);
+    }
+    .info-box.tip h4 { color: #2ecc71; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 12px;
+    }
+    th, td {
+      padding: 10px;
+      text-align: left;
+      border-bottom: 1px solid #333;
+    }
+    th { color: #667eea; font-weight: 600; background: #15152a; }
+    td { color: #aaa; }
+    tr:hover td { background: #1a1a2e; }
+    .escape-table {
+      font-family: 'Fira Code', 'Consolas', monospace;
+    }
+    .escape-table code {
+      background: #0f0f1a;
+    }
+    .quiz-container {
+      max-width: 600px;
+      margin: 0 auto;
+    }
+    .quiz-item {
+      background: #15152a;
+      border: 1px solid #333;
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 16px;
+    }
+    .quiz-item h4 {
+      color: #667eea;
+      margin-bottom: 12px;
+    }
+    .quiz-options {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .quiz-option {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 10px 12px;
+      background: #1a1a2e;
+      border: 1px solid #333;
+      border-radius: 6px;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+    .quiz-option:hover {
+      border-color: #667eea;
+      background: #252540;
+    }
+    .quiz-option .option-letter {
+      background: #333;
+      color: #888;
+      padding: 4px 10px;
+      border-radius: 4px;
+      font-weight: bold;
+      font-size: 0.85rem;
+    }
+    .quiz-option.correct {
+      border-color: #2ecc71;
+      background: rgba(46, 204, 113, 0.1);
+    }
+    .quiz-option.correct .option-letter {
+      background: #2ecc71;
+      color: white;
+    }
+    .quiz-option.incorrect {
+      border-color: #e74c3c;
+      background: rgba(231, 76, 60, 0.1);
+    }
+    .quiz-option.incorrect .option-letter {
+      background: #e74c3c;
+      color: white;
+    }
+    .quiz-option.selected {
+      border-color: #667eea;
+      background: rgba(102, 126, 234, 0.1);
+    }
+    .quiz-option.selected .option-letter {
+      background: #667eea;
+      color: white;
+    }
+    .quiz-result {
+      margin-top: 12px;
+      padding: 12px;
+      border-radius: 6px;
+      font-size: 0.9rem;
+    }
+    .quiz-result.correct {
+      background: rgba(46, 204, 113, 0.2);
+      color: #2ecc71;
+    }
+    .quiz-result.incorrect {
+      background: rgba(231, 76, 60, 0.2);
+      color: #e74c3c;
+    }
+    .best-practice-item {
+      background: #15152a;
+      border-left: 3px solid #667eea;
+      padding: 12px 16px;
+      margin: 12px 0;
+      border-radius: 0 8px 8px 0;
+    }
+    .best-practice-item.good {
+      border-left-color: #2ecc71;
+    }
+    .best-practice-item.bad {
+      border-left-color: #e74c3c;
+    }
+    .best-practice-item h5 {
+      margin-bottom: 6px;
+      font-size: 0.95rem;
+    }
+    .best-practice-item.good h5 { color: #2ecc71; }
+    .best-practice-item.bad h5 { color: #e74c3c; }
+    .best-practice-item code {
+      font-size: 0.85em;
+    }
+  </style>
+</head>
+<body>
+  <h1>🔍 CSS 选择器转义交互演示</h1>
+
+  <div class="tab-nav">
+    <button class="tab-btn active" data-tab="problem">问题演示</button>
+    <button class="tab-btn" data-tab="getbyid">getElementById 方案</button>
+    <button class="tab-btn" data-tab="escape">CSS 转义方案</button>
+    <button class="tab-btn" data-tab="best">最佳实践</button>
+    <button class="tab-btn" data-tab="quiz">自测题</button>
+  </div>
+
+  <!-- Tab 1: 问题演示 -->
+  <div id="tab-problem" class="tab-content active">
+    <div class="demo-area">
+      <h3>❌ 问题：querySelector 无法直接选取数字开头的 ID</h3>
+      
+      <div class="test-element" id="el-1">
+        <span class="label">#1</span>
+        <span>这是第一个测试元素，id="1"</span>
+      </div>
+      
+      <div class="test-element" id="el-2">
+        <span class="label">#2</span>
+        <span>这是第二个测试元素，id="2"</span>
+      </div>
+      
+      <div class="test-element" id="el-123">
+        <span class="label">#123</span>
+        <span>这是第三个测试元素，id="123"</span>
+      </div>
+      
+      <div style="margin-top: 16px;">
+        <button class="primary" onclick="demoWrongQuery()">尝试 querySelector("#1")</button>
+        <button onclick="resetDemo()">重置</button>
+      </div>
+      
+      <div class="result-box" id="result-problem"></div>
+    </div>
+    
+    <div class="info-box warning">
+      <h4>⚠️ 为什么报错？</h4>
+      <p><code>document.querySelector()</code> 接受的是 <strong>CSS 选择器语法字符串</strong>，而不是 HTML 属性值。</p>
+      <p>CSS 规范不允许 ID 选择器以数字开头，因此解析器抛出 <code>DOMException: '#1' is not a valid selector</code>。</p>
+    </div>
+    
+    <div class="info-box">
+      <h4>📚 CSS 语法 vs HTML 规范</h4>
+      <table>
+        <tr><th>方面</th><th>CSS 选择器</th><th>HTML ID 属性</th></tr>
+        <tr><td>数字开头</td><td>❌ 不允许</td><td>✅ 允许</td></tr>
+        <tr><td>规范来源</td><td>W3C CSS Selectors</td><td>W3C HTML</td></tr>
+        <tr><td>使用方式</td><td>querySelector()</td><td>getElementById()</td></tr>
+      </table>
+    </div>
+  </div>
+
+  <!-- Tab 2: getElementById 方案 -->
+  <div id="tab-getbyid" class="tab-content">
+    <div class="demo-area">
+      <h3>✅ 方案一：getElementById（推荐）</h3>
+      <p style="color: #888; margin-bottom: 16px;">getElementById() 直接接受字符串参数，遵循 HTML 规范，不受 CSS 选择器语法限制。</p>
+      
+      <div class="test-element" id="item-1">
+        <span class="label">#item-1</span>
+        <span>id="item-1" 的元素（注意：这是数字开头但有前缀）</span>
+      </div>
+      
+      <div class="test-element" id="1">
+        <span class="label">#1</span>
+        <span>id="1" 的元素（纯数字开头）</span>
+      </div>
+      
+      <div style="margin-top: 16px;">
+        <button class="success" onclick="demoGetById()">getElementById("1")</button>
+        <button onclick="demoGetByIdItem()">getElementById("item-1")</button>
+        <button onclick="resetGetByIdDemo()">重置</button>
+      </div>
+      
+      <div class="code-block">
+<span class="comment">// 获取 id="1" 的元素</span>
+<span class="keyword">const</span> element = document.<span class="string">getElementById</span>(<span class="string">'1'</span>);
+console.log(element.textContent); <span class="comment">// "id="1" 的元素"</span>
+      </div>
+      
+      <div class="result-box" id="result-getbyid"></div>
+    </div>
+    
+    <div class="info-box tip">
+      <h4>✨ 优点</h4>
+      <p>• 语法简单，代码易读<br>
+         • 性能与 querySelector 相当<br>
+         • 不需要了解转义规则<br>
+         • 是处理数字开头 ID 的首选方案</p>
+    </div>
+    
+    <div class="info-box">
+      <h4>💡 注意</h4>
+      <p>getElementById() 只能获取单个元素，且只能通过 ID 获取。如果需要使用复杂选择器，请参考「CSS 转义方案」。</p>
+    </div>
+  </div>
+
+  <!-- Tab 3: CSS 转义方案 -->
+  <div id="tab-escape" class="tab-content">
+    <div class="demo-area">
+      <h3>🔧 方案二：CSS 转义语法</h3>
+      <p style="color: #888; margin-bottom: 16px;">使用 CSS 转义序列，让 querySelector 能够匹配以数字开头的 ID。</p>
+      
+      <h4>转义对照表</h4>
+      <table class="escape-table">
+        <tr><th>字符</th><th>3 位转义</th><th>6 位转义</th></tr>
+        <tr><td>0</td><td><code>\30</code></td><td><code>\000030</code></td></tr>
+        <tr><td>1</td><td><code>\31</code></td><td><code>\000031</code></td></tr>
+        <tr><td>2</td><td><code>\32</code></td><td><code>\000032</code></td></tr>
+        <tr><td>3</td><td><code>\33</code></td><td><code>\000033</code></td></tr>
+        <tr><td>...</td><td>...</td><td>...</td></tr>
+        <tr><td>9</td><td><code>\39</code></td><td><code>\000039</code></td></tr>
+      </table>
+      
+      <h4>实际演示</h4>
+      <div class="test-element" id="1">
+        <span class="label">#1</span>
+        <span>id="1" 的元素</span>
+      </div>
+      
+      <div class="test-element" id="12">
+        <span class="label">#12</span>
+        <span>id="12" 的元素</span>
+      </div>
+      
+      <div class="test-element" id="123">
+        <span class="label">#123</span>
+        <span>id="123" 的元素</span>
+      </div>
+      
+      <div style="margin-top: 16px;">
+        <button onclick="demoEscape1()">querySelector('#\\31')</button>
+        <button onclick="demoEscape12()">querySelector('#\\31\\32')</button>
+        <button onclick="demoEscape123()">querySelector('#\\31\\32\\33')</button>
+        <button onclick="demoEscape6digit()">6位转义 \\000031</button>
+      </div>
+      
+      <div class="code-block" id="escape-code">
+<span class="comment">// 3位转义：数字1 → \31</span>
+document.<span class="string">querySelector</span>(<span class="string">'#\\31'</span>);
+
+<span class="comment">// 多个数字：12 → \31 \32（每个数字分别转义）</span>
+document.<span class="string">querySelector</span>(<span class="string">'#\\31\\32'</span>);
+
+<span class="comment">// 6位转义：数字1 → \000031</span>
+document.<span class="string">querySelector</span>(<span class="string">'#\\000031'</span>);
+      </div>
+      
+      <div class="result-box" id="result-escape"></div>
+    </div>
+    
+    <div class="info-box warning">
+      <h4>⚠️ 注意事项</h4>
+      <p>• JavaScript 字符串中反斜杠需要转义，所以是 <code>'#\\31'</code><br>
+         • 6位转义后通常需要空格或其他分隔符<br>
+         • 建议使用 getElementById 代替，除非必须使用 querySelector</p>
+    </div>
+  </div>
+
+  <!-- Tab 4: 最佳实践 -->
+  <div id="tab-best" class="tab-content">
+    <div class="demo-area">
+      <h3>🏆 最佳实践：避免数字开头的 ID</h3>
+      
+      <div class="best-practice-item bad">
+        <h5>❌ 不推荐：纯数字 ID</h5>
+        <code>&lt;div id="1"&gt;</code>
+        <code>&lt;div id="2"&gt;</code>
+        <code>&lt;div id="123"&gt;</code>
+        <p style="color: #888; margin-top: 8px; font-size: 0.9rem;">问题：无法直接使用 querySelector()，需要额外处理</p>
+      </div>
+      
+      <div class="best-practice-item good">
+        <h5>✅ 推荐：使用字母前缀</h5>
+        <code>&lt;div id="row-1"&gt;</code>
+        <code>&lt;div id="row-2"&gt;</code>
+        <code>&lt;div id="user-123"&gt;</code>
+        <p style="color: #888; margin-top: 8px; font-size: 0.9rem;">优势：语义清晰，可直接使用 querySelector()</p>
+      </div>
+      
+      <div class="best-practice-item good">
+        <h5>✅ 推荐：驼峰命名</h5>
+        <code>&lt;div id="tableRow1"&gt;</code>
+        <code>&lt;div id="productCard"&gt;</code>
+        <code>&lt;div id="mainContent"&gt;</code>
+        <p style="color: #888; margin-top: 8px; font-size: 0.9rem;">优势：符合 JS 命名习惯，IDE 友好</p>
+      </div>
+      
+      <div class="best-practice-item good">
+        <h5>✅ 推荐：下划线分隔</h5>
+        <code>&lt;div id="header_main"&gt;</code>
+        <code>&lt;div id="sidebar_left"&gt;</code>
+        <p style="color: #888; margin-top: 8px; font-size: 0.9rem;">优势：可读性好，适合 CSS 类名风格</p>
+      </div>
+    </div>
+    
+    <div class="demo-area">
+      <h3>🛠️ 工具函数封装</h3>
+      <p style="color: #888; margin-bottom: 16px;">封装工具函数，统一处理 ID 获取逻辑：</p>
+      
+      <div class="code-block">
+<span class="comment">// 选择器工具函数</span>
+<span class="keyword">const</span> $ = {
+  <span class="comment">// 根据 ID 获取元素（支持数字开头）</span>
+  byId(id) {
+    <span class="keyword">return</span> document.<span class="string">getElementById</span>(id);
+  },
+  
+  <span class="comment">// CSS 转义 ID</span>
+  escapeId(id) {
+    <span class="keyword">return</span> id.replace(<span class="string">/[^\w-]/g</span>, char => {
+      <span class="keyword">return</span> <span class="string">'\\'</span> + char.charCodeAt(<span class="number">0</span>).toString(<span class="number">16</span>).padStart(<span class="number">4</span>, <span class="string">'0'</span>) + <span class="string">' '</span>;
+    });
+  },
+  
+  <span class="comment">// 安全的选择器查询</span>
+  safeQuery(id) {
+    <span class="keyword">if</span> (<span class="string">/^\d/</span>.test(id)) {
+      <span class="keyword">return</span> <span class="keyword">this</span>.byId(id);
+    }
+    <span class="keyword">return</span> document.<span class="string">querySelector</span>(<span class="string">'#'</span> + id);
+  }
+};
+
+<span class="comment">// 使用示例</span>
+<span class="keyword">const</span> el1 = $.byId(<span class="string">'1'</span>);           <span class="comment">// 直接获取</span>
+<span class="keyword">const</span> el2 = $.safeQuery(<span class="string">'123'</span>);     <span class="comment">// 智能判断</span>
+      </div>
+    </div>
+    
+    <div class="info-box tip">
+      <h4>💡 总结</h4>
+      <p>• 新项目：使用字母前缀命名 ID，从源头避免问题<br>
+         • 已有数字开头 ID：优先使用 getElementById()<br>
+         • 必须用 querySelector：使用 CSS 转义语法<br>
+         • 团队协作：统一 ID 命名规范</p>
+    </div>
+  </div>
+
+  <!-- Tab 5: 自测题 -->
+  <div id="tab-quiz" class="tab-content">
+    <div class="demo-area">
+      <h3>📝 自测题</h3>
+      <p style="color: #888; margin-bottom: 16px;">测试你对 CSS 选择器转义的理解程度。</p>
+      
+      <div class="quiz-container">
+        <!-- 题目 1 -->
+        <div class="quiz-item" data-quiz="1" data-answer="b">
+          <h4>第 1 题：以下哪种方式可以正确获取 id="1" 的元素？</h4>
+          <div class="quiz-options">
+            <div class="quiz-option" data-option="a">
+              <span class="option-letter">A</span>
+              <code>document.querySelector('#1')</code>
+            </div>
+            <div class="quiz-option" data-option="b">
+              <span class="option-letter">B</span>
+              <code>document.getElementById('1')</code>
+            </div>
+            <div class="quiz-option" data-option="c">
+              <span class="option-letter">C</span>
+              <code>document.querySelector('#\31')</code>
+            </div>
+            <div class="quiz-option" data-option="d">
+              <span class="option-letter">D</span>
+              <code>document.getElement('#1')</code>
+            </div>
+          </div>
+          <div class="quiz-result"></div>
+        </div>
+
+        <!-- 题目 2 -->
+        <div class="quiz-item" data-quiz="2" data-answer="c">
+          <h4>第 2 题：在 CSS 转义中，数字 "5" 的 3 位十六进制转义是什么？</h4>
+          <div class="quiz-options">
+            <div class="quiz-option" data-option="a">
+              <span class="option-letter">A</span>
+              <code>\5</code>
+            </div>
+            <div class="quiz-option" data-option="b">
+              <span class="option-letter">B</span>
+              <code>\05</code>
+            </div>
+            <div class="quiz-option" data-option="c">
+              <span class="option-letter">C</span>
+              <code>\35</code>（5 的十六进制是 0x05，补零为 35）
+            </div>
+            <div class="quiz-option" data-option="d">
+              <span class="option-letter">D</span>
+              <code>\000035</code>
+            </div>
+          </div>
+          <div class="quiz-result"></div>
+        </div>
+
+        <!-- 题目 3 -->
+        <div class="quiz-item" data-quiz="3" data-answer="a">
+          <h4>第 3 题：id="user-123" 是否可以直接使用 querySelector 获取？</h4>
+          <div class="quiz-options">
+            <div class="quiz-option" data-option="a">
+              <span class="option-letter">A</span>
+              <code>querySelector('#user-123')</code> - 可以，因为不是纯数字开头
+            </div>
+            <div class="quiz-option" data-option="b">
+              <span class="option-letter">B</span>
+              <code>querySelector('#\\user-123')</code> - 需要全部转义
+            </div>
+            <div class="quiz-option" data-option="c">
+              <span class="option-letter">C</span>
+              <code>querySelector('[id="user-123"]')</code> - 必须用属性选择器
+            </div>
+            <div class="quiz-option" data-option="d">
+              <span class="option-letter">D</span>
+              <span>getElementById("user-123") 是唯一方式</span>
+            </div>
+          </div>
+          <div class="quiz-result"></div>
+        </div>
+      </div>
+      
+      <div style="margin-top: 20px; text-align: center;">
+        <button class="primary" onclick="checkAllAnswers()">检查答案</button>
+        <button onclick="resetQuiz()">重新答题</button>
+      </div>
+      
+      <div class="result-box" id="quiz-summary" style="margin-top: 16px;"></div>
+    </div>
+  </div>
+
+  <script>
+    // Tab 切换
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+      });
+    });
+
+    // 重置函数
+    function resetDemo() {
+      document.querySelectorAll('.test-element').forEach(el => {
+        el.classList.remove('highlight', 'error');
+      });
+      document.getElementById('result-problem').textContent = '';
+      document.getElementById('result-problem').className = 'result-box';
+    }
+
+    function resetGetByIdDemo() {
+      document.querySelectorAll('#tab-getbyid .test-element').forEach(el => {
+        el.classList.remove('highlight', 'error');
+      });
+      document.getElementById('result-getbyid').textContent = '';
+      document.getElementById('result-getbyid').className = 'result-box';
+    }
+
+    // Tab 1: 问题演示
+    function demoWrongQuery() {
+      resetDemo();
+      const resultBox = document.getElementById('result-problem');
+      try {
+        document.querySelector('#1');
+        resultBox.textContent = '意外成功！';
+        resultBox.className = 'result-box error';
+      } catch (e) {
+        resultBox.textContent = '❌ DOMException: ' + e.message;
+        resultBox.className = 'result-box error';
+        document.querySelectorAll('#tab-problem .test-element')[0].classList.add('error');
+      }
+    }
+
+    // Tab 2: getElementById
+    function demoGetById() {
+      resetGetByIdDemo();
+      const resultBox = document.getElementById('result-getbyid');
+      const element = document.getElementById('1');
+      if (element) {
+        element.classList.add('highlight');
+        resultBox.textContent = '✅ 成功获取！\n元素内容: ' + element.textContent.trim();
+        resultBox.className = 'result-box success';
+      } else {
+        resultBox.textContent = '❌ 未找到元素';
+        resultBox.className = 'result-box error';
+      }
+    }
+
+    function demoGetByIdItem() {
+      resetGetByIdDemo();
+      const resultBox = document.getElementById('result-getbyid');
+      const element = document.getElementById('item-1');
+      if (element) {
+        element.classList.add('highlight');
+        resultBox.textContent = '✅ 成功获取！\n元素内容: ' + element.textContent.trim();
+        resultBox.className = 'result-box success';
+      } else {
+        resultBox.textContent = '❌ 未找到元素';
+        resultBox.className = 'result-box error';
+      }
+    }
+
+    // Tab 3: CSS 转义
+    function demoEscape1() {
+      const resultBox = document.getElementById('result-escape');
+      const element = document.querySelector('#\\31');
+      if (element) {
+        element.classList.add('highlight');
+        document.querySelectorAll('#tab-escape .test-element').forEach(el => {
+          if (el.id !== '1') el.classList.remove('highlight');
+        });
+        resultBox.textContent = '✅ querySelector(\'#\\\\31\') 成功！\n获取到 id="1" 的元素';
+        resultBox.className = 'result-box success';
+      } else {
+        resultBox.textContent = '❌ 查询失败';
+        resultBox.className = 'result-box error';
+      }
+    }
+
+    function demoEscape12() {
+      const resultBox = document.getElementById('result-escape');
+      const element = document.querySelector('#\\31\\32');
+      if (element) {
+        document.querySelectorAll('#tab-escape .test-element').forEach(el => {
+          el.classList.remove('highlight');
+          if (el.id === '12') el.classList.add('highlight');
+        });
+        resultBox.textContent = '✅ querySelector(\'#\\\\31\\\\32\') 成功！\n获取到 id="12" 的元素';
+        resultBox.className = 'result-box success';
+      } else {
+        resultBox.textContent = '❌ 查询失败';
+        resultBox.className = 'result-box error';
+      }
+    }
+
+    function demoEscape123() {
+      const resultBox = document.getElementById('result-escape');
+      const element = document.querySelector('#\\31\\32\\33');
+      if (element) {
+        document.querySelectorAll('#tab-escape .test-element').forEach(el => {
+          el.classList.remove('highlight');
+          if (el.id === '123') el.classList.add('highlight');
+        });
+        resultBox.textContent = '✅ querySelector(\'#\\\\31\\\\32\\\\33\') 成功！\n获取到 id="123" 的元素';
+        resultBox.className = 'result-box success';
+      } else {
+        resultBox.textContent = '❌ 查询失败';
+        resultBox.className = 'result-box error';
+      }
+    }
+
+    function demoEscape6digit() {
+      const resultBox = document.getElementById('result-escape');
+      const element = document.querySelector('#\\000031');
+      if (element) {
+        document.querySelectorAll('#tab-escape .test-element').forEach(el => {
+          el.classList.remove('highlight');
+          if (el.id === '1') el.classList.add('highlight');
+        });
+        resultBox.textContent = '✅ querySelector(\'#\\\\000031\') 成功！\n6位转义也能获取到 id="1" 的元素';
+        resultBox.className = 'result-box success';
+      } else {
+        resultBox.textContent = '❌ 查询失败';
+        resultBox.className = 'result-box error';
+      }
+    }
+
+    // Tab 5: 自测题
+    document.querySelectorAll('.quiz-option').forEach(option => {
+      option.addEventListener('click', function() {
+        const quizItem = this.closest('.quiz-item');
+        quizItem.querySelectorAll('.quiz-option').forEach(o => {
+          o.classList.remove('selected');
+        });
+        this.classList.add('selected');
+        const resultEl = quizItem.querySelector('.quiz-result');
+        resultEl.textContent = '';
+        resultEl.className = 'quiz-result';
+      });
+    });
+
+    function checkAllAnswers() {
+      let correct = 0;
+      const total = document.querySelectorAll('.quiz-item').length;
+      
+      document.querySelectorAll('.quiz-item').forEach(quizItem => {
+        const answer = quizItem.dataset.answer;
+        const selected = quizItem.querySelector('.quiz-option.selected');
+        const resultEl = quizItem.querySelector('.quiz-result');
+        
+        quizItem.querySelectorAll('.quiz-option').forEach(o => {
+          o.classList.remove('correct', 'incorrect');
+        });
+        
+        if (selected) {
+          const selectedOption = selected.dataset.option;
+          if (selectedOption === answer) {
+            correct++;
+            selected.classList.add('correct');
+            resultEl.textContent = '正确！';
+            resultEl.className = 'quiz-result correct';
+          } else {
+            selected.classList.add('incorrect');
+            const correctOption = quizItem.querySelector(`[data-option="${answer}"]`);
+            if (correctOption) correctOption.classList.add('correct');
+            resultEl.textContent = '错误。正确答案是 ' + answer.toUpperCase() + '。';
+            resultEl.className = 'quiz-result incorrect';
+          }
+        }
+      });
+      
+      const summaryBox = document.getElementById('quiz-summary');
+      if (correct === total) {
+        summaryBox.textContent = '🎉 恭喜！全部答对！' + correct + '/' + total;
+        summaryBox.className = 'result-box success';
+      } else {
+        summaryBox.textContent = '答题结果：' + correct + '/' + total + ' 正确';
+        summaryBox.className = 'result-box info';
+      }
+    }
+
+    function resetQuiz() {
+      document.querySelectorAll('.quiz-option').forEach(o => {
+        o.classList.remove('selected', 'correct', 'incorrect');
+      });
+      document.querySelectorAll('.quiz-result').forEach(r => {
+        r.textContent = '';
+        r.className = 'quiz-result';
+      });
+      document.getElementById('quiz-summary').textContent = '';
+      document.getElementById('quiz-summary').className = 'result-box';
+    }
+  </script>
+</body>
+</html>

--- a/examples/css/demos/stacking-context-debug/index.html
+++ b/examples/css/demos/stacking-context-debug/index.html
@@ -1,0 +1,645 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS 层叠上下文调试交互演示</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0a0a0f;
+      color: #e0e0e0;
+      min-height: 100vh;
+      padding: 20px;
+    }
+    h1 {
+      text-align: center;
+      font-size: 1.8rem;
+      margin-bottom: 20px;
+      background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .tab-nav {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .tab-btn {
+      padding: 10px 20px;
+      background: #1a1a2e;
+      border: 1px solid #333;
+      border-radius: 8px;
+      color: #888;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: all 0.2s;
+    }
+    .tab-btn:hover { background: #252540; color: #fff; }
+    .tab-btn.active {
+      background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+      color: white;
+      border-color: transparent;
+    }
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+    .demo-area {
+      background: #1a1a2e;
+      border: 1px solid #333;
+      border-radius: 12px;
+      padding: 20px;
+      margin-bottom: 20px;
+    }
+    .demo-area h3 {
+      color: #f093fb;
+      margin-bottom: 12px;
+      font-size: 1.1rem;
+    }
+    .demo-area p {
+      color: #aaa;
+      font-size: 0.9rem;
+      line-height: 1.6;
+      margin-bottom: 12px;
+    }
+    .demo-box {
+      background: #0f0f1a;
+      border: 1px solid #333;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+    }
+    .demo-box h4 {
+      color: #f093fb;
+      margin-bottom: 12px;
+      font-size: 1rem;
+    }
+    .code-block {
+      background: #0d0d1a;
+      border: 1px solid #333;
+      border-radius: 6px;
+      padding: 12px;
+      margin: 12px 0;
+      font-family: 'Fira Code', 'Consolas', monospace;
+      font-size: 0.85rem;
+      overflow-x: auto;
+      color: #a0a0c0;
+      white-space: pre-wrap;
+    }
+    .code-block .keyword { color: #c678dd; }
+    .code-block .string { color: #98c379; }
+    .code-block .property { color: #e5c07b; }
+    .code-block .value { color: #61afef; }
+    .code-block .selector { color: #e06c75; }
+    .code-block .comment { color: #5c6370; font-style: italic; }
+
+    /* Demo Scenarios */
+    .scene-container {
+      position: relative;
+      border: 2px solid #f093fb;
+      border-radius: 8px;
+      padding: 20px;
+      min-height: 200px;
+      margin: 16px 0;
+    }
+
+    /* Scene 1: Normal z-index stacking */
+    .scene1-box {
+      position: absolute;
+      width: 80px;
+      height: 80px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.75rem;
+      font-weight: bold;
+      border-radius: 6px;
+    }
+    .scene1-a {
+      top: 20px;
+      left: 20px;
+      background: #e06c75;
+      z-index: 1;
+    }
+    .scene1-b {
+      top: 50px;
+      left: 50px;
+      background: #61afef;
+      z-index: 2;
+    }
+    .scene1-c {
+      top: 80px;
+      left: 80px;
+      background: #98c379;
+      z-index: 3;
+    }
+
+    /* Scene 2: Parent transform creates stacking context */
+    .scene2-parent {
+      position: absolute;
+      top: 20px;
+      left: 20px;
+      width: 150px;
+      height: 150px;
+      background: rgba(240, 147, 251, 0.2);
+      border: 2px solid #f093fb;
+      border-radius: 8px;
+    }
+    .scene2-parent-inner {
+      position: absolute;
+      top: 20px;
+      left: 20px;
+      width: 80px;
+      height: 80px;
+      background: #e06c75;
+      z-index: 1000; /* High z-index inside parent */
+    }
+    .scene2-child {
+      position: absolute;
+      top: 60px;
+      left: 100px;
+      width: 80px;
+      height: 80px;
+      background: #61afef;
+      z-index: 1; /* Lower z-index outside */
+    }
+    .scene2-external {
+      position: absolute;
+      top: 120px;
+      left: 20px;
+      width: 80px;
+      height: 80px;
+      background: #98c379;
+      z-index: 2;
+    }
+
+    /* Scene 3: Multiple stacking contexts */
+    .scene3-container {
+      position: relative;
+      padding: 10px;
+    }
+    .scene3-context {
+      position: absolute;
+      width: 120px;
+      height: 120px;
+      border-radius: 8px;
+      padding: 10px;
+      font-size: 0.7rem;
+    }
+    .scene3-a {
+      top: 20px;
+      left: 20px;
+      background: rgba(224, 108, 117, 0.3);
+      border: 2px solid #e06c75;
+      z-index: 1;
+    }
+    .scene3-b {
+      top: 50px;
+      left: 60px;
+      background: rgba(97, 175, 239, 0.3);
+      border: 2px solid #61afef;
+      z-index: 2;
+    }
+    .scene3-c {
+      top: 80px;
+      left: 100px;
+      background: rgba(152, 195, 121, 0.3);
+      border: 2px solid #98c379;
+      z-index: 3;
+    }
+    .scene3-inner {
+      position: absolute;
+      bottom: 10px;
+      right: 10px;
+      width: 50px;
+      height: 50px;
+      background: #f093fb;
+      border-radius: 4px;
+    }
+
+    .controls {
+      display: flex;
+      gap: 12px;
+      margin-top: 12px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    button {
+      padding: 10px 20px;
+      background: #252540;
+      border: 1px solid #444;
+      border-radius: 6px;
+      color: #e0e0e0;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: all 0.2s;
+    }
+    button:hover { background: #333355; border-color: #f093fb; }
+    button.primary {
+      background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+      border: none;
+    }
+    .info-box {
+      background: #15152a;
+      border: 1px solid #333;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 16px;
+    }
+    .info-box h4 { color: #f093fb; margin-bottom: 8px; }
+    .info-box p { color: #aaa; font-size: 0.9rem; line-height: 1.6; }
+    .warning-box {
+      background: rgba(245, 87, 108, 0.1);
+      border: 1px solid #f5576c;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 16px;
+    }
+    .warning-box h4 { color: #f5576c; margin-bottom: 8px; }
+    .warning-box p { color: #ccc; font-size: 0.9rem; line-height: 1.6; }
+    code {
+      background: #1a1a2e;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-family: 'Fira Code', 'Consolas', monospace;
+      font-size: 0.85rem;
+      color: #e5c07b;
+    }
+    .label {
+      display: inline-block;
+      padding: 4px 8px;
+      background: #333;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      margin-top: 8px;
+    }
+    .label.warning { background: #f5576c; color: white; }
+    .label.success { background: #98c379; color: #0a0a0f; }
+  </style>
+</head>
+<body>
+  <h1>CSS 层叠上下文调试交互演示</h1>
+
+  <div class="tab-nav">
+    <button class="tab-btn active" data-tab="intro">概念介绍</button>
+    <button class="tab-btn" data-tab="scene1">场景1：正常层叠</button>
+    <button class="tab-btn" data-tab="scene2">场景2：transform 陷阱</button>
+    <button class="tab-btn" data-tab="scene3">场景3：多层上下文</button>
+    <button class="tab-btn" data-tab="debug">调试技巧</button>
+  </div>
+
+  <div id="tab-intro" class="tab-content active">
+    <div class="demo-area">
+      <h3>什么是层叠上下文（Stacking Context）</h3>
+      <p>层叠上下文是 HTML 元素在三维空间中按 z 轴顺序层叠的概念。当元素创建新的层叠上下文时，其子元素的 z-index 只在该上下文内部有效。</p>
+
+      <div class="demo-box">
+        <h4>创建层叠上下文的条件</h4>
+        <table class="comparison-table">
+          <thead>
+            <tr>
+              <th>条件</th>
+              <th>示例</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>根元素</td>
+              <td><code>&lt;html&gt;</code></td>
+            </tr>
+            <tr>
+              <td>position + z-index</td>
+              <td><code>position: relative; z-index: 1</code></td>
+            </tr>
+            <tr>
+              <td>opacity &lt; 1</td>
+              <td><code>opacity: 0.9</code></td>
+            </tr>
+            <tr>
+              <td>transform</td>
+              <td><code>transform: translateZ(0)</code></td>
+            </tr>
+            <tr>
+              <td>filter</td>
+              <td><code>filter: blur(1px)</code></td>
+            </tr>
+            <tr>
+              <td>backdrop-filter</td>
+              <td><code>backdrop-filter: blur(10px)</code></td>
+            </tr>
+            <tr>
+              <td>CSS Grid/Flex + z-index</td>
+              <td><code>display: flex; z-index: 1</code></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="warning-box">
+        <h4>关键概念</h4>
+        <p>
+          <strong>z-index 是相对的！</strong><br>
+          子元素的 z-index 值只在创建它的层叠上下文内部有意义。
+          不同层叠上下文之间的比较只看它们"根"的 z-index 值。
+        </p>
+      </div>
+
+      <div class="info-box">
+        <h4>核心规则</h4>
+        <p>
+          1. 层叠上下文 A 内的元素，永远无法超过层叠上下文 A 的边界<br>
+          2. 不同层叠上下文之间，根 z-index 大的优先<br>
+          3. 同一层叠上下文内，按 z-index 从低到高排序
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div id="tab-scene1" class="tab-content">
+    <div class="demo-area">
+      <h3>场景1：正常 z-index 层叠</h3>
+      <p>没有层叠上下文干扰时，z-index 直接决定元素的层叠顺序。数值越大，越在上层。</p>
+
+      <div class="demo-box">
+        <h4>交互演示</h4>
+        <div class="scene-container" id="scene1-demo">
+          <div class="scene1-box scene1-a">z-index: 1</div>
+          <div class="scene1-box scene1-b">z-index: 2</div>
+          <div class="scene1-box scene1-c">z-index: 3</div>
+        </div>
+        <div class="controls">
+          <button onclick="scene1Toggle()">切换层叠顺序</button>
+          <button onclick="scene1Reset()">重置</button>
+        </div>
+      </div>
+
+      <div class="code-block"><span class="comment">/* 正常层叠：z-index 决定一切 */</span>
+<span class="selector">.box-1</span> { <span class="property">position</span>: <span class="value">absolute</span>; <span class="property">z-index</span>: <span class="value">1</span>; }
+<span class="selector">.box-2</span> { <span class="property">position</span>: <span class="value">absolute</span>; <span class="property">z-index</span>: <span class="value">2</span>; }
+<span class="selector">.box-3</span> { <span class="property">position</span>: <span class="value">absolute</span>; <span class="property">z-index</span>: <span class="value">3</span>; }
+
+<span class="comment">/* 结果：box-3 盖住 box-2，box-2 盖住 box-1 */</span></div>
+
+      <div class="info-box">
+        <h4>要点</h4>
+        <p>当所有元素都在同一个层叠上下文（根层叠上下文）中时，z-index 值直接比较，值大的在上。</p>
+      </div>
+    </div>
+  </div>
+
+  <div id="tab-scene2" class="tab-content">
+    <div class="demo-area">
+      <h3>场景2：transform 创建层叠上下文陷阱</h3>
+      <p>当父元素使用 transform 时，会创建新的层叠上下文。子元素的 z-index 只在该上下文内有效！</p>
+
+      <div class="demo-box">
+        <h4>问题演示</h4>
+        <p style="color: #f5576c;">紫色容器有 transform，红色方块 z-index: 1000 在它内部。<br>绿色方块 z-index: 2 在外部，但仍然盖住红色方块！</p>
+        <div class="scene-container" id="scene2-demo">
+          <div class="scene2-parent" id="scene2-parent">
+            <div class="scene2-parent-inner" id="scene2-inner">z-index: 1000</div>
+          </div>
+          <div class="scene2-child" id="scene2-child">z-index: 2</div>
+          <div class="scene2-external">z-index: 2</div>
+        </div>
+        <div class="controls">
+          <button onclick="scene2ToggleTransform()">切换 transform</button>
+          <button onclick="scene2Reset()">重置</button>
+        </div>
+      </div>
+
+      <div class="code-block"><span class="comment">/* 父元素没有 transform - 正常行为 */</span>
+<span class="selector">.parent</span> { <span class="property">position</span>: <span class="value">relative</span>; }
+<span class="selector">.child</span> { <span class="property">position</span>: <span class="value">absolute</span>; <span class="property">z-index</span>: <span class="value">1000</span>; }
+<span class="selector">.external</span> { <span class="property">position</span>: <span class="value">relative</span>; <span class="property">z-index</span>: <span class="value">2</span>; }
+
+<span class="comment">/* 问题：.child 会被 .external 盖住！ */</span>
+<span class="comment">/* 原因：.parent 的 transform 创建了新层叠上下文 */</span>
+<span class="selector">.parent</span> { <span class="property">transform</span>: <span class="value">scale(1)</span>; }</div>
+
+      <div class="warning-box">
+        <h4>为什么 z-index: 1000 输了？</h4>
+        <p>
+          因为 <code>.parent</code> 有 <code>transform</code>，它创建了一个新的层叠上下文。<br><br>
+          在这个新上下文中，<code>.child</code> 的 <code>z-index: 1000</code> 是相对于 <code>.parent</code> 的。<br><br>
+          而 <code>.parent</code> 本身的 z-index 是 <code>auto</code>（相当于 0），所以 <code>.parent</code> 整体会排在 <code>.external</code>（z-index: 2）下面。
+        </p>
+      </div>
+
+      <div class="info-box">
+        <h4>解决方案</h4>
+        <p>
+          1. 移除不必要的 transform<br>
+          2. 将需要比较的元素放到同一个层叠上下文中<br>
+          3. 给父元素设置更高的 z-index
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div id="tab-scene3" class="tab-content">
+    <div class="demo-area">
+      <h3>场景3：多个层叠上下文叠加</h3>
+      <p>展示多个层叠上下文同时存在时的层叠规则。</p>
+
+      <div class="demo-box">
+        <h4>三层嵌套的层叠上下文</h4>
+        <div class="scene-container" id="scene3-demo">
+          <div class="scene3-context scene3-a" id="ctx-a">
+            Context A<br>z-index: 1
+            <div class="scene3-inner" style="background: #e06c75;">inner: 999</div>
+          </div>
+          <div class="scene3-context scene3-b" id="ctx-b">
+            Context B<br>z-index: 2
+            <div class="scene3-inner" style="background: #61afef;">inner: 1</div>
+          </div>
+          <div class="scene3-context scene3-c" id="ctx-c">
+            Context C<br>z-index: 3
+            <div class="scene3-inner" style="background: #98c379;">inner: 1</div>
+          </div>
+        </div>
+        <div class="controls">
+          <button onclick="scene3ToggleContext()">切换上下文 z-index</button>
+          <button onclick="scene3Reset()">重置</button>
+        </div>
+      </div>
+
+      <div class="code-block"><span class="comment">/* 每个容器都有自己的层叠上下文 */</span>
+<span class="selector">.context-a</span> { <span class="property">position</span>: <span class="value">absolute</span>; <span class="property">z-index</span>: <span class="value">1</span>; <span class="property">transform</span>: <span class="value">scale(1)</span>; }
+<span class="selector">.context-b</span> { <span class="property">position</span>: <span class="value">absolute</span>; <span class="property">z-index</span>: <span class="value">2</span>; <span class="property">transform</span>: <span class="value">scale(1)</span>; }
+<span class="selector">.context-c</span> { <span class="property">position</span>: <span class="value">absolute</span>; <span class="property">z-index</span>: <span class="value">3</span>; <span class="property">transform</span>: <span class="value">scale(1)</span>; }
+
+<span class="comment">/* 即使 inner 在 context-a 内有 z-index: 999 */</span>
+<span class="comment">/* 它的层级仍然受限于 context-a 的根 z-index: 1 */</span>
+<span class="comment">/* 所以它永远在 context-b（根 z-index: 2）之下 */</span></div>
+
+      <div class="warning-box">
+        <h4>层叠上下文之间的比较规则</h4>
+        <p>
+          比较两个层叠上下文时，只比较它们"根"的 z-index。<br><br>
+          <code>context-a.inner (z-index: 999)</code> vs <code>context-b (z-index: 2)</code><br>
+          → 比较的是 context-a 的根 (auto=0) 和 context-b 的根 (2)<br>
+          → 0 < 2，所以 context-b 整体在上层
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div id="tab-debug" class="tab-content">
+    <div class="demo-area">
+      <h3>Chrome DevTools 调试技巧</h3>
+
+      <div class="demo-box">
+        <h4>1. 打开 Layers 面板</h4>
+        <p>使用快捷键 <code>Cmd+Shift+P</code>（Mac）或 <code>Ctrl+Shift+P</code>（Windows）打开命令面板，输入 "Layers"。</p>
+      </div>
+
+      <div class="demo-box">
+        <h4>2. 显示图层边框</h4>
+        <p>在命令面板中输入 "Show Layer Borders"，页面上的每个图层会显示彩色边框：</p>
+        <ul style="color: #aaa; margin: 12px; line-height: 1.8;">
+          <li>橙色边框：合成图层（Compositor Layer）</li>
+          <li>蓝色边框：GCD 纹理图层</li>
+        </ul>
+      </div>
+
+      <div class="demo-box">
+        <h4>3. Elements 面板检查</h4>
+        <p>在 Elements 面板中选中元素，查看 Styles 面板：</p>
+        <div class="code-block"><span class="comment">检查这些属性：*/</span>
+<span class="property">position</span>: <span class="value">relative</span> | <span class="value">absolute</span> | <span class="value">fixed</span>
+<span class="property">z-index</span>: <span class="value">数字</span> | <span class="value">auto</span>
+<span class="property">transform</span>: <span class="value">非 none 值会创建层叠上下文</span>
+<span class="property">opacity</span>: <span class="value">&lt; 1 会创建层叠上下文</span>
+<span class="property">filter</span>: <span class="value">非 none 值会创建层叠上下文</span></div>
+      </div>
+
+      <div class="demo-box">
+        <h4>4. 调试步骤流程</h4>
+        <div class="info-box">
+          <h4>步骤 1：定位问题元素</h4>
+          <p>使用选择工具点击被遮挡的元素</p>
+        </div>
+        <div class="info-box">
+          <h4>步骤 2：检查 z-index</h4>
+          <p>在 Styles 面板查看 z-index 值</p>
+        </div>
+        <div class="info-box">
+          <h4>步骤 3：检查父元素</h4>
+          <p>向上遍历，检查是否有 transform/filter/opacity/position+z-index</p>
+        </div>
+        <div class="info-box">
+          <h4>步骤 4：验证 Layers 面板</h4>
+          <p>在 Layers 面板中查看图层顺序是否正确</p>
+        </div>
+      </div>
+
+      <div class="warning-box">
+        <h4>常见踩坑点</h4>
+        <p>
+          <strong>1. transform 导致层叠上下文</strong><br>
+          给元素添加 transform（如 translateZ(0) 做 GPU 加速）会隐式创建层叠上下文。<br><br>
+          <strong>2. z-index 的相对性</strong><br>
+          z-index: 100 在层叠上下文 A 内，可能比 z-index: 1 在层叠上下文 B 内更低。<br><br>
+          <strong>3. opacity &lt; 1 也会创建</strong><br>
+          opacity: 0.99 看起来和不透明一样，但会创建新的层叠上下文！
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // Tab switching
+    const tabBtns = document.querySelectorAll('.tab-btn');
+    const tabContents = document.querySelectorAll('.tab-content');
+    tabBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const tabId = btn.dataset.tab;
+        tabBtns.forEach(b => b.classList.remove('active'));
+        tabContents.forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById('tab-' + tabId).classList.add('active');
+      });
+    });
+
+    // Scene 1: Toggle z-index
+    let scene1Order = [1, 2, 3];
+    function scene1Toggle() {
+      scene1Order = scene1Order.map(v => 4 - v);
+      const boxes = document.querySelectorAll('.scene1-box');
+      boxes.forEach((box, i) => {
+        box.style.zIndex = scene1Order[i];
+        box.textContent = `z-index: ${scene1Order[i]}`;
+      });
+    }
+    function scene1Reset() {
+      scene1Order = [1, 2, 3];
+      const boxes = document.querySelectorAll('.scene1-box');
+      boxes.forEach((box, i) => {
+        box.style.zIndex = scene1Order[i];
+        box.textContent = `z-index: ${scene1Order[i]}`;
+      });
+    }
+
+    // Scene 2: Toggle transform
+    let hasTransform = true;
+    function scene2ToggleTransform() {
+      hasTransform = !hasTransform;
+      const parent = document.getElementById('scene2-parent');
+      const inner = document.getElementById('scene2-inner');
+      const child = document.getElementById('scene2-child');
+
+      if (hasTransform) {
+        parent.style.transform = 'scale(1)';
+        inner.textContent = 'z-index: 1000';
+        child.textContent = 'z-index: 2';
+        child.nextElementSibling.textContent = 'z-index: 2';
+      } else {
+        parent.style.transform = 'none';
+        inner.textContent = 'z-index: 1000 (无 transform)';
+        child.textContent = 'z-index: 2 (外部)';
+        child.nextElementSibling.textContent = 'z-index: 2';
+      }
+    }
+    function scene2Reset() {
+      hasTransform = true;
+      const parent = document.getElementById('scene2-parent');
+      const inner = document.getElementById('scene2-inner');
+      const child = document.getElementById('scene2-child');
+      parent.style.transform = 'scale(1)';
+      inner.textContent = 'z-index: 1000';
+      child.textContent = 'z-index: 2';
+      child.nextElementSibling.textContent = 'z-index: 2';
+    }
+
+    // Scene 3: Toggle context z-index
+    let scene3Order = [1, 2, 3];
+    function scene3ToggleContext() {
+      scene3Order = scene3Order.map(v => 4 - v);
+      const contexts = ['ctx-a', 'ctx-b', 'ctx-c'];
+      contexts.forEach((id, i) => {
+        const el = document.getElementById(id);
+        el.style.zIndex = scene3Order[i];
+        el.querySelector('.scene3-inner').style.background =
+          ['#e06c75', '#61afef', '#98c379'][i];
+      });
+    }
+    function scene3Reset() {
+      scene3Order = [1, 2, 3];
+      const contexts = ['ctx-a', 'ctx-b', 'ctx-c'];
+      contexts.forEach((id, i) => {
+        const el = document.getElementById(id);
+        el.style.zIndex = scene3Order[i];
+        el.querySelector('.scene3-inner').style.background =
+          ['#e06c75', '#61afef', '#98c379'][i];
+      });
+    }
+
+    // Initialize scene 2 with transform
+    scene2Reset();
+  </script>
+</body>
+</html>

--- a/examples/css/demos/sticky-position/sticky-position-demo.html
+++ b/examples/css/demos/sticky-position/sticky-position-demo.html
@@ -1,0 +1,1021 @@
+﻿<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>CSS Sticky Position 交互演示</title>
+<style>
+  * {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    background: #1a1a2e;
+    color: #eee;
+    min-height: 100vh;
+  }
+
+  /* Tab 导航 */
+  .tab-nav {
+    position: sticky;
+    top: 0;
+    z-index: 100;
+    display: flex;
+    background: #16213e;
+    border-bottom: 1px solid #0f3460;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .tab-nav::-webkit-scrollbar {
+    display: none;
+  }
+
+  .tab-btn {
+    flex: 0 0 auto;
+    padding: 14px 20px;
+    background: transparent;
+    border: none;
+    color: #888;
+    font-size: 14px;
+    cursor: pointer;
+    transition: all 0.2s;
+    white-space: nowrap;
+    border-bottom: 2px solid transparent;
+  }
+
+  .tab-btn:hover {
+    color: #eee;
+    background: rgba(255,255,255,0.05);
+  }
+
+  .tab-btn.active {
+    color: #00d9ff;
+    border-bottom-color: #00d9ff;
+  }
+
+  /* Tab 内容区 */
+  .tab-content {
+    display: none;
+    padding: 20px;
+    max-width: 900px;
+    margin: 0 auto;
+  }
+
+  .tab-content.active {
+    display: block;
+  }
+
+  /* 通用标题 */
+  h2 {
+    color: #00d9ff;
+    margin: 20px 0 15px;
+    font-size: 18px;
+  }
+
+  h3 {
+    color: #fff;
+    margin: 15px 0 10px;
+    font-size: 16px;
+  }
+
+  p, li {
+    color: #ccc;
+    line-height: 1.7;
+    font-size: 14px;
+  }
+
+  ul {
+    padding-left: 20px;
+  }
+
+  li {
+    margin: 5px 0;
+  }
+
+  code {
+    background: #0f3460;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-family: 'Fira Code', 'Consolas', monospace;
+    font-size: 13px;
+    color: #e94560;
+  }
+
+  pre {
+    background: #0f3460;
+    padding: 15px;
+    border-radius: 8px;
+    overflow-x: auto;
+    margin: 10px 0;
+  }
+
+  pre code {
+    background: transparent;
+    padding: 0;
+    color: #a8dadc;
+    font-size: 13px;
+    line-height: 1.5;
+  }
+
+  /* 卡片通用样式 */
+  .demo-card {
+    background: #16213e;
+    border-radius: 12px;
+    margin: 20px 0;
+    overflow: hidden;
+    border: 1px solid #0f3460;
+  }
+
+  .demo-card-header {
+    padding: 12px 16px;
+    background: #0f3460;
+    font-size: 13px;
+    color: #00d9ff;
+    font-weight: 600;
+  }
+
+  .demo-card-body {
+    padding: 16px;
+  }
+
+  /* 模拟滚动区域 */
+  .scroll-container {
+    height: 300px;
+    overflow-y: auto;
+    background: linear-gradient(to bottom, #16213e, #0f3460, #16213e);
+    border-radius: 8px;
+    position: relative;
+  }
+
+  .scroll-content {
+    padding: 20px;
+    min-height: 600px;
+  }
+
+  /* Sticky 元素样式 */
+  .sticky-element {
+    position: sticky;
+    background: linear-gradient(135deg, #00d9ff, #00ff88);
+    color: #1a1a2e;
+    padding: 15px 20px;
+    border-radius: 8px;
+    font-weight: 600;
+    text-align: center;
+    box-shadow: 0 4px 15px rgba(0,217,255,0.3);
+  }
+
+  .sticky-top {
+    top: 0;
+  }
+
+  .sticky-bottom {
+    bottom: 0;
+  }
+
+  /* 按钮样式 */
+  .btn {
+    display: inline-block;
+    padding: 10px 20px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    font-size: 14px;
+    transition: transform 0.2s;
+  }
+
+  .btn:hover {
+    transform: scale(1.05);
+  }
+
+  /* 代码对比表 */
+  .compare-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 15px 0;
+    font-size: 13px;
+  }
+
+  .compare-table th,
+  .compare-table td {
+    padding: 10px 12px;
+    text-align: left;
+    border: 1px solid #0f3460;
+  }
+
+  .compare-table th {
+    background: #0f3460;
+    color: #00d9ff;
+    font-weight: 600;
+  }
+
+  .compare-table tr:nth-child(even) {
+    background: rgba(15,52,96,0.3);
+  }
+
+  /* 检查清单 */
+  .checklist {
+    background: #0f3460;
+    border-radius: 8px;
+    padding: 15px;
+    margin: 15px 0;
+  }
+
+  .checklist-item {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 8px 0;
+    border-bottom: 1px solid rgba(255,255,255,0.1);
+  }
+
+  .checklist-item:last-child {
+    border-bottom: none;
+  }
+
+  .check-icon {
+    color: #00ff88;
+    font-size: 16px;
+  }
+
+  /* 流程图 */
+  .flow-diagram {
+    background: #0f3460;
+    border-radius: 8px;
+    padding: 20px;
+    margin: 15px 0;
+  }
+
+  .flow-step {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    padding: 10px 0;
+  }
+
+  .flow-number {
+    width: 28px;
+    height: 28px;
+    background: linear-gradient(135deg, #00d9ff, #00ff88);
+    color: #1a1a2e;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    font-size: 14px;
+    flex-shrink: 0;
+  }
+
+  .flow-text {
+    color: #eee;
+    font-size: 14px;
+  }
+
+  /* Quiz */
+  .quiz-container {
+    background: #0f3460;
+    border-radius: 8px;
+    padding: 20px;
+    margin: 15px 0;
+  }
+
+  .quiz-question {
+    font-size: 15px;
+    color: #fff;
+    margin-bottom: 15px;
+    font-weight: 600;
+  }
+
+  .quiz-options {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+  }
+
+  .quiz-option {
+    padding: 12px 16px;
+    background: #16213e;
+    border: 1px solid #0f3460;
+    border-radius: 8px;
+    cursor: pointer;
+    transition: all 0.2s;
+    color: #ccc;
+  }
+
+  .quiz-option:hover {
+    border-color: #00d9ff;
+    background: rgba(0,217,255,0.1);
+  }
+
+  .quiz-option.selected {
+    border-color: #00d9ff;
+    background: rgba(0,217,255,0.2);
+  }
+
+  .quiz-option.correct {
+    border-color: #00ff88;
+    background: rgba(0,255,136,0.2);
+  }
+
+  .quiz-option.incorrect {
+    border-color: #e94560;
+    background: rgba(233,69,96,0.2);
+  }
+
+  .quiz-result {
+    margin-top: 15px;
+    padding: 12px;
+    border-radius: 8px;
+    font-size: 14px;
+    display: none;
+  }
+
+  .quiz-result.show {
+    display: block;
+  }
+
+  .quiz-result.correct {
+    background: rgba(0,255,136,0.2);
+    color: #00ff88;
+  }
+
+  .quiz-result.incorrect {
+    background: rgba(233,69,96,0.2);
+    color: #e94560;
+  }
+
+  /* Demo 页面特有样式 */
+  .demo-page {
+    min-height: 100vh;
+    padding: 20px;
+  }
+
+  .demo-header {
+    text-align: center;
+    padding: 30px 0;
+    margin-bottom: 20px;
+  }
+
+  .demo-header h1 {
+    color: #00d9ff;
+    font-size: 24px;
+    margin-bottom: 10px;
+  }
+
+  .demo-header p {
+    color: #888;
+    font-size: 14px;
+  }
+
+  .card-demo {
+    max-width: 400px;
+    margin: 0 auto;
+    background: #16213e;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.3);
+  }
+
+  .card-image {
+    width: 100%;
+    height: 150px;
+    object-fit: cover;
+  }
+
+  .card-content {
+    padding: 16px;
+  }
+
+  .card-title {
+    color: #fff;
+    font-size: 18px;
+    margin-bottom: 8px;
+  }
+
+  .card-text {
+    color: #888;
+    font-size: 14px;
+    line-height: 1.6;
+    margin-bottom: 15px;
+  }
+
+  .card-footer {
+    position: sticky;
+    bottom: 0;
+    background: #16213e;
+    padding: 12px 16px;
+    border-top: 1px solid #0f3460;
+    box-shadow: 0 -4px 15px rgba(0,0,0,0.2);
+  }
+
+  .sticky-btn {
+    width: 100%;
+    padding: 12px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    border: none;
+    border-radius: 8px;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s;
+  }
+
+  .sticky-btn:hover {
+    transform: scale(1.02);
+  }
+
+  .spacer {
+    height: 100vh;
+  }
+
+  .scroll-indicator {
+    position: fixed;
+    top: 60px;
+    right: 20px;
+    background: #0f3460;
+    padding: 10px 15px;
+    border-radius: 8px;
+    font-size: 12px;
+    color: #00d9ff;
+    z-index: 99;
+  }
+
+  /* 滚动条样式 */
+  .scroll-container::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .scroll-container::-webkit-scrollbar-track {
+    background: rgba(255,255,255,0.1);
+    border-radius: 3px;
+  }
+
+  .scroll-container::-webkit-scrollbar-thumb {
+    background: #00d9ff;
+    border-radius: 3px;
+  }
+
+  /* 提示框 */
+  .tip-box {
+    background: rgba(0,217,255,0.1);
+    border: 1px solid #00d9ff;
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin: 15px 0;
+  }
+
+  .tip-box.warning {
+    background: rgba(233,69,96,0.1);
+    border-color: #e94560;
+  }
+
+  .tip-box.success {
+    background: rgba(0,255,136,0.1);
+    border-color: #00ff88;
+  }
+
+  .tip-title {
+    color: #00d9ff;
+    font-size: 13px;
+    font-weight: 600;
+    margin-bottom: 5px;
+  }
+
+  .tip-box.warning .tip-title {
+    color: #e94560;
+  }
+
+  .tip-box.success .tip-title {
+    color: #00ff88;
+  }
+
+  .tip-content {
+    color: #ccc;
+    font-size: 13px;
+  }
+</style>
+</head>
+<body>
+
+<!-- Tab 导航 -->
+<nav class="tab-nav">
+  <button class="tab-btn active" data-tab="overview">📚 概念总览</button>
+  <button class="tab-btn" data-tab="demo">🎯 交互演示</button>
+  <button class="tab-btn" data-tab="solution">💡 解决方案</button>
+  <button class="tab-btn" data-tab="troubleshoot">🔧 问题排查</button>
+  <button class="tab-btn" data-tab="quiz">📝 自测题</button>
+</nav>
+
+<!-- 概念总览 -->
+<div id="overview" class="tab-content active">
+  <h2>什么是 Sticky 定位？</h2>
+  <div class="tip-box">
+    <div class="tip-title">一句话理解</div>
+    <div class="tip-content">Sticky = relative + fixed 的混合体。元素在滚动时表现为 relative，达到阈值后表现为 fixed。</div>
+  </div>
+
+  <h2>核心特性</h2>
+  <ul>
+    <li><strong>未滚动时</strong>：像 <code>position: relative</code> 一样占据文档流位置</li>
+    <li><strong>滚动超过阈值</strong>：像 <code>position: fixed</code> 一样固定在视口</li>
+    <li><strong>不会脱离文档流</strong>：占据的空间始终保留</li>
+    <li><strong>父容器是关键</strong>：父容器的高度和 overflow 属性直接影响 sticky 行为</li>
+  </ul>
+
+  <h2>与其他定位对比</h2>
+  <table class="compare-table">
+    <thead>
+      <tr>
+        <th>定位类型</th>
+        <th>参照物</th>
+        <th>脱标</th>
+        <th>滚动行为</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><code>relative</code></td>
+        <td>元素原位置</td>
+        <td>否</td>
+        <td>随页面滚动</td>
+      </tr>
+      <tr>
+        <td><code>absolute</code></td>
+        <td>定位祖先</td>
+        <td>是</td>
+        <td>随容器滚动</td>
+      </tr>
+      <tr>
+        <td><code>fixed</code></td>
+        <td>视口</td>
+        <td>是</td>
+        <td>固定不动</td>
+      </tr>
+      <tr style="background: rgba(0,217,255,0.1);">
+        <td><code>sticky</code></td>
+        <td>滚动容器</td>
+        <td>否</td>
+        <td>阈值前随页面滚动，阈值后固定</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>工作原理图解</h2>
+  <div class="flow-diagram">
+    <div class="flow-step">
+      <span class="flow-number">1</span>
+      <span class="flow-text">初始状态：sticky 元素在文档流中正常定位（relative 行为）</span>
+    </div>
+    <div class="flow-step">
+      <span class="flow-number">2</span>
+      <span class="flow-text">用户开始滚动，sticky 元素随页面移动</span>
+    </div>
+    <div class="flow-step">
+      <span class="flow-number">3</span>
+      <span class="flow-text">滚动超过 <code>top</code> 值设定的阈值</span>
+    </div>
+    <div class="flow-step">
+      <span class="flow-number">4</span>
+      <span class="flow-text">sticky 元素"粘"在视口指定位置（fixed 行为）</span>
+    </div>
+    <div class="flow-step">
+      <span class="flow-number">5</span>
+      <span class="flow-text">滚动到父容器底部，sticky 效果解除</span>
+    </div>
+  </div>
+
+  <h2>必须条件</h2>
+  <div class="checklist">
+    <div class="checklist-item">
+      <span class="check-icon">✓</span>
+      <span>父容器不能有 <code>overflow: hidden/auto/scroll</code></span>
+    </div>
+    <div class="checklist-item">
+      <span class="check-icon">✓</span>
+      <span>父容器高度必须大于 sticky 元素</span>
+    </div>
+    <div class="checklist-item">
+      <span class="check-icon">✓</span>
+      <span>必须指定 <code>top/bottom/left/right</code> 之一</span>
+    </div>
+    <div class="checklist-item">
+      <span class="check-icon">✓</span>
+      <span>祖先元素不能有 <code>transform</code> 属性</span>
+    </div>
+  </div>
+</div>
+
+<!-- 交互演示 -->
+<div id="demo" class="tab-content">
+  <h2>Sticky 卡片按钮固定演示</h2>
+  <p>向下滚动页面，观察卡片底部的按钮如何固定：</p>
+
+  <div class="demo-card">
+    <div class="demo-card-header">📱 卡片按钮 Sticky 固定效果</div>
+    <div class="demo-card-body">
+      <div class="card-demo">
+        <img src="https://picsum.photos/400/150?random=1" alt="卡片图片" class="card-image">
+        <div class="card-content">
+          <h3 class="card-title">卡片标题</h3>
+          <p class="card-text">
+            向下滚动这个页面。当卡片滚过视口顶部时，底部的操作按钮将自动固定在视口底部...
+          </p>
+        </div>
+        <div class="card-footer">
+          <button class="sticky-btn">🎯 操作按钮（已固定）</button>
+        </div>
+      </div>
+      <div class="spacer"></div>
+    </div>
+  </div>
+
+  <h2>Sticky 元素在容器内固定</h2>
+  <p>在滚动容器内，sticky 元素会在容器内固定：</p>
+
+  <div class="demo-card">
+    <div class="demo-card-header">📦 滚动容器内的 Sticky 效果</div>
+    <div class="demo-card-body">
+      <div class="scroll-container">
+        <div class="scroll-content">
+          <div class="sticky-element sticky-top">🔥 我在顶部 sticky 固定</div>
+          <p style="margin: 20px 0; color: #888;">
+            继续向下滚动... 我是占位内容，用于增加滚动区域的高度。
+          </p>
+          <p style="margin: 20px 0; color: #888;">
+            Sticky 元素的固定范围受限于父容器。当父容器滚动到底部时，sticky 效果会自动解除。
+          </p>
+          <p style="margin: 20px 0; color: #888;">
+            这是为了确保 sticky 元素不会超出其容器的边界。
+          </p>
+          <div class="sticky-element sticky-bottom">🎯 我在底部 sticky 固定</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h2>实际应用场景</h2>
+  <div class="demo-card">
+    <div class="demo-card-header">📝 表单提交按钮固定</div>
+    <div class="demo-card-body">
+      <div class="flow-diagram">
+        <p style="color: #ccc; font-size: 14px;">
+          场景：长表单页面，提交按钮需要始终可见。<br>
+          方案：使用 <code>position: sticky</code> + <code>bottom: 0</code> 让按钮固定在视口底部。
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-card">
+    <div class="demo-card-header">📊 表格列头固定</div>
+    <div class="demo-card-body">
+      <div class="flow-diagram">
+        <p style="color: #ccc; font-size: 14px;">
+          场景：数据表格很长，滚动时列头需要始终可见。<br>
+          方案：给 <code>thead th</code> 设置 <code>position: sticky</code> + <code>top: 0</code>。
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- 解决方案 -->
+<div id="solution" class="tab-content">
+  <h2>卡片内按钮固定：完整代码</h2>
+
+  <h3>HTML 结构</h3>
+  <pre><code>&lt;div class="card"&gt;
+  &lt;div class="card-content"&gt;
+    &lt;h3&gt;卡片标题&lt;/h3&gt;
+    &lt;p&gt;卡片内容...&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;div class="card-footer"&gt;
+    &lt;button&gt;操作按钮&lt;/button&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
+  <h3>CSS 样式</h3>
+  <pre><code>.card {
+  position: relative; /* 关键：创建定位上下文 */
+  background: white;
+  border-radius: 12px;
+  margin-bottom: 20px;
+}
+
+.card-footer {
+  position: sticky;    /* 启用 sticky */
+  bottom: 0;          /* 距离底部 0 时固定 */
+  background: white;   /* 背景色覆盖下方内容 */
+  padding: 12px 16px;
+  border-top: 1px solid #eee;
+}
+
+button {
+  width: 100%;
+  padding: 12px;
+  background: #007AFF;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+}</code></pre>
+
+  <h2>方案对比</h2>
+  <table class="compare-table">
+    <thead>
+      <tr>
+        <th>方案</th>
+        <th>优点</th>
+        <th>缺点</th>
+        <th>适用场景</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Sticky 包裹按钮</td>
+        <td>简单、原生支持</td>
+        <td>父容器 overflow 影响</td>
+        <td>大多数场景</td>
+      </tr>
+      <tr>
+        <td>按钮独立 sticky</td>
+        <td>更灵活</td>
+        <td>需要预留空间</td>
+        <td>按钮在内容区底部</td>
+      </tr>
+      <tr>
+        <td>Fixed 定位</td>
+        <td>不受父容器影响</td>
+        <td>需要 JS 控制显隐</td>
+        <td>复杂交互场景</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>iOS Safari 兼容处理</h2>
+  <div class="tip-box warning">
+    <div class="tip-title">⚠️ iOS Safari 问题</div>
+    <div class="tip-content">iOS Safari 14.5 以下版本对 sticky 支持不完整，需要使用 -webkit- 前缀。</div>
+  </div>
+  <pre><code>/* iOS Safari Hack */
+.sticky-footer {
+  position: sticky;
+  position: -webkit-sticky; /* iOS Safari */
+  bottom: 0;
+  /* 添加 transform 触发 GPU 加速 */
+  transform: translateZ(0);
+}</code></pre>
+
+  <h2>降级方案</h2>
+  <div class="tip-box success">
+    <div class="tip-title">✅ 推荐降级写法</div>
+    <div class="tip-content">使用 @supports 检测浏览器支持情况，不支持时降级为 fixed。</div>
+  </div>
+  <pre><code>@supports (position: sticky) {
+  .sticky-element {
+    position: sticky;
+    top: 0;
+  }
+}
+
+@supports not (position: sticky) {
+  .sticky-element {
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+  }
+}</code></pre>
+</div>
+
+<!-- 问题排查 -->
+<div id="troubleshoot" class="tab-content">
+  <h2>Sticky 不生效？按顺序检查！</h2>
+
+  <div class="checklist">
+    <div class="checklist-item">
+      <span class="check-icon">1</span>
+      <span><strong>是否指定了 top/bottom/left/right？</strong><br>
+      <code style="color:#888;">position: sticky</code> 单独写不会生效，必须配合偏移值。</span>
+    </div>
+    <div class="checklist-item">
+      <span class="check-icon">2</span>
+      <span><strong>父容器是否有 overflow 设置？</strong><br>
+      <code style="color:#888;">overflow: hidden/auto/scroll</code> 会阻断 sticky 效果。</span>
+    </div>
+    <div class="checklist-item">
+      <span class="check-icon">3</span>
+      <span><strong>父容器高度是否足够？</strong><br>
+      如果父容器比 sticky 元素还矮，就不会有滚动空间。</span>
+    </div>
+    <div class="checklist-item">
+      <span class="check-icon">4</span>
+      <span><strong>祖先元素是否有 transform？</strong><br>
+      transform 会创建新的 containing block，影响 sticky 参照。</span>
+    </div>
+    <div class="checklist-item">
+      <span class="check-icon">5</span>
+      <span><strong>是否在 flex 容器内？</strong><br>
+      flex 子元素的 sticky 行为可能不符合预期。</span>
+    </div>
+  </div>
+
+  <h2>常见错误代码</h2>
+
+  <h3>错误 1：忘记写偏移值</h3>
+  <div class="demo-card">
+    <div class="demo-card-header">❌ 错误写法</div>
+    <div class="demo-card-body">
+      <pre><code>.sticky {
+  position: sticky;
+  /* 忘记写 top/bottom! */
+}</code></pre>
+    </div>
+  </div>
+  <div class="demo-card">
+    <div class="demo-card-header">✅ 正确写法</div>
+    <div class="demo-card-body">
+      <pre><code>.sticky {
+  position: sticky;
+  top: 0; /* 必须写！ */
+}</code></pre>
+    </div>
+  </div>
+
+  <h3>错误 2：父容器 overflow 阻断</h3>
+  <div class="demo-card">
+    <div class="demo-card-header">❌ 错误写法</div>
+    <div class="demo-card-body">
+      <pre><code>.parent {
+  overflow: hidden; /* 阻断 sticky! */
+}
+
+.sticky {
+  position: sticky;
+  top: 0;
+}</code></pre>
+    </div>
+  </div>
+  <div class="demo-card">
+    <div class="demo-card-header">✅ 正确写法</div>
+    <div class="demo-card-body">
+      <pre><code>.parent {
+  overflow: visible; /* 或不设置 */
+}
+
+.sticky {
+  position: sticky;
+  top: 0;
+}</code></pre>
+    </div>
+  </div>
+
+  <h3>错误 3：祖先元素有 transform</h3>
+  <div class="demo-card">
+    <div class="demo-card-header">❌ 错误写法</div>
+    <div class="demo-card-body">
+      <pre><code>.ancestor {
+  transform: translateZ(0); /* 创建新的 containing block! */
+}
+
+.parent {
+  /* sticky 效果会被影响 */
+}</code></pre>
+    </div>
+  </div>
+
+  <h2>iOS Safari 特殊处理</h2>
+  <div class="tip-box warning">
+    <div class="tip-title">iOS Safari 兼容清单</div>
+    <div class="tip-content">
+      1. 使用 <code>-webkit-</code> 前缀<br>
+      2. 确保父容器不是 <code>overflow: hidden</code><br>
+      3. 添加 <code>transform: translateZ(0)</code> 触发 GPU 加速
+    </div>
+  </div>
+</div>
+
+<!-- 自测题 -->
+<div id="quiz" class="tab-content">
+  <h2>自测检验学习成果</h2>
+
+  <div class="quiz-container">
+    <div class="quiz-question">1. position: sticky 必须配合哪个属性才能生效？</div>
+    <div class="quiz-options">
+      <div class="quiz-option" data-correct="true">top / bottom / left / right 之一</div>
+      <div class="quiz-option">z-index</div>
+      <div class="quiz-option">display: flex</div>
+      <div class="quiz-option">overflow: visible</div>
+    </div>
+    <div class="quiz-result"></div>
+  </div>
+
+  <div class="quiz-container">
+    <div class="quiz-question">2. 什么情况下 sticky 会失效？</div>
+    <div class="quiz-options">
+      <div class="quiz-option">父容器设置 overflow: hidden</div>
+      <div class="quiz-option">父容器高度小于 sticky 元素</div>
+      <div class="quiz-option">祖先元素有 transform</div>
+      <div class="quiz-option" data-correct="true">以上都是</div>
+    </div>
+    <div class="quiz-result"></div>
+  </div>
+
+  <div class="quiz-container">
+    <div class="quiz-question">3. sticky 元素滚动超过阈值后会变成什么定位？</div>
+    <div class="quiz-options">
+      <div class="quiz-option">relative</div>
+      <div class="quiz-option" data-correct="true">fixed</div>
+      <div class="quiz-option">absolute</div>
+      <div class="quiz-option">static</div>
+    </div>
+    <div class="quiz-result"></div>
+  </div>
+
+  <div class="quiz-container">
+    <div class="quiz-question">4. iOS Safari 需要加什么前缀？</div>
+    <div class="quiz-options">
+      <div class="quiz-option">-ms-sticky</div>
+      <div class="quiz-option">-moz-sticky</div>
+      <div class="quiz-option" data-correct="true">-webkit-sticky</div>
+      <div class="quiz-option">不需要前缀</div>
+    </div>
+    <div class="quiz-result"></div>
+  </div>
+
+  <div class="quiz-container">
+    <div class="quiz-question">5. sticky 相对于什么定位？</div>
+    <div class="quiz-options">
+      <div class="quiz-option">视口</div>
+      <div class="quiz-option">html 元素</div>
+      <div class="quiz-option" data-correct="true">滚动容器（父元素）</div>
+      <div class="quiz-option">body 元素</div>
+    </div>
+    <div class="quiz-result"></div>
+  </div>
+</div>
+
+<div style="height: 100px;"></div>
+
+<script>
+// Tab 切换
+document.querySelectorAll('.tab-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    // 移除所有 active
+    document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+    document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+
+    // 添加 active
+    btn.classList.add('active');
+    const tabId = btn.dataset.tab;
+    document.getElementById(tabId).classList.add('active');
+  });
+});
+
+// Quiz 交互
+document.querySelectorAll('.quiz-option').forEach(option => {
+  option.addEventListener('click', function() {
+    const container = this.closest('.quiz-container');
+    const options = container.querySelectorAll('.quiz-option');
+    const result = container.querySelector('.quiz-result');
+    const isCorrect = this.dataset.correct === 'true';
+
+    // 清除所有选中状态
+    options.forEach(opt => {
+      opt.classList.remove('selected', 'correct', 'incorrect');
+    });
+
+    // 标记当前选中
+    this.classList.add('selected');
+
+    // 显示结果
+    result.classList.add('show');
+    if (isCorrect) {
+      this.classList.add('correct');
+      result.textContent = '✅ 回答正确！';
+      result.classList.add('correct');
+      result.classList.remove('incorrect');
+    } else {
+      this.classList.add('incorrect');
+      // 显示正确答案
+      options.forEach(opt => {
+        if (opt.dataset.correct === 'true') {
+          opt.classList.add('correct');
+        }
+      });
+      result.textContent = '❌ 回答错误，正确答案是绿色高亮的选项。';
+      result.classList.add('incorrect');
+      result.classList.remove('correct');
+    }
+  });
+});
+</script>
+
+</body>
+</html>

--- a/examples/css/demos/typical-css-layouts/index.html
+++ b/examples/css/demos/typical-css-layouts/index.html
@@ -1,0 +1,651 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>典型 CSS 布局交互演示</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0a0a0f;
+      color: #e0e0e0;
+      min-height: 100vh;
+      padding: 20px;
+    }
+    h1 {
+      text-align: center;
+      font-size: 1.8rem;
+      margin-bottom: 20px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .tab-nav {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .tab-btn {
+      padding: 10px 20px;
+      background: #1a1a2e;
+      border: 1px solid #333;
+      border-radius: 8px;
+      color: #888;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: all 0.2s;
+    }
+    .tab-btn:hover { background: #252540; color: #fff; }
+    .tab-btn.active {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      border-color: transparent;
+    }
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+    .demo-area {
+      background: #1a1a2e;
+      border: 1px solid #333;
+      border-radius: 12px;
+      padding: 20px;
+      margin-bottom: 20px;
+    }
+    .demo-area h3 {
+      color: #667eea;
+      margin-bottom: 12px;
+      font-size: 1.1rem;
+    }
+    .demo-area p {
+      color: #aaa;
+      font-size: 0.9rem;
+      line-height: 1.6;
+      margin-bottom: 12px;
+    }
+    .demo-box {
+      background: #0f0f1a;
+      border: 1px solid #333;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+    }
+    .demo-box h4 {
+      color: #667eea;
+      margin-bottom: 12px;
+      font-size: 1rem;
+    }
+    .code-block {
+      background: #0d0d1a;
+      border: 1px solid #333;
+      border-radius: 6px;
+      padding: 12px;
+      margin: 12px 0;
+      font-family: 'Fira Code', 'Consolas', monospace;
+      font-size: 0.85rem;
+      overflow-x: auto;
+      color: #a0a0c0;
+      white-space: pre-wrap;
+    }
+    .code-block .keyword { color: #c678dd; }
+    .code-block .string { color: #98c379; }
+    .code-block .property { color: #e5c07b; }
+    .code-block .value { color: #61afef; }
+    .code-block .selector { color: #e06c75; }
+    .code-block .comment { color: #5c6370; font-style: italic; }
+    /* Layout Demos */
+    .single-column-demo {
+      display: flex;
+      flex-direction: column;
+      border: 2px solid #667eea;
+      border-radius: 8px;
+      min-height: 200px;
+    }
+    .single-column-demo header {
+      background: #667eea;
+      padding: 12px;
+      text-align: center;
+      border-radius: 6px 6px 0 0;
+    }
+    .single-column-demo main {
+      flex: 1;
+      padding: 12px;
+      background: #1a1a2e;
+    }
+    .single-column-demo footer {
+      background: #764ba2;
+      padding: 12px;
+      text-align: center;
+      border-radius: 0 0 6px 6px;
+    }
+    .two-column-demo {
+      display: flex;
+      border: 2px solid #667eea;
+      border-radius: 8px;
+      min-height: 150px;
+      overflow: hidden;
+    }
+    .two-column-demo .sidebar {
+      width: 120px;
+      background: #764ba2;
+      padding: 12px;
+      flex-shrink: 0;
+    }
+    .two-column-demo .content {
+      flex: 1;
+      background: #1a1a2e;
+      padding: 12px;
+    }
+    .three-column-demo {
+      display: flex;
+      border: 2px solid #667eea;
+      border-radius: 8px;
+      min-height: 120px;
+      overflow: hidden;
+    }
+    .three-column-demo .left-sidebar,
+    .three-column-demo .right-sidebar {
+      width: 80px;
+      background: #764ba2;
+      padding: 12px;
+      flex-shrink: 0;
+    }
+    .three-column-demo .main {
+      flex: 1;
+      background: #1a1a2e;
+      padding: 12px;
+    }
+    .holy-grail-demo {
+      display: flex;
+      flex-direction: column;
+      border: 2px solid #667eea;
+      border-radius: 8px;
+      min-height: 200px;
+      overflow: hidden;
+    }
+    .holy-grail-demo .body {
+      display: flex;
+      flex: 1;
+    }
+    .holy-grail-demo header,
+    .holy-grail-demo footer {
+      background: #667eea;
+      padding: 12px;
+      text-align: center;
+    }
+    .holy-grail-demo .left-sidebar,
+    .holy-grail-demo .right-sidebar {
+      width: 80px;
+      background: #764ba2;
+      padding: 12px;
+      flex-shrink: 0;
+    }
+    .holy-grail-demo .main {
+      flex: 1;
+      background: #1a1a2e;
+      padding: 12px;
+    }
+    .grid-demo {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 12px;
+      border: 2px solid #667eea;
+      border-radius: 8px;
+      padding: 12px;
+    }
+    .grid-demo .grid-item {
+      background: #764ba2;
+      border-radius: 6px;
+      padding: 20px;
+      text-align: center;
+    }
+    .masonry-demo {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+      grid-auto-rows: 60px;
+      gap: 8px;
+      border: 2px solid #667eea;
+      border-radius: 8px;
+      padding: 12px;
+    }
+    .masonry-demo .masonry-item {
+      background: #764ba2;
+      border-radius: 6px;
+      padding: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.8rem;
+    }
+    .masonry-demo .masonry-item:nth-child(odd) { grid-row: span 3; }
+    .masonry-demo .masonry-item:nth-child(even) { grid-row: span 2; }
+    .flex-center-demo {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      border: 2px solid #667eea;
+      border-radius: 8px;
+      height: 150px;
+      background: #1a1a2e;
+    }
+    .flex-center-demo .center-box {
+      width: 100px;
+      height: 100px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      border-radius: 12px;
+    }
+    .controls {
+      display: flex;
+      gap: 12px;
+      margin-top: 12px;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    button {
+      padding: 10px 20px;
+      background: #252540;
+      border: 1px solid #444;
+      border-radius: 6px;
+      color: #e0e0e0;
+      cursor: pointer;
+      font-size: 0.9rem;
+      transition: all 0.2s;
+    }
+    button:hover { background: #333355; border-color: #667eea; }
+    button.primary {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      border: none;
+    }
+    .info-box {
+      background: #15152a;
+      border: 1px solid #333;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 16px;
+    }
+    .info-box h4 { color: #667eea; margin-bottom: 8px; }
+    .info-box p { color: #aaa; font-size: 0.9rem; line-height: 1.6; }
+    .comparison-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 12px 0;
+    }
+    .comparison-table th,
+    .comparison-table td {
+      border: 1px solid #333;
+      padding: 10px;
+      text-align: left;
+      font-size: 0.9rem;
+    }
+    .comparison-table th {
+      background: #1a1a2e;
+      color: #667eea;
+    }
+    .comparison-table td {
+      background: #0d0d1a;
+      color: #aaa;
+    }
+    .tag {
+      display: inline-block;
+      padding: 2px 8px;
+      background: #333;
+      border-radius: 4px;
+      font-size: 0.8rem;
+      margin-right: 4px;
+    }
+    .tag.recommended {
+      background: #667eea;
+      color: white;
+    }
+    .tag.traditional {
+      background: #764ba2;
+      color: white;
+    }
+    .tag.modern {
+      background: #98c379;
+      color: #0a0a0f;
+    }
+    code {
+      background: #1a1a2e;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-family: 'Fira Code', 'Consolas', monospace;
+      font-size: 0.85rem;
+      color: #e5c07b;
+    }
+  </style>
+</head>
+<body>
+  <h1>典型 CSS 布局交互演示</h1>
+
+  <div class="tab-nav">
+    <button class="tab-btn active" data-tab="overview">总览</button>
+    <button class="tab-btn" data-tab="single">单栏布局</button>
+    <button class="tab-btn" data-tab="two">两栏布局</button>
+    <button class="tab-btn" data-tab="three">三栏布局</button>
+    <button class="tab-btn" data-tab="holy-grail">圣杯布局</button>
+    <button class="tab-btn" data-tab="grid">Grid 布局</button>
+    <button class="tab-btn" data-tab="comparison">方案对比</button>
+  </div>
+
+  <div id="tab-overview" class="tab-content active">
+    <div class="demo-area">
+      <h3>CSS 布局方案总览</h3>
+      <p>CSS 布局经历了从 Table 到 Float 到 Flexbox 再到 CSS Grid 的演进。以下是常见布局模式及其适用场景：</p>
+      <table class="comparison-table">
+        <thead>
+          <tr>
+            <th>布局类型</th>
+            <th>推荐方案</th>
+            <th>适用场景</th>
+            <th>难度</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>单栏布局</td>
+            <td><span class="tag recommended">Flexbox</span></td>
+            <td>博客、文档</td>
+            <td>入门</td>
+          </tr>
+          <tr>
+            <td>两栏布局</td>
+            <td><span class="tag recommended">Flexbox/Grid</span></td>
+            <td>后台、侧边栏</td>
+            <td>入门</td>
+          </tr>
+          <tr>
+            <td>三栏布局</td>
+            <td><span class="tag recommended">Grid</span></td>
+            <td>门户网站</td>
+            <td>中等</td>
+          </tr>
+          <tr>
+            <td>圣杯布局</td>
+            <td><span class="tag modern">Flexbox</span></td>
+            <td>管理后台</td>
+            <td>中等</td>
+          </tr>
+          <tr>
+            <td>卡片网格</td>
+            <td><span class="tag recommended">Grid auto-fit</span></td>
+            <td>产品列表</td>
+            <td>入门</td>
+          </tr>
+          <tr>
+            <td>瀑布流</td>
+            <td><span class="tag modern">Grid + span</span></td>
+            <td>图片展示</td>
+            <td>中等</td>
+          </tr>
+        </tbody>
+      </table>
+      <div class="info-box">
+        <h4>💡 选择建议</h4>
+        <p>
+          <strong>一维布局</strong>（导航、列表、居中）→ Flexbox<br>
+          <strong>二维布局</strong>（页面框架、卡片网格）→ CSS Grid<br>
+          <strong>传统 Float</strong> → 仅需了解，新项目不再使用
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div id="tab-single" class="tab-content">
+    <div class="demo-area">
+      <h3>单栏布局 (Single Column)</h3>
+      <p>内容居中，头部、主体、底部垂直排列。Flexbox 方案最简洁。</p>
+      <div class="demo-box">
+        <div class="single-column-demo">
+          <header>Header 头部</header>
+          <main>Main Content 主内容区，自动填充剩余高度</main>
+          <footer>Footer 底部</footer>
+        </div>
+      </div>
+      <div class="code-block"><span class="selector">.single-column</span> {
+  <span class="property">display</span>: <span class="value">flex</span>;
+  <span class="property">flex-direction</span>: <span class="value">column</span>;
+  <span class="property">min-height</span>: <span class="value">100vh</span>;
+}
+<span class="selector">.single-column main</span> {
+  <span class="property">flex</span>: <span class="value">1</span>; <span class="comment">/* 主内容自动撑满 */</span>
+}</div>
+      <div class="info-box">
+        <h4>Flexbox 优势</h4>
+        <p>
+          相比 Float，无需处理清除浮动问题。<br>
+          相比 Table，语义更清晰，性能更好。<br>
+          相比 absolute 定位，不会脱离文档流。
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div id="tab-two" class="tab-content">
+    <div class="demo-area">
+      <h3>两栏布局 (Two Column)</h3>
+      <p>左侧固定宽度侧栏 + 右侧自适应内容区。</p>
+      <div class="demo-box">
+        <div class="two-column-demo">
+          <aside class="sidebar">Sidebar 250px</aside>
+          <main class="content">Main Content 自适应填充</main>
+        </div>
+      </div>
+      <div class="code-block"><span class="selector">.two-column</span> {
+  <span class="property">display</span>: <span class="value">flex</span>;
+}
+<span class="selector">.sidebar</span> {
+  <span class="property">width</span>: <span class="value">250px</span>;
+  <span class="property">flex-shrink</span>: <span class="value">0</span>; <span class="comment">/* 禁止压缩 */</span>
+}
+<span class="selector">.content</span> {
+  <span class="property">flex</span>: <span class="value">1</span>; <span class="comment">/* 自动填充 */</span>
+}</div>
+      <div class="info-box">
+        <h4>关键技巧</h4>
+        <p>
+          <code>flex-shrink: 0</code> 确保侧栏宽度固定不被压缩。<br>
+          <code>flex: 1</code> 让内容区自动填充剩余空间。
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div id="tab-three" class="tab-content">
+    <div class="demo-area">
+      <h3>三栏布局 (Three Column)</h3>
+      <p>左右侧栏固定宽度，中间内容自适应。</p>
+      <div class="demo-box">
+        <div class="three-column-demo">
+          <aside class="left-sidebar">Left</aside>
+          <main class="main">Main Content</main>
+          <aside class="right-sidebar">Right</aside>
+        </div>
+      </div>
+      <div class="code-block"><span class="comment">/* Flexbox 方案 */</span>
+<span class="selector">.three-column</span> { <span class="property">display</span>: <span class="value">flex</span>; }
+<span class="selector">.left-sidebar, .right-sidebar</span> { <span class="property">width</span>: <span class="value">200px</span>; <span class="property">flex-shrink</span>: <span class="value">0</span>; }
+<span class="selector">.main</span> { <span class="property">flex</span>: <span class="value">1</span>; }
+
+<span class="comment">/* Grid 方案（更简洁）*/</span>
+<span class="selector">.three-column</span> {
+  <span class="property">display</span>: <span class="value">grid</span>;
+  <span class="property">grid-template-columns</span>: <span class="value">200px 1fr 200px</span>;
+}</div>
+    </div>
+  </div>
+
+  <div id="tab-holy-grail" class="tab-content">
+    <div class="demo-area">
+      <h3>圣杯布局 (Holy Grail)</h3>
+      <p>经典五区域布局：Header + Left + Main + Right + Footer。Flexbox 一行搞定。</p>
+      <div class="demo-box">
+        <div class="holy-grail-demo">
+          <header>Header</header>
+          <div class="body">
+            <aside class="left-sidebar">Left</aside>
+            <main class="main">Main Content</main>
+            <aside class="right-sidebar">Right</aside>
+          </div>
+          <footer>Footer</footer>
+        </div>
+      </div>
+      <div class="code-block"><span class="selector">.holy-grail</span> {
+  <span class="property">display</span>: <span class="value">flex</span>;
+  <span class="property">flex-direction</span>: <span class="value">column</span>;
+  <span class="property">min-height</span>: <span class="value">100vh</span>;
+}
+<span class="selector">.holy-grail .body</span> { <span class="property">display</span>: <span class="value">flex</span>; <span class="property">flex</span>: <span class="value">1</span>; }
+<span class="selector">.holy-grail main</span> { <span class="property">flex</span>: <span class="value">1</span>; }
+<span class="selector">.holy-grail .left-sidebar, .holy-grail .right-sidebar</span> {
+  <span class="property">width</span>: <span class="value">200px</span>;
+  <span class="property">flex-shrink</span>: <span class="value">0</span>;
+}</div>
+      <div class="info-box">
+        <h4>历史回顾</h4>
+        <p>
+          圣杯布局诞生于 2006 年，最初使用 Float 实现，代码复杂。<br>
+          现代 Flexbox 让这个经典布局变得异常简单，10 行 CSS 即可。
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div id="tab-grid" class="tab-content">
+    <div class="demo-area">
+      <h3>Grid 布局</h3>
+      <p>CSS Grid 是二维布局的终极方案，特别适合卡片网格和复杂页面结构。</p>
+      
+      <h4 style="color:#667eea;margin:16px 0 8px;">基础网格</h4>
+      <div class="demo-box">
+        <div class="grid-demo">
+          <div class="grid-item">Item 1</div>
+          <div class="grid-item">Item 2</div>
+          <div class="grid-item">Item 3</div>
+          <div class="grid-item">Item 4</div>
+          <div class="grid-item">Item 5</div>
+          <div class="grid-item">Item 6</div>
+        </div>
+      </div>
+      <div class="code-block"><span class="selector">.grid</span> {
+  <span class="property">display</span>: <span class="value">grid</span>;
+  <span class="property">grid-template-columns</span>: <span class="value">repeat(3, 1fr)</span>;
+  <span class="property">gap</span>: <span class="value">12px</span>;
+}</div>
+
+      <h4 style="color:#667eea;margin:16px 0 8px;">瀑布流 (Masonry)</h4>
+      <div class="demo-box">
+        <div class="masonry-demo">
+          <div class="masonry-item">1</div>
+          <div class="masonry-item">2</div>
+          <div class="masonry-item">3</div>
+          <div class="masonry-item">4</div>
+          <div class="masonry-item">5</div>
+          <div class="masonry-item">6</div>
+          <div class="masonry-item">7</div>
+          <div class="masonry-item">8</div>
+        </div>
+      </div>
+      <div class="code-block"><span class="selector">.masonry</span> {
+  <span class="property">display</span>: <span class="value">grid</span>;
+  <span class="property">grid-template-columns</span>: <span class="value">repeat(auto-fill, minmax(120px, 1fr))</span>;
+  <span class="property">grid-auto-rows</span>: <span class="value">60px</span>;
+  <span class="property">grid-auto-flow</span>: <span class="value">dense</span>; <span class="comment">/* 填充空隙 */</span>
+}</div>
+
+      <h4 style="color:#667eea;margin:16px 0 8px;">Flexbox 居中</h4>
+      <div class="demo-box">
+        <div class="flex-center-demo">
+          <div class="center-box"></div>
+        </div>
+      </div>
+      <div class="code-block"><span class="selector">.container</span> {
+  <span class="property">display</span>: <span class="value">flex</span>;
+  <span class="property">justify-content</span>: <span class="value">center</span>;
+  <span class="property">align-items</span>: <span class="value">center</span>;
+  <span class="property">height</span>: <span class="value">300px</span>;
+}</div>
+    </div>
+  </div>
+
+  <div id="tab-comparison" class="tab-content">
+    <div class="demo-area">
+      <h3>布局方案对比</h3>
+      <p>根据不同场景选择最合适的布局方案：</p>
+      
+      <table class="comparison-table">
+        <thead>
+          <tr>
+            <th>场景</th>
+            <th>推荐方案</th>
+            <th>原因</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>页面整体结构</td>
+            <td><span class="tag recommended">Grid</span></td>
+            <td>二维控制，轨道定义清晰</td>
+          </tr>
+          <tr>
+            <td>导航栏</td>
+            <td><span class="tag recommended">Flexbox</span></td>
+            <td>一维分布，space-between 神器</td>
+          </tr>
+          <tr>
+            <td>卡片列表</td>
+            <td><span class="tag recommended">Grid auto-fit</span></td>
+            <td>自动响应式，无需 Media Query</td>
+          </tr>
+          <tr>
+            <td>垂直居中</td>
+            <td><span class="tag recommended">Flexbox</span></td>
+            <td>一行搞定，兼容性好</td>
+          </tr>
+          <tr>
+            <td>圣杯布局</td>
+            <td><span class="tag modern">Flexbox</span></td>
+            <td>现代方案，代码简洁</td>
+          </tr>
+          <tr>
+            <td>组件内部布局</td>
+            <td><span class="tag modern">Container Queries</span></td>
+            <td>根据容器而非视口自适应</td>
+          </tr>
+          <tr>
+            <td>瀑布流</td>
+            <td><span class="tag modern">Grid + span</span></td>
+            <td>自动填充空隙</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="info-box">
+        <h4>🎯 Grid vs Flexbox 选择决策树</h4>
+        <p>
+          <strong>需要同时控制行和列？</strong> → Grid<br>
+          <strong>只需要控制一行或一列？</strong> → Flexbox<br>
+          <strong>两者都行？</strong> → 优先 Flexbox（兼容性更好）
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // Tab switching
+    const tabBtns = document.querySelectorAll('.tab-btn');
+    const tabContents = document.querySelectorAll('.tab-content');
+    tabBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        const tabId = btn.dataset.tab;
+        tabBtns.forEach(b => b.classList.remove('active'));
+        tabContents.forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById('tab-' + tabId).classList.add('active');
+      });
+    });
+  </script>
+</body>
+</html>

--- a/src/topics/02.layout/09.text-overflow/_demos/text-overflow-spacing-demo.html
+++ b/src/topics/02.layout/09.text-overflow/_demos/text-overflow-spacing-demo.html
@@ -1,0 +1,721 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>text-overflow ellipsis 间距控制</title>
+  <style>
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f5f5f5;
+      color: #333;
+      padding: 20px;
+      line-height: 1.6;
+    }
+
+    h1 {
+      text-align: center;
+      margin-bottom: 30px;
+      color: #1a1a1a;
+    }
+
+    .tabs {
+      display: flex;
+      gap: 4px;
+      background: #e0e0e0;
+      padding: 4px;
+      border-radius: 8px;
+      flex-wrap: wrap;
+      margin-bottom: 20px;
+    }
+
+    .tab-btn {
+      padding: 8px 16px;
+      border: none;
+      background: transparent;
+      cursor: pointer;
+      border-radius: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      color: #666;
+      transition: all 0.2s;
+    }
+
+    .tab-btn:hover {
+      background: #d0d0d0;
+    }
+
+    .tab-btn.active {
+      background: #fff;
+      color: #007AFF;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+
+    .tab-content {
+      display: none;
+      background: #fff;
+      border-radius: 12px;
+      padding: 24px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+    }
+
+    .tab-content.active {
+      display: block;
+    }
+
+    .demo-row {
+      margin-bottom: 24px;
+    }
+
+    .demo-label {
+      font-weight: 600;
+      margin-bottom: 8px;
+      color: #444;
+      font-size: 14px;
+    }
+
+    .demo-desc {
+      font-size: 13px;
+      color: #888;
+      margin-bottom: 12px;
+    }
+
+    /* Container styles */
+    .demo-container {
+      width: 280px;
+      background: #fafafa;
+      border: 1px solid #e0e0e0;
+      border-radius: 6px;
+      padding: 12px;
+      margin-bottom: 12px;
+    }
+
+    .demo-label-inline {
+      font-size: 12px;
+      color: #666;
+      margin-bottom: 6px;
+    }
+
+    /* Technique 1: Default - no spacing */
+    .t1-default {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    /* Technique 2: padding-right */
+    .t2-padding {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      padding-right: 16px;
+    }
+
+    /* Technique 3: Double container */
+    .t3-outer {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
+
+    .t3-inner {
+      padding-right: 16px;
+      display: inline;
+    }
+
+    /* Technique 4: Custom pseudo-element */
+    .t4-wrapper {
+      position: relative;
+      overflow: hidden;
+      white-space: nowrap;
+    }
+
+    .t4-wrapper::after {
+      content: '…';
+      position: absolute;
+      right: 0;
+      top: 0;
+      padding-left: 8px;
+      background: linear-gradient(to right, transparent, #fafafa 40%);
+    }
+
+    .t4-text {
+      display: inline;
+      background: linear-gradient(to right, #fafafa 80%, transparent);
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+    }
+
+    /* Technique 5: JS with spacing */
+    .t5-js {
+      overflow: hidden;
+      white-space: nowrap;
+    }
+
+    /* Control panel */
+    .controls {
+      background: #f8f8f8;
+      border: 1px solid #e0e0e0;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 16px;
+    }
+
+    .control-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+
+    .control-row label {
+      font-size: 13px;
+      font-weight: 500;
+      min-width: 120px;
+    }
+
+    .control-row input[type="range"] {
+      flex: 1;
+      cursor: pointer;
+    }
+
+    .control-row span {
+      font-size: 13px;
+      color: #666;
+      min-width: 40px;
+    }
+
+    /* Table */
+    .compare-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 16px;
+      font-size: 14px;
+    }
+
+    .compare-table th,
+    .compare-table td {
+      padding: 10px 12px;
+      text-align: left;
+      border-bottom: 1px solid #eee;
+    }
+
+    .compare-table th {
+      background: #f8f8f8;
+      font-weight: 600;
+      color: #444;
+    }
+
+    .compare-table tr:hover {
+      background: #fafafa;
+    }
+
+    .star {
+      color: #ff9500;
+    }
+
+    /* Legend */
+    .legend {
+      display: flex;
+      gap: 20px;
+      margin-top: 16px;
+      flex-wrap: wrap;
+    }
+
+    .legend-item {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+    }
+
+    .legend-color {
+      width: 12px;
+      height: 12px;
+      border-radius: 2px;
+    }
+
+    .legend-color.ellipsis {
+      background: #ff3b30;
+    }
+
+    .legend-color.spacing {
+      background: #007AFF;
+    }
+
+    .legend-color.content {
+      background: #34c759;
+    }
+
+    /* Algorithm section */
+    .algo-step {
+      background: #f8f8f8;
+      border-left: 3px solid #007AFF;
+      padding: 12px 16px;
+      margin: 12px 0;
+      border-radius: 0 6px 6px 0;
+      font-family: 'SF Mono', Monaco, monospace;
+      font-size: 13px;
+    }
+
+    .algo-step-num {
+      display: inline-block;
+      background: #007AFF;
+      color: #fff;
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      text-align: center;
+      line-height: 20px;
+      font-size: 11px;
+      margin-right: 8px;
+      font-family: sans-serif;
+    }
+
+    /* Quiz section */
+    .quiz-question {
+      background: #f0f7ff;
+      border: 1px solid #cce4ff;
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 16px;
+    }
+
+    .quiz-question h4 {
+      color: #007AFF;
+      margin-bottom: 12px;
+    }
+
+    .quiz-options {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .quiz-option {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      cursor: pointer;
+      padding: 8px 12px;
+      border-radius: 6px;
+      transition: background 0.2s;
+    }
+
+    .quiz-option:hover {
+      background: #e6f0ff;
+    }
+
+    .quiz-option input {
+      margin-top: 2px;
+    }
+
+    .quiz-feedback {
+      margin-top: 12px;
+      padding: 12px;
+      border-radius: 6px;
+      font-size: 14px;
+      display: none;
+    }
+
+    .quiz-feedback.correct {
+      background: #e8f5e9;
+      border: 1px solid #a5d6a7;
+      color: #2e7d32;
+      display: block;
+    }
+
+    .quiz-feedback.incorrect {
+      background: #ffebee;
+      border: 1px solid #ef9a9a;
+      color: #c62828;
+      display: block;
+    }
+
+    /* Responsive */
+    @media (max-width: 600px) {
+      .tabs {
+        gap: 2px;
+      }
+      .tab-btn {
+        padding: 6px 10px;
+        font-size: 13px;
+      }
+      .demo-container {
+        width: 100%;
+      }
+      .compare-table {
+        font-size: 12px;
+      }
+      .compare-table th, .compare-table td {
+        padding: 8px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <h1>🎯 text-overflow ellipsis 间距控制</h1>
+
+  <div class="tabs">
+    <button class="tab-btn active" data-tab="demo">交互演示</button>
+    <button class="tab-btn" data-tab="principle">原理解析</button>
+    <button class="tab-btn" data-tab="comparison">方案对比</button>
+    <button class="tab-btn" data-tab="quiz">自测题</button>
+  </div>
+
+  <!-- 交互演示 -->
+  <div class="tab-content active" id="demo">
+    <div class="demo-row">
+      <div class="demo-label">对比：默认 vs 添加 padding-right</div>
+      <div class="demo-desc">添加 padding-right 后，省略号左移，容器右侧留白，产生视觉间距</div>
+
+      <div class="demo-container t1-default">
+        默认省略号（无间距）
+      </div>
+      <div class="demo-container t2-padding">
+        padding-right: 16px
+      </div>
+    </div>
+
+    <div class="demo-row">
+      <div class="demo-label">控制面板：实时调整间距</div>
+      <div class="demo-container" id="live-demo" style="width: 280px;">
+        <div id="live-text" class="t2-padding" style="font-size: 14px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; background: #fafafa; padding-right: 16px;">
+          这是一段测试文本，用于演示省略号间距控制效果
+        </div>
+      </div>
+      <div class="controls">
+        <div class="control-row">
+          <label for="spacing-slider">省略号前间距:</label>
+          <input type="range" id="spacing-slider" min="0" max="40" value="16" />
+          <span id="spacing-value">16px</span>
+        </div>
+        <div class="control-row">
+          <label for="container-width">容器宽度:</label>
+          <input type="range" id="container-width" min="120" max="300" value="280" />
+          <span id="width-value">280px</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-row">
+      <div class="demo-label">双层嵌套方案</div>
+      <div class="demo-desc">外层控制省略号，内层 padding-right 间接控制间距</div>
+      <div class="demo-container">
+        <div class="t3-outer">
+          <span class="t3-inner">双层嵌套省略号间距演示</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="demo-row">
+      <div class="demo-label">伪元素自定义省略号</div>
+      <div class="demo-desc">用 ::after 模拟省略号，完全自定义位置和样式</div>
+      <div class="demo-container t4-wrapper">
+        <span class="t4-text">伪元素省略号</span>
+      </div>
+    </div>
+
+    <div class="legend">
+      <div class="legend-item">
+        <div class="legend-color ellipsis"></div>
+        <span>省略号</span>
+      </div>
+      <div class="legend-item">
+        <div class="legend-color spacing"></div>
+        <span>间距区域</span>
+      </div>
+      <div class="legend-item">
+        <div class="legend-color content"></div>
+        <span>内容</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- 原理解析 -->
+  <div class="tab-content" id="principle">
+    <h3 style="margin-bottom: 16px;">text-overflow: ellipsis 工作原理</h3>
+
+    <div class="algo-step">
+      <span class="algo-step-num">1</span>
+      浏览器根据 white-space 和 overflow 属性判断容器是否需要截断文本
+    </div>
+    <div class="algo-step">
+      <span class="algo-step-num">2</span>
+      当文本超出容器宽度，overflow: hidden 裁剪溢出部分
+    </div>
+    <div class="algo-step">
+      <span class="algo-step-num">3</span>
+      text-overflow: ellipsis 让渲染引擎在截断位置插入省略号字符 "…"
+    </div>
+    <div class="algo-step">
+      <span class="algo-step-num">4</span>
+      省略号是渲染层附加的字符，不是 DOM 节点，无法通过 CSS 选择器单独控制
+    </div>
+
+    <h3 style="margin: 24px 0 16px;">为什么 padding-right 能产生间距？</h3>
+
+    <p style="margin-bottom: 12px;">
+      当给容器添加 <code>padding-right: 16px</code> 时：
+    </p>
+    <ol style="margin-left: 20px; margin-bottom: 16px;">
+      <li>容器内容区域减小 16px（右边距）</li>
+      <li>文本在更窄的内容区域内截断</li>
+      <li>省略号出现在更左侧的位置</li>
+      <li>省略号右侧有 16px 的留白（padding 区域）</li>
+    </ol>
+
+    <p style="margin-bottom: 12px;">
+      <strong>关键点</strong>：这实际上不是省略号和文字之间的间距，而是省略号和容器右边缘之间的间距。
+      省略号始终紧贴最后一个可见字符。
+    </p>
+
+    <h3 style="margin: 24px 0 16px;">padding-right vs padding-left 的区别</h3>
+
+    <table class="compare-table">
+      <thead>
+        <tr>
+          <th>属性</th>
+          <th>效果</th>
+          <th>适用场景</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>padding-right</td>
+          <td>省略号左移，产生右间距</td>
+          <td>✅ 推荐，最常用</td>
+        </tr>
+        <tr>
+          <td>padding-left</td>
+          <td>内容整体右移，省略号位置不变</td>
+          <td>❌ 不影响省略号位置</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- 方案对比 -->
+  <div class="tab-content" id="comparison">
+    <h3 style="margin-bottom: 16px;">各方案对比</h3>
+
+    <table class="compare-table">
+      <thead>
+        <tr>
+          <th>方案</th>
+          <th>省略号前间距</th>
+          <th>省略号后间距</th>
+          <th>兼容性</th>
+          <th>复杂度</th>
+          <th>推荐度</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>padding-right</td>
+          <td>✅</td>
+          <td>❌</td>
+          <td>全部</td>
+          <td>⭐</td>
+          <td>⭐⭐⭐⭐⭐</td>
+        </tr>
+        <tr>
+          <td>双层嵌套</td>
+          <td>✅</td>
+          <td>❌</td>
+          <td>全部</td>
+          <td>⭐⭐</td>
+          <td>⭐⭐⭐⭐</td>
+        </tr>
+        <tr>
+          <td>伪元素</td>
+          <td>✅</td>
+          <td>✅</td>
+          <td>现代浏览器</td>
+          <td>⭐⭐⭐</td>
+          <td>⭐⭐⭐</td>
+        </tr>
+        <tr>
+          <td>JS 动态注入</td>
+          <td>✅</td>
+          <td>✅</td>
+          <td>全部</td>
+          <td>⭐⭐⭐⭐</td>
+          <td>⭐⭐</td>
+        </tr>
+        <tr>
+          <td>line-clamp</td>
+          <td>✅ (via padding)</td>
+          <td>❌</td>
+          <td>WebKit</td>
+          <td>⭐⭐</td>
+          <td>⭐⭐⭐⭐</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 style="margin: 24px 0 16px;">推荐选择</h3>
+
+    <div class="demo-row">
+      <div class="demo-label">✅ 首选：padding-right</div>
+      <div class="demo-desc">简单、兼容、效果好，满足大多数场景</div>
+    </div>
+
+    <div class="demo-row">
+      <div class="demo-label">✅ 多行文本：-webkit-line-clamp + padding</div>
+      <div class="demo-desc">配合 padding-bottom 控制多行省略号间距</div>
+    </div>
+
+    <div class="demo-row">
+      <div class="demo-label">⚠️ 需要前后都有间距：伪元素</div>
+      <div class="demo-desc">可以精确控制省略号前后两端的间距</div>
+    </div>
+  </div>
+
+  <!-- 自测题 -->
+  <div class="tab-content" id="quiz">
+    <h3 style="margin-bottom: 16px;">自测题</h3>
+
+    <div class="quiz-question">
+      <h4>Q1: text-overflow: ellipsis 生效需要满足几个条件？</h4>
+      <div class="quiz-options">
+        <label class="quiz-option">
+          <input type="radio" name="q1" value="a" />
+          <span>1 个条件</span>
+        </label>
+        <label class="quiz-option">
+          <input type="radio" name="q1" value="b" />
+          <span>2 个条件</span>
+        </label>
+        <label class="quiz-option">
+          <input type="radio" name="q1" value="c" />
+          <span>3 个条件</span>
+        </label>
+      </div>
+      <div class="quiz-feedback" id="q1-feedback"></div>
+    </div>
+
+    <div class="quiz-question">
+      <h4>Q2: 以下哪种方法可以产生省略号前的间距？</h4>
+      <div class="quiz-options">
+        <label class="quiz-option">
+          <input type="radio" name="q2" value="a" />
+          <span>padding-left: 20px</span>
+        </label>
+        <label class="quiz-option">
+          <input type="radio" name="q2" value="b" />
+          <span>padding-right: 20px</span>
+        </label>
+        <label class="quiz-option">
+          <input type="radio" name="q2" value="c" />
+          <span>margin-right: 20px</span>
+        </label>
+      </div>
+      <div class="quiz-feedback" id="q2-feedback"></div>
+    </div>
+
+    <div class="quiz-question">
+      <h4>Q3: 省略号是 DOM 节点吗？</h4>
+      <div class="quiz-options">
+        <label class="quiz-option">
+          <input type="radio" name="q3" value="a" />
+          <span>是，可以用 CSS 选择器选中</span>
+        </label>
+        <label class="quiz-option">
+          <input type="radio" name="q3" value="b" />
+          <span>不是，是渲染引擎附加的字符</span>
+        </label>
+      </div>
+      <div class="quiz-feedback" id="q3-feedback"></div>
+    </div>
+
+    <div class="quiz-question">
+      <h4>Q4: 多行文本截断应该使用哪个属性？</h4>
+      <div class="quiz-options">
+        <label class="quiz-option">
+          <input type="radio" name="q4" value="a" />
+          <span>text-overflow: ellipsis (单行)</span>
+        </label>
+        <label class="quiz-option">
+          <input type="radio" name="q4" value="b" />
+          <span>-webkit-line-clamp</span>
+        </label>
+        <label class="quiz-option">
+          <input type="radio" name="q4" value="c" />
+          <span>overflow-y: scroll</span>
+        </label>
+      </div>
+      <div class="quiz-feedback" id="q4-feedback"></div>
+    </div>
+
+    <button id="check-answers" style="margin-top: 16px; padding: 10px 20px; background: #007AFF; color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 14px;">查看答案</button>
+  </div>
+
+  <script>
+    // Tab switching
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById(btn.dataset.tab).classList.add('active');
+      });
+    });
+
+    // Live demo controls
+    const spacingSlider = document.getElementById('spacing-slider');
+    const spacingValue = document.getElementById('spacing-value');
+    const widthSlider = document.getElementById('container-width');
+    const widthValue = document.getElementById('width-value');
+    const liveText = document.getElementById('live-text');
+    const liveDemo = document.getElementById('live-demo');
+
+    spacingSlider.addEventListener('input', (e) => {
+      const val = e.target.value + 'px';
+      spacingValue.textContent = val;
+      liveText.style.paddingRight = val;
+    });
+
+    widthSlider.addEventListener('input', (e) => {
+      const val = e.target.value + 'px';
+      widthValue.textContent = val;
+      liveDemo.style.width = val;
+      liveText.style.width = '100%';
+    });
+
+    // Quiz answers
+    const answers = {
+      q1: 'c', // 3 conditions: white-space: nowrap, overflow: hidden, text-overflow: ellipsis
+      q2: 'b', // padding-right
+      q3: 'b', // Not a DOM node, rendered character
+      q4: 'b'  // -webkit-line-clamp
+    };
+
+    document.getElementById('check-answers').addEventListener('click', () => {
+      Object.keys(answers).forEach(q => {
+        const selected = document.querySelector(`input[name="${q}"]:checked`);
+        const feedback = document.getElementById(`${q}-feedback`);
+        if (selected) {
+          if (selected.value === answers[q]) {
+            feedback.textContent = '✅ 回答正确！';
+            feedback.className = 'quiz-feedback correct';
+          } else {
+            feedback.textContent = '❌ 回答错误';
+            feedback.className = 'quiz-feedback incorrect';
+          }
+        } else {
+          feedback.textContent = '请选择一个答案';
+          feedback.className = 'quiz-feedback incorrect';
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/src/topics/02.layout/09.text-overflow/index.mdx
+++ b/src/topics/02.layout/09.text-overflow/index.mdx
@@ -1,0 +1,307 @@
+---
+title: text-overflow ellipsis 间距控制
+category: 布局进阶
+tags: [text-overflow, ellipsis, overflow, white-space, truncation]
+description: 深入讲解 CSS text-overflow: ellipsis 的工作原理，以及如何控制省略号与文本之间的间距。
+keywords: text-overflow, ellipsis, 省略号, 文本截断, white-space, overflow
+---
+
+# text-overflow ellipsis 间距控制
+
+**控制省略号与文本之间的间距，让截断效果更优雅**
+
+## 引言
+
+`text-overflow: ellipsis` 是前端开发中常用的文本截断方案。但默认情况下，省略号紧贴最后一行文本，没有间距。当产品设计要求省略号与文本之间留有一定距离时，默认行为就无法满足需求。
+
+本文深入分析 `text-overflow: ellipsis` 的工作原理，并提供多种控制省略号间距的方案。
+
+## text-overflow 基础回顾
+
+text-overflow 是 CSS3 新增的属性，用于控制容器内文本溢出的显示方式。
+
+### 必要条件
+
+text-overflow 生效需要同时满足三个条件：
+
+```css
+.container {
+  /* 1. 内容必须不换行 */
+  white-space: nowrap;
+  
+  /* 2. 容器必须 overflow hidden */
+  overflow: hidden;
+  
+  /* 3. 启用省略号 */
+  text-overflow: ellipsis;  /* 或 clip */
+}
+```
+
+```html
+<div class="container">
+  这是一段很长的文本内容，当容器宽度不够时会被截断显示省略号
+</div>
+```
+
+### 核心原理
+
+text-overflow: ellipsis 的省略号是**渲染引擎在绘制时附加到文本末尾的字符**，它不是 DOM 节点，无法通过常规 CSS 选择器单独控制。
+
+### text-overflow 的值
+
+| 值 | 描述 |
+|---|---|
+| `clip` | 直接截断，无省略号（默认值） |
+| `ellipsis` | 显示省略号 `…` |
+| `string` | 显示自定义字符串（仅 Firefox 支持） |
+
+## 省略号间距问题
+
+### 问题描述
+
+默认情况下，省略号紧贴最后显示的字符，没有间距：
+
+```
+「这是一段被截断的长文本…」
+```
+
+产品期望的间距效果：
+
+```
+「这是一段被截断的长文本 …」
+      ↑ 省略号前有一定间距
+```
+
+### 根本原因
+
+省略号是渲染引擎在文本绘制阶段附加的特殊字符，它**不是 DOM 节点**，无法用 `::after` 等伪元素覆盖或添加间距。
+
+## 方案一：容器内边距（最简单）
+
+给容器添加 `padding-right`，让容器留出空白，省略号自然左移：
+
+```css
+.container {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  
+  /* 关键：右边距 = 期望的省略号前间距 */
+  padding-right: 12px;
+}
+```
+
+**效果**：
+- 省略号左移，容器右侧留出空白
+- 空白区域即为省略号前的视觉间距
+
+**优点**：简单、兼容性好
+**缺点**：容器实际宽度减小，内容更少
+
+```html
+<div class="container padding-solution">
+  <span class="text">CSS省略号前间距控制效果演示</span>
+</div>
+
+<style>
+.container.padding-solution {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 16px; /* 省略号前间距 */
+  background: #f0f0f0;
+  border-radius: 4px;
+}
+</style>
+```
+
+## 方案二：双层嵌套（内容与省略号分离）
+
+使用双层 div，外层控制省略号，内层控制内容间距：
+
+```css
+.outer {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.inner {
+  display: inline;
+  /* 通过 padding-left 间接实现省略号右侧间距 */
+  padding-right: 12px;
+}
+```
+
+```html
+<div class="outer">
+  <span class="inner">这是一段被截断的文本内容</span>
+</div>
+```
+
+**注意**：由于省略号附着在 outer 容器的文本末尾，内层的 `padding-right` 实际上控制的是内容右侧到容器右边缘的距离。
+
+## 方案三：自定义省略号 + 伪元素（自定义程度高）
+
+由于 text-overflow 的省略号无法直接控制，可以用伪元素模拟：
+
+```css
+.container {
+  position: relative;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+/* 用伪元素显示省略号，可以独立控制位置 */
+.container::after {
+  content: '…';
+  position: absolute;
+  right: 0;
+  top: 0;
+  padding-left: 12px; /* 省略号与文字的间距 */
+  background: linear-gradient(to right, transparent, #fff 30%);
+}
+```
+
+**优点**：完全自定义省略号位置和样式
+**缺点**：需要处理省略时机，不够自动化
+
+## 方案四：line-clamp + CSS 变量控制（多行文本）
+
+对于多行文本截断，使用 `line-clamp`：
+
+```css
+.container {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3; /* 显示 3 行 */
+  overflow: hidden;
+  /* 省略号位置用 padding-bottom 间接控制 */
+  padding-bottom: 4px;
+}
+```
+
+### -webkit-line-clamp 的省略号
+
+```css
+.container {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* 通过 padding 控制省略号位置 */
+  padding-right: 16px;
+}
+```
+
+## 方案五：JS 动态注入（精确控制）
+
+用 JavaScript 在合适位置插入省略号字符：
+
+```javascript
+function truncateWithSpacing(element, maxChars, spacing = ' ') {
+  const text = element.textContent;
+  if (text.length <= maxChars) return;
+  
+  // 在 maxChars-1 位置截断，保留一个字符
+  const truncated = text.substring(0, maxChars - 1);
+  element.textContent = truncated + spacing + '…';
+}
+```
+
+**优点**：精确控制，省略号前后都能加间距
+**缺点**：需要 JS，失去响应式能力
+
+## 方案对比
+
+| 方案 | 省略号前间距 | 省略号后间距 | 兼容性 | 复杂度 |
+|------|-------------|-------------|--------|--------|
+| padding-right | ✅ | ❌ | 全部 | ⭐ |
+| 双层嵌套 | ✅ | ❌ | 全部 | ⭐⭐ |
+| 伪元素 | ✅ | ✅ | 现代浏览器 | ⭐⭐⭐ |
+| JS 动态 | ✅ | ✅ | 全部 | ⭐⭐⭐⭐ |
+
+## 实战场景
+
+### 场景 1：单行标题省略号间距
+
+```css
+.title {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 8px; /* 省略号前 8px 间距 */
+}
+```
+
+### 场景 2：表格单元格省略号
+
+```css
+.cell {
+  max-width: 200px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 12px;
+}
+```
+
+### 场景 3：卡片描述多行省略号
+
+```css
+.card-desc {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 12px; /* 底部省略号间距 */
+}
+```
+
+## 常见问题
+
+### Q: 为什么 padding-right 能影响省略号位置？
+
+A: 省略号绘制在容器文本的最右端。添加 `padding-right` 后，容器右侧留白，省略号会被"挤"到左边，从而在省略号和容器右边缘之间产生间距。但省略号和文字之间的间距实际上是 padding-right 的一部分，不是省略号和文字之间的间距。
+
+### Q: 能用 ::after 添加省略号和间距吗？
+
+A: 可以，但需要让原始文本不可见：
+
+```css
+.container {
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.container::after {
+  content: '…';
+  position: absolute;
+  right: 8px; /* 省略号右侧偏移 */
+  padding-left: 8px; /* 省略号左侧间距 */
+  background: inherit; /* 或白色背景 */
+}
+```
+
+### Q: 省略号能换位置吗？
+
+A: CSS 无法直接控制省略号的位置。但可以用绝对定位的伪元素模拟不同位置。
+
+### Q: 多行文本省略号间距怎么控制？
+
+A: 多行使用 `-webkit-line-clamp`，通过 `padding-bottom` 或 `padding-right` 间接控制。
+
+## 总结
+
+控制 text-overflow 省略号间距的核心思路：
+
+1. **了解原理**：省略号是渲染引擎附加的字符，不是 DOM 节点
+2. **间接控制**：通过 padding 改变省略号相对位置
+3. **选择方案**：
+   - 简单场景 → padding-right
+   - 多行文本 → line-clamp + padding
+   - 自定义需求 → 伪元素模拟
+   - 精确控制 → JS 动态注入
+


### PR DESCRIPTION
## 任务说明
重新添加 sticky 定位文档和交互演示（之前 PR 未合并到 main）

## 新增内容

### docs/css/sticky-position.md
- Sticky 定位核心原理（relative + fixed 混合）
- 与 relative/fixed/absolute 对比表
- Sticky 生效的必要条件（父容器 overflow/height/transform）
- 卡片内按钮固定的三种方案（sticky 包裹/独立 sticky/fixed 降级）
- iOS Safari 兼容处理（-webkit-sticky + transform hack）
- 降级方案（@supports）
- 决策树：选择定位方案

### examples/css/demos/sticky-position/sticky-position-demo.html
- 5 个 Tab：概念总览/交互演示/解决方案/问题排查/自测题
- 完整卡片按钮 Sticky 固定演示
- iOS 兼容代码
- 5 道自测题

## Reminder ID
recveKV3P5upq3