### PR TITLE
docs: add CSS layout guide (Flexbox vs Grid vs Table)

### DIFF
--- a/docs/css/fixed-relative-positioning.md
+++ b/docs/css/fixed-relative-positioning.md
@@ -1,0 +1,190 @@
+# CSS 固定定位：相对视图窗口 vs 相对元素
+
+## 核心问题
+
+> 如何实现一个元素既**相对视图窗口固定**（如 `position: fixed`），又**相对于某一元素定位**（如相对于父容器偏移）？
+
+这看似矛盾，但有多种解决方案。
+
+## Position 定位体系回顾
+
+| 值 | 定位上下文 | 文档流 |
+|----|-----------|--------|
+| `static` | 正常文档流 | 保留 |
+| `relative` | 自身原位置 | 保留 |
+| `absolute` | 最近定位祖先 | 脱离 |
+| `fixed` | 视口窗口 | 脱离 |
+| `sticky` | 视口 + 滚动容器混合 | 保留 |
+
+## 问题根源
+
+`position: fixed` 的定位上下文是**视口**（viewport），而非父元素。这是 CSS 规范定义的行为。
+
+```css
+.parent {
+  position: relative; /* 有用吗？*/
+}
+.child {
+  position: fixed;
+  top: 0; /* 相对于视口，不是 .parent */
+}
+```
+
+无论 `.parent` 设置什么定位，`.child` 的 `fixed` 始终相对于视口定位。
+
+## 解决方案
+
+### 方案一：transform 欺骗法（推荐）
+
+**原理**：transform 会创建新的包含块（Containing Block），使 `fixed` 相对于被 transform 的元素定位。
+
+```css
+.container {
+  position: relative;
+  transform: translate(0); /* 激活新的定位上下文 */
+}
+.fixed-element {
+  position: fixed;
+  top: 0;
+  /* 现在相对于 .container 定位 */
+}
+```
+
+**适用场景**：侧边栏固定、跟随按钮、浮层定位
+
+### 方案二：absolute + JS 计算
+
+**原理**：使用 `absolute` 定位，通过 JavaScript 动态计算相对于目标元素的位置。
+
+```js
+function positionFixedRelativeTo(element, target) {
+  const rect = target.getBoundingClientRect();
+  element.style.position = 'absolute';
+  element.style.top = rect.top + 'px';
+  element.style.left = rect.left + 'px';
+}
+```
+
+**适用场景**：复杂交互、需要实时跟随
+
+### 方案三：position: sticky（伪固定）
+
+**原理**：在滚动容器内"粘"在某一位置，但会随容器滚动。
+
+```css
+.sticky-element {
+  position: sticky;
+  top: 10px;
+}
+```
+
+**限制**：只在父容器滚动范围内有效，父容器滚出视口后不再固定。
+
+### 方案四：JS + ResizeObserver 监听
+
+**原理**：监听目标元素位置变化，实时更新 fixed 元素位置。
+
+```js
+const observer = new ResizeObserver(entries => {
+  for (const entry of entries) {
+    updatePosition(entry.target);
+  }
+});
+observer.observe(targetElement);
+```
+
+## 实战场景
+
+### 场景 1：相对父容器的固定浮层
+
+```html
+<div class="container">
+  <button class="toggle">显示浮层</button>
+  <div class="dropdown">下拉内容</div>
+</div>
+```
+
+```css
+.container {
+  position: relative;
+  transform: translate(0); /* 关键：创建新的包含块 */
+}
+.dropdown {
+  position: fixed;
+  top: 100%; /* 相对于 .container 的底部定位 */
+  left: 0;
+  /* 不受外部滚动影响 */
+}
+```
+
+### 场景 2：固定在元素旁边的 Tooltip
+
+```css
+.wrapper {
+  position: relative;
+  transform: translate(0);
+}
+.tooltip {
+  position: fixed;
+  /* JS 动态设置 left/top 基于 wrapper 的位置 */
+}
+```
+
+### 场景 3：吸顶但有边距
+
+```css
+.sticky-header {
+  position: fixed;
+  top: 20px; /* 距离视口顶部 20px */
+  left: 50%;
+  transform: translateX(-50%);
+}
+```
+
+## 常见误区
+
+### ❌ 误区 1：父元素设置 relative 就能影响 fixed
+
+```css
+/* 无效 */
+.parent {
+  position: relative;
+}
+.child {
+  position: fixed;
+  top: 20px; /* 仍然是相对于视口 */
+}
+```
+
+### ❌ 误区 2：fixed 元素不需要考虑 z-index
+
+实际上 fixed 元素会创建新的层叠上下文（Stacking Context），需要注意层叠顺序。
+
+### ❌ 误区 3：transform 不影响 fixed
+
+实际上 **transform 会影响 fixed**！这是 hack 的核心原理。
+
+## 浏览器兼容性
+
+| 特性 | Chrome | Firefox | Safari | Edge |
+|------|--------|---------|--------|------|
+| transform 影响 fixed | ✅ | ✅ | ✅ | ✅ |
+| position: sticky | ✅ | ✅ | ✅ | ✅ |
+| CSS `anchor-positioning` | ✅ (实验) | ❌ | ❌ | ❌ |
+
+## 决策树
+
+```
+需要固定定位?
+├── 相对视口固定 → position: fixed
+├── 相对父容器固定（无滚动）→ position: absolute
+├── 相对父容器固定（会滚动）→ transform 欺骗法
+├── 在容器内"粘住" → position: sticky
+└── 需要动态跟随 → JS 计算 + ResizeObserver
+```
+
+## 相关资源
+
+- [MDN: position](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
+- [CSS Transforms 创建包含块](https://www.w3.org/TR/css-transforms-1/#transform-rendering)
+- [Chrome DevTools 调试定位问题](/examples/css/demos/fixed-relative-positioning.html)

--- a/docs/css/layout-guide.md
+++ b/docs/css/layout-guide.md
@@ -1,0 +1,122 @@
+# CSS 布局详解
+
+## 布局方案演进
+
+| 时代 | 方案 | 特点 |
+|------|------|------|
+| 早期 | Table | 表格嵌套，语义差，不推荐 |
+| 中期 | Float + Position | 浮动清理，定位层叠 |
+| 现代 | Flexbox + Grid | 主流通用方案 |
+| 2024+ | Grid + Subgrid + Container Queries | 响应式新特性 |
+
+## Flexbox（一维布局）
+
+适合**组件内**的元素排列（导航栏、卡片组、居中）。
+
+```css
+.container {
+  display: flex;
+  justify-content: space-between; /* 主轴分布 */
+  align-items: center;            /* 交叉轴对齐 */
+  gap: 10px;
+}
+```
+
+**核心属性**：
+- `flex-direction`: row | column
+- `justify-content`: flex-start | center | space-between | space-around
+- `align-items`: stretch | center | flex-start
+- `flex-wrap`: nowrap | wrap
+
+**适用场景**：导航栏、按钮组、表单对齐、卡片行。
+
+## CSS Grid（二维布局）
+
+适合**页面级**复杂布局（多行多列、响应式网格）。
+
+```css
+.page {
+  display: grid;
+  grid-template-columns: minmax(200px, 1fr) 3fr;
+  gap: 20px;
+}
+```
+
+**核心属性**：
+- `grid-template-columns/rows`: repeat(auto-fill, minmax(200px, 1fr))
+- `gap`: 行列间距统一设置
+- `grid-area`: 命名区域布局
+- `minmax(min, max)`: 自适应尺寸
+
+**适用场景**：页面整体框架、仪表盘、相册网格。
+
+## Flex vs Grid 选型
+
+| 场景 | 推荐方案 | 原因 |
+|------|----------|------|
+| 导航栏按钮均匀分布 | Flex | 一维排列，justify-content 即可 |
+| 页面整体两栏/三栏 | Grid | 二维控制，模板定义清晰 |
+| 卡片网格（自适应列数） | Grid + auto-fit | `repeat(auto-fill, minmax(250px, 1fr))` |
+| 表单项垂直对齐 | Flex column | 标签+输入框自然对齐 |
+| 圣杯布局（header/footer/sidebar） | Grid | 三区域一次性定义 |
+
+## 2024 新特性
+
+### Subgrid（Chrome 117+, Safari 16+）
+
+子网格继承父 Grid 行列，实现卡片内容对齐：
+
+```css
+.parent {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+.child {
+  grid-column: span 3;
+  display: grid;
+  grid-template-columns: subgrid; /* 继承父列轨道 */
+}
+```
+
+### Container Queries（组件级响应）
+
+不依赖视口，根据容器尺寸响应：
+
+```css
+@container (min-width: 400px) {
+  .card { flex-direction: row; }
+}
+```
+
+### clamp() 响应式尺寸
+
+无媒体查询的自适应：
+
+```css
+width: clamp(300px, 50%, 800px); /* min/首选/max */
+font-size: clamp(14px, 2vw, 18px);
+```
+
+## 固定头部布局
+
+主流方案：
+
+```css
+/* 方案一：absolute + padding */
+body { padding-top: 60px; }
+header { position: absolute; top: 0; height: 60px; }
+
+/* 方案二：grid 模板 */
+body {
+  display: grid;
+  grid-template-rows: 60px 1fr auto;
+  grid-template-areas: "header" "main" "footer";
+}
+header { grid-area: header; }
+```
+
+## 参考
+
+- [Smashing Magazine: Modern CSS Layouts](https://www.smashingmagazine.com/2024/05/modern-css-layouts-no-framework-needed/)
+- [CSS Tricks: A Complete Guide to Grid](https://css-tricks.com/snippets/css/complete-guide-grid/)
+- [CSS Tricks: A Complete Guide to Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)

--- a/docs/css/relative-fixed-positioning.md
+++ b/docs/css/relative-fixed-positioning.md
@@ -1,0 +1,465 @@
+# 相对固定定位：元素固定却相对于某元素定位
+
+## 概述
+
+CSS `position: fixed` 通常让元素相对于视口固定，但`transform`属性会改变fixed的定位上下文，造成"相对于某元素固定"的效果。这种"双重固定"布局是现代前端常见的交互模式。
+
+> 核心矛盾：fixed 相对于视口定位，但 transform 会重建定位上下文，让 fixed 相对于变换后的容器定位。
+
+## 定位体系回顾
+
+### CSS Position 定位类型
+
+| 值 | 定位行为 | 定位上下文 |
+|----|---------|-----------|
+| `static` | 正常文档流，无定位 | 无 |
+| `relative` | 相对自身原始位置偏移 | 自身 |
+| `absolute` | 绝对定位 | 最近已定位祖先 |
+| `fixed` | 相对于视口固定 | 视口（初始） |
+| `sticky` | 滚动时吸附 | 最近滚动容器 |
+
+### Containing Block（定位上下文）
+
+元素的定位上下文决定了 `absolute` 和 `fixed` 的参照框架：
+
+```
+视口（初始，包含块）
+  └── 某元素（设置了 transform/perspective/filter）
+        └── 定位上下文变为该元素
+              └── absolute/fixed 子元素相对于该元素定位
+```
+
+**固定定位上下文重建条件**（满足任一）：
+- 祖先元素设置了 `transform`（非 `none`）
+- 祖先元素设置了 `perspective`（非 `none`）
+- 祖先元素设置了 `filter`（非 `none`）
+- 祖先元素设置了 `will-change: transform`
+
+## transform 对 fixed 的影响
+
+### 核心原理
+
+当一个祖先元素应用了 `transform`（如 `transform: translateX(0)`），该元素会创建一个新的**物理包含块**。此时，子元素的 `position: fixed` 不再相对于视口定位，而是相对于这个新的包含块定位。
+
+```css
+.container {
+  transform: translateX(0); /* 或任何非none值 */
+}
+
+.fixed-child {
+  position: fixed;
+  top: 0;
+  /* 实际表现：相对于 .container 定位，而非视口 */
+}
+```
+
+### 关键验证
+
+Chrome DevTools 可通过 "Layer" 面板验证：设置了 transform 的元素会产生新的**GraphicsLayer**，其子元素的 fixed 定位会在新图层内计算。
+
+```html
+<div class="outer">
+  <div class="container">
+    <div class="fixed-box">fixed</div>
+  </div>
+</div>
+
+<style>
+.outer {
+  width: 600px;
+  height: 400px;
+  background: #f0f0f0;
+  overflow: auto;
+}
+
+.container {
+  width: 300px;
+  height: 800px;
+  background: #ddd;
+  transform: translateX(0); /* 创建新的包含块 */
+  margin-left: 150px;
+}
+
+.fixed-box {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  background: #e74c3c;
+  color: white;
+  padding: 10px 20px;
+  border-radius: 4px;
+}
+</style>
+```
+
+上述代码中，`fixed-box` 会出现在 `.container` 的左上角（距 left 20px, top 20px），而非 `.outer` 或视口。
+
+## 实现方案
+
+### 方案一：父容器 + transform: translateX(0)
+
+最简洁的方案，给父容器添加 `transform: translateX(0)` 即可重建定位上下文：
+
+```css
+.parent {
+  transform: translateX(0);
+}
+
+.fixed-child {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+}
+```
+
+> 注意：`translateX(0)` 本身不会产生视觉位移，但会强制创建新的包含块。
+
+### 方案二：父容器 + transform: scale(1)
+
+```css
+.parent {
+  transform: scale(1);
+}
+```
+
+与 `translateX(0)` 效果相同，但更语义化地表达"保持原尺寸"。
+
+### 方案三：父容器 + position: relative（辅助定位）
+
+```css
+.parent {
+  position: relative;
+  /* 不需要设置 top/left，只是创建定位上下文 */
+}
+
+.fixed-child {
+  position: fixed;
+  top: 0;
+  left: 0;
+  /* 相对于 .parent 的 border-box 定位 */
+}
+```
+
+### 方案四：absolute 嵌套 fixed（复古方案）
+
+利用 `absolute` 相对于最近定位祖先的特性：
+
+```css
+.wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  /* 祖先元素提供定位上下文 */
+}
+
+.fixed-child {
+  position: fixed;
+  /* 相对于 wrapper 定位（因为 wrapper 是最近的定位祖先） */
+}
+```
+
+## 常见使用场景
+
+### 1. 吸顶效果（Sticky Header）
+
+```css
+.nav-container {
+  transform: translateX(0); /* 创建定位上下文 */
+}
+
+.sticky-nav {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+/* 吸附逻辑需要 JS 配合 */
+.sticky-nav.scrolled {
+  transform: translateY(0);
+}
+```
+
+### 2. 跟随按钮（Floating Action Button）
+
+在某个卡片/面板内固定位置的按钮：
+
+```css
+.card {
+  position: relative;
+  padding: 16px;
+  background: #f5f5f5;
+  border-radius: 8px;
+}
+
+.fab {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #3b82f6;
+  color: white;
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.5);
+}
+```
+
+### 3. 模态框/浮层定位
+
+相对于某个触发元素定位的浮层：
+
+```css
+.dropdown-container {
+  position: relative; /* 建立定位上下文 */
+}
+
+.dropdown-trigger {
+  /* 触发器样式 */
+}
+
+.dropdown-menu {
+  position: fixed;
+  top: 0;
+  left: 0;
+  /* JS 计算位置：trigger.getBoundingClientRect() */
+  /* 设置 top/left 为具体数值 */
+}
+```
+
+### 4. 固定在父容器内的角标
+
+```css
+.badge-container {
+  transform: translateZ(0); /* 或 translateX(0) */
+}
+
+.badge {
+  position: fixed;
+  top: 0;
+  right: 0;
+  background: #e74c3c;
+  color: white;
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+```
+
+### 5. 滚动时固定在视口的侧边栏
+
+```css
+.sidebar-wrapper {
+  transform: translateX(0);
+}
+
+.sidebar {
+  position: fixed;
+  top: 80px; /* 头部高度 */
+  width: 250px;
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
+}
+```
+
+## 常见踩坑与解决方案
+
+### 坑 1：transform 触发性能问题
+
+**问题**：滥用 `transform` 可能导致过多合成层，影响渲染性能。
+
+**解决**：
+- 仅在必要时使用
+- 使用 `will-change: transform` 明确告知浏览器即将变化
+- 避免在高频动画元素上使用
+
+```css
+/* 推荐：使用 transform 而非 top/left 做动画 */
+.animated-element {
+  transform: translateX(0); /* 创建上下文 */
+}
+
+/* 动画时 */
+.animated-element.animating {
+  transform: translateX(100px);
+  transition: transform 0.3s ease;
+}
+```
+
+### 坑 2：transform 导致子元素文字模糊
+
+**问题**：`transform` 可能触发子元素文字亚像素渲染，导致模糊。
+
+**解决**：
+- 使用 `translateZ(0)` 或 `translate3d(0,0,0)` 强制 GPU 渲染
+- 或使用 `backdrop-filter` 替代方案（兼容性较差）
+
+```css
+.clear-render {
+  transform: translateZ(0);
+  -webkit-font-smoothing: antialiased;
+}
+```
+
+### 坑 3：fixed 元素超出父容器滚动区域
+
+**问题**：`fixed` 相对于父容器定位后，滚动父容器时 `fixed` 元素会"跑出"可见区域。
+
+**解决**：根据滚动位置动态计算 `top/left`：
+
+```javascript
+container.addEventListener('scroll', () => {
+  const rect = container.getBoundingClientRect();
+  fixedElement.style.top = `${rect.top + 20}px`;
+  fixedElement.style.left = `${rect.left + 20}px`;
+});
+```
+
+### 坑 4：fixed 与 absolute 混淆
+
+**问题**：在需要相对于祖先定位时错误使用 `absolute`，导致定位不符合预期。
+
+**解决**：
+- `fixed`：相对于视口定位（不受滚动影响）
+- `absolute`：相对于最近**已定位**祖先定位
+
+```css
+/* fixed — 视口固定 */
+.popover {
+  position: fixed;
+  top: 50px;
+}
+
+/* absolute — 相对于父容器 */
+.tooltip {
+  position: absolute;
+  top: 100%;
+  left: 0;
+}
+```
+
+### 坑 5：z-index 层叠问题
+
+**问题**：`transform` 创建的新包含块可能有独立的层叠上下文，影响 z-index 层级。
+
+**解决**：
+- 确保正确的 z-index 层级
+- 必要时在共同祖先上设置 `z-index`
+
+```css
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  z-index: 1000;
+}
+
+.modal-content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  /* 由于外层 modal-overlay 已建立层叠上下文 */
+  /* 需要更高的 z-index */
+  z-index: 1001;
+}
+```
+
+## 实战：完整示例
+
+### 卡片内固定角标
+
+```html
+<div class="card">
+  <div class="card-badge">新品</div>
+  <h3>产品标题</h3>
+  <p>产品描述内容...</p>
+</div>
+
+<style>
+.card {
+  position: relative;
+  padding: 16px;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  overflow: hidden;
+}
+
+.card-badge {
+  position: fixed;
+  top: 12px;
+  right: -32px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  font-size: 12px;
+  padding: 4px 40px;
+  transform: rotate(45deg);
+  transform-origin: center;
+}
+</style>
+```
+
+### 吸附式侧边栏
+
+```html
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-sticky">
+      <h2>分类</h2>
+      <nav>...</nav>
+    </div>
+  </aside>
+  <main class="content">...</main>
+</div>
+
+<style>
+.sidebar {
+  transform: translateX(0); /* 创建包含块 */
+}
+
+.sidebar-sticky {
+  position: fixed;
+  top: 80px;
+  width: 250px;
+}
+
+.content {
+  margin-left: 270px;
+}
+</style>
+```
+
+## 浏览器支持
+
+`transform` 对 `position: fixed` 的影响是 CSS 规范的一部分，所有现代浏览器均支持：
+
+| 特性 | Chrome | Firefox | Safari | Edge |
+|------|--------|---------|--------|------|
+| transform 创建包含块 | ✅ 1+ | ✅ 3.5+ | ✅ 3.1+ | ✅ 12+ |
+| fixed 相对于 transform 父元素 | ✅ 51+ | ✅ 36+ | ✅ 15+ | ✅ 79+ |
+
+> 注：Chrome 51 之前，transform 父元素不会影响 fixed 的行为。
+
+## 总结
+
+| 场景 | 推荐方案 |
+|------|---------|
+| 简单的"相对于父元素固定" | `transform: translateX(0)` 或 `scale(1)` |
+| 需要 relative 定位辅助 | `position: relative` 在父容器 |
+| 需要滚动联动 | JS 动态计算 `top/left` |
+| 避免性能问题 | 限制 transform 使用，合理分层 |
+
+**核心原理**：transform 创建新的物理包含块，fixed 定位相对于该包含块而非视口计算。
+
+## 参考资源
+
+- [MDN: transform 属性](https://developer.mozilla.org/en-US/docs/Web/CSS/transform)
+- [MDN: position 属性](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
+- [CSS Transforms Spec](https://www.w3.org/TR/css-transforms-1/)
+- [What's New in CSS Containment](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Containment)
+- [Layer-based rendering explained](https://developer.chrome.com/docs/web-platform/layers)

--- a/examples/css/demos/fixed-relative-positioning.html
+++ b/examples/css/demos/fixed-relative-positioning.html
@@ -1,0 +1,527 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Fixed 相对定位：视图窗口 vs 元素</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f5f5f5;
+      padding: 20px;
+      padding-bottom: 100px;
+    }
+    h1 {
+      font-size: 24px;
+      margin-bottom: 20px;
+      color: #333;
+    }
+    h2 {
+      font-size: 18px;
+      margin: 20px 0 10px;
+      color: #444;
+    }
+    .demo-container {
+      background: white;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    .tab-nav {
+      display: flex;
+      gap: 4px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+    }
+    .tab-btn {
+      padding: 8px 16px;
+      border: none;
+      background: #e0e0e0;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 14px;
+      transition: all 0.2s;
+    }
+    .tab-btn:hover {
+      background: #d0d0d0;
+    }
+    .tab-btn.active {
+      background: #007AFF;
+      color: white;
+    }
+    .tab-content {
+      display: none;
+    }
+    .tab-content.active {
+      display: block;
+    }
+    
+    /* 场景1: 标准 fixed */
+    .scene1-wrapper {
+      position: relative;
+      height: 200px;
+      background: #f0f0f0;
+      border: 2px dashed #ccc;
+      border-radius: 8px;
+      overflow: auto;
+    }
+    .scene1-fixed {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      background: #ff6b6b;
+      color: white;
+      padding: 10px 16px;
+      border-radius: 6px;
+      font-size: 12px;
+      z-index: 1000;
+    }
+    .scene1-content {
+      padding: 60px 20px;
+      height: 400px;
+    }
+    .scene1-content p {
+      margin-bottom: 16px;
+      color: #666;
+      line-height: 1.6;
+    }
+    
+    /* 场景2: transform 欺骗法 */
+    .scene2-wrapper {
+      position: relative;
+      height: 200px;
+      background: #e8f5e9;
+      border: 2px solid #4CAF50;
+      border-radius: 8px;
+      overflow: auto;
+      transform: translate(0); /* 关键：创建新的包含块 */
+    }
+    .scene2-fixed {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      background: #4CAF50;
+      color: white;
+      padding: 10px 16px;
+      border-radius: 6px;
+      font-size: 12px;
+    }
+    .scene2-content {
+      padding: 60px 20px;
+      height: 400px;
+    }
+    .scene2-content p {
+      margin-bottom: 16px;
+      color: #666;
+      line-height: 1.6;
+    }
+    
+    /* 场景3: sticky 对比 */
+    .scene3-container {
+      height: 200px;
+      background: #fff3e0;
+      border: 2px solid #FF9800;
+      border-radius: 8px;
+      overflow: auto;
+    }
+    .scene3-sticky {
+      position: sticky;
+      top: 10px;
+      background: #FF9800;
+      color: white;
+      padding: 10px 16px;
+      border-radius: 6px;
+      font-size: 12px;
+      margin: 10px;
+      width: fit-content;
+    }
+    .scene3-normal {
+      background: #FFE0B2;
+      padding: 60px 20px;
+      margin: 10px;
+      border-radius: 4px;
+    }
+    
+    /* 对比表 */
+    .comparison-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 16px;
+    }
+    .comparison-table th,
+    .comparison-table td {
+      border: 1px solid #ddd;
+      padding: 12px;
+      text-align: left;
+      font-size: 14px;
+    }
+    .comparison-table th {
+      background: #f5f5f5;
+      font-weight: 600;
+    }
+    .comparison-table tr:hover {
+      background: #fafafa;
+    }
+    .tag {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 12px;
+      margin: 2px;
+    }
+    .tag-green { background: #e8f5e9; color: #2e7d32; }
+    .tag-yellow { background: #fff3e0; color: #f57c00; }
+    .tag-red { background: #ffebee; color: #c62828; }
+    
+    /* 结论卡片 */
+    .conclusion {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 20px;
+      border-radius: 8px;
+      margin-top: 16px;
+    }
+    .conclusion h3 {
+      margin-bottom: 12px;
+      font-size: 16px;
+    }
+    .conclusion ul {
+      margin-left: 20px;
+    }
+    .conclusion li {
+      margin-bottom: 8px;
+      line-height: 1.5;
+    }
+    
+    /* 代码块 */
+    .code-block {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 16px;
+      border-radius: 6px;
+      font-family: 'Monaco', 'Menlo', monospace;
+      font-size: 13px;
+      overflow-x: auto;
+      line-height: 1.6;
+      margin: 12px 0;
+    }
+    .code-block .comment { color: #6a9955; }
+    .code-block .keyword { color: #569cd6; }
+    .code-block .string { color: #ce9178; }
+    .code-block .property { color: #9cdcfe; }
+    .code-block .value { color: #ce9178; }
+    
+    /* 说明文字 */
+    .explanation {
+      background: #e3f2fd;
+      border-left: 4px solid #2196F3;
+      padding: 12px 16px;
+      margin: 12px 0;
+      border-radius: 0 4px 4px 0;
+      font-size: 14px;
+      line-height: 1.6;
+    }
+    .warning {
+      background: #fff3e0;
+      border-left: 4px solid #ff9800;
+      padding: 12px 16px;
+      margin: 12px 0;
+      border-radius: 0 4px 4px 0;
+      font-size: 14px;
+    }
+    
+    /* 滚动区域标记 */
+    .scroll-indicator {
+      position: absolute;
+      bottom: 10px;
+      right: 10px;
+      background: rgba(0,0,0,0.6);
+      color: white;
+      padding: 4px 8px;
+      border-radius: 4px;
+      font-size: 11px;
+    }
+    
+    /* 测试区 */
+    .test-area {
+      background: #fafafa;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 16px;
+    }
+    .test-area h4 {
+      font-size: 14px;
+      margin-bottom: 12px;
+      color: #333;
+    }
+    .test-row {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+    .test-item {
+      flex: 1;
+      min-width: 200px;
+      background: white;
+      border: 1px solid #eee;
+      border-radius: 4px;
+      padding: 12px;
+    }
+    .test-item h5 {
+      font-size: 12px;
+      color: #666;
+      margin-bottom: 8px;
+    }
+  </style>
+</head>
+<body>
+  <h1>CSS Fixed 定位：相对视图窗口 vs 相对元素</h1>
+  
+  <div class="demo-container">
+    <div class="tab-nav">
+      <button class="tab-btn active" onclick="showTab('overview')">📖 概念总览</button>
+      <button class="tab-btn" onclick="showTab('scene1')">🎯 标准 Fixed</button>
+      <button class="tab-btn" onclick="showTab('scene2')">✨ Transform 法</button>
+      <button class="tab-btn" onclick="showTab('scene3')">🔒 Sticky 对比</button>
+      <button class="tab-btn" onclick="showTab('decision')">🌳 决策树</button>
+    </div>
+    
+    <!-- 概念总览 -->
+    <div id="overview" class="tab-content active">
+      <h2>核心概念</h2>
+      <div class="explanation">
+        <strong>问题：</strong>如何让一个 <code>position: fixed</code> 的元素，相对于某个<em>特定元素</em>定位，而不是整个视口？
+      </div>
+      
+      <h2>为什么 fixed 总是相对于视口？</h2>
+      <p style="margin: 12px 0; line-height: 1.6; color: #666;">
+        根据 CSS 规范，<code>position: fixed</code> 的定位上下文是<strong>视口</strong>（viewport）。
+        即使父元素设置了 <code>position: relative</code>，也不会影响 fixed 子元素的定位上下文。
+      </p>
+      
+      <div class="code-block">
+<span class="comment">/* ❌ 这个父元素的 relative 对 fixed 子元素无效 */</span>
+.parent {
+  <span class="property">position</span>: <span class="value">relative</span>; <span class="comment">/* 无效 */</span>
+}
+.child {
+  <span class="property">position</span>: <span class="value">fixed</span>;
+  <span class="property">top</span>: <span class="value">0</span>; <span class="comment">/* 仍然是相对于视口定位 */</span>
+}
+      </div>
+      
+      <h2>解决方案概览</h2>
+      <table class="comparison-table">
+        <thead>
+          <tr>
+            <th>方案</th>
+            <th>原理</th>
+            <th>适用场景</th>
+            <th>兼容性</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>transform 欺骗法</strong></td>
+            <td>transform 会创建新的包含块</td>
+            <td>浮层、Tooltip、固定按钮</td>
+            <td><span class="tag tag-green">✅ 全部支持</span></td>
+          </tr>
+          <tr>
+            <td><strong>JS 动态计算</strong></td>
+            <td>使用 absolute + JS 计算位置</td>
+            <td>复杂交互、实时跟随</td>
+            <td><span class="tag tag-green">✅ 全部支持</span></td>
+          </tr>
+          <tr>
+            <td><strong>position: sticky</strong></td>
+            <td>在滚动容器内粘住</td>
+            <td>表格头、侧边栏分类导航</td>
+            <td><span class="tag tag-green">✅ 全部支持</span></td>
+          </tr>
+          <tr>
+            <td><strong>CSS anchor-positioning</strong></td>
+            <td>原生锚点定位（实验性）</td>
+            <td>Tooltip、下拉菜单</td>
+            <td><span class="tag tag-yellow">⚠️ Chrome 实验</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    
+    <!-- 场景1: 标准 Fixed -->
+    <div id="scene1" class="tab-content">
+      <h2>标准 Fixed：始终相对于视口</h2>
+      <div class="scene1-wrapper">
+        <div class="scene1-fixed">我是 Fixed（红）</div>
+        <div class="scene1-content">
+          <p>滚动这个容器，观察红色 Fixed 元素的行为：</p>
+          <p>它始终固定在<strong>视口</strong>的右上角，不受容器滚动影响。</p>
+          <p style="margin-top: 30px;">这是因为 fixed 的定位上下文是整个视口，而非父容器。</p>
+        </div>
+        <span class="scroll-indicator">↓ 滚动我</span>
+      </div>
+      
+      <div class="code-block">
+<span class="keyword">.fixed-element</span> {
+  <span class="property">position</span>: <span class="value">fixed</span>;
+  <span class="property">top</span>: <span class="value">10px</span>;
+  <span class="property">right</span>: <span class="value">10px</span>;
+  <span class="comment">/* 始终相对于视口定位，不受父元素影响 */</span>
+}
+      </div>
+    </div>
+    
+    <!-- 场景2: Transform 欺骗法 -->
+    <div id="scene2" class="tab-content">
+      <h2>Transform 欺骗法：Fixed 相对于父元素</h2>
+      <div class="explanation">
+        <strong>关键：</strong>给父元素添加 <code>transform: translate(0)</code> 会创建新的<em>包含块</em>，
+        使 fixed 元素相对于这个新的包含块定位！
+      </div>
+      
+      <div class="scene2-wrapper">
+        <div class="scene2-fixed">我是 Transform Fixed（绿）</div>
+        <div class="scene2-content">
+          <p>滚动这个容器，观察绿色 Fixed 元素的行为：</p>
+          <p>它固定在<strong>父容器的右上角</strong>，随容器滚动而滚动！</p>
+          <p style="margin-top: 30px;">这是因为 transform 创建了新的包含块，改变了 fixed 的定位上下文。</p>
+        </div>
+        <span class="scroll-indicator">↓ 滚动我</span>
+      </div>
+      
+      <div class="code-block">
+<span class="comment">/* ✅ 父元素添加 transform 创建新的包含块 */</span>
+.container {
+  <span class="property">position</span>: <span class="value">relative</span>;
+  <span class="property">transform</span>: <span class="value">translate(0)</span>; <span class="comment">/* 关键！*/</span>
+}
+
+<span class="keyword">.fixed-element</span> {
+  <span class="property">position</span>: <span class="value">fixed</span>;
+  <span class="property">top</span>: <span class="value">10px</span>;
+  <span class="property">right</span>: <span class="value">10px</span>;
+  <span class="comment">/* 现在相对于 .container 定位！*/</span>
+}
+      </div>
+      
+      <div class="warning">
+        <strong>注意：</strong>transform 会影响子元素的视觉效果（scale, rotate 等），确保这些副作用可接受。
+      </div>
+    </div>
+    
+    <!-- 场景3: Sticky 对比 -->
+    <div id="scene3" class="tab-content">
+      <h2>position: sticky：容器内的"伪固定"</h2>
+      <div class="scene3-container">
+        <div class="scene3-sticky">我是 Sticky（橙）</div>
+        <div class="scene3-normal">
+          <p>这是普通内容区域...</p>
+          <p>sticky 元素会"粘"在容器的顶部，当容器滚出视口时，它也会跟着消失。</p>
+          <p>与 fixed 的区别：</p>
+          <ul style="margin-left: 20px; margin-top: 8px; color: #666;">
+            <li>fixed：永远固定在视口</li>
+            <li>sticky：只在父容器滚动范围内固定</li>
+          </ul>
+        </div>
+        <div class="scene3-normal">
+          <p>继续滚动...</p>
+        </div>
+        <span class="scroll-indicator">↓ 滚动我</span>
+      </div>
+      
+      <div class="code-block">
+<span class="keyword">.sticky-element</span> {
+  <span class="property">position</span>: <span class="value">sticky</span>;
+  <span class="property">top</span>: <span class="value">10px</span>; <span class="comment">/* 距离容器顶部的偏移 */</span>
+}
+      </div>
+      
+      <div class="warning">
+        <strong>sticky 的限制：</strong>
+        <ul style="margin-left: 20px; margin-top: 8px;">
+          <li>父容器必须有 overflow: auto/scroll/hidden</li>
+          <li>父容器滚出视口后，sticky 也会消失</li>
+          <li>不支持 IE</li>
+        </ul>
+      </div>
+    </div>
+    
+    <!-- 决策树 -->
+    <div id="decision" class="tab-content">
+      <h2>如何选择？</h2>
+      
+      <div class="test-area">
+        <h4>根据场景选择方案：</h4>
+        <div class="test-row">
+          <div class="test-item">
+            <h5>场景 1：浮层/下拉菜单</h5>
+            <p style="font-size: 13px; color: #666;">相对于触发元素定位，滚动时跟随</p>
+            <span class="tag tag-green">推荐：transform 欺骗法</span>
+          </div>
+          <div class="test-item">
+            <h5>场景 2：吸顶导航</h5>
+            <p style="font-size: 13px; color: #666;">固定在视口顶部，页面滚动时不动</p>
+            <span class="tag tag-green">推荐：position: fixed</span>
+          </div>
+          <div class="test-item">
+            <h5>场景 3：表格头、分类导航</h5>
+            <p style="font-size: 13px; color: #666;">在容器内滚动时固定，容器滚走则消失</p>
+            <span class="tag tag-green">推荐：position: sticky</span>
+          </div>
+          <div class="test-item">
+            <h5>场景 4：Tooltip/复杂跟随</h5>
+            <p style="font-size: 13px; color: #666;">需要根据目标元素位置实时计算</p>
+            <span class="tag tag-yellow">推荐：JS + getBoundingClientRect</span>
+          </div>
+        </div>
+      </div>
+      
+      <div class="conclusion">
+        <h3>💡 核心要点</h3>
+        <ul>
+          <li><strong>fixed 的定位上下文是视口</strong>，不受父元素 position 影响</li>
+          <li><strong>transform 会改变 fixed 的定位上下文</strong>，这是实现"相对固定"的关键</li>
+          <li><strong>sticky 是 fixed 和 relative 的混合</strong>，只在父容器内有效</li>
+          <li><strong>复杂场景用 JS</strong>，但优先考虑 CSS 方案（性能更好）</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function showTab(tabId) {
+      // Hide all tabs
+      document.querySelectorAll('.tab-content').forEach(tab => {
+        tab.classList.remove('active');
+      });
+      document.querySelectorAll('.tab-btn').forEach(btn => {
+        btn.classList.remove('active');
+      });
+      
+      // Show selected tab
+      document.getElementById(tabId).classList.add('active');
+      event.target.classList.add('active');
+    }
+    
+    // Demo: 动态更新滚动位置
+    function updateScrollIndicator() {
+      document.querySelectorAll('.scroll-indicator').forEach(indicator => {
+        const wrapper = indicator.parentElement;
+        indicator.textContent = `滚动位置: ${wrapper.scrollTop}px`;
+      });
+    }
+    
+    document.querySelectorAll('.scene1-wrapper, .scene2-wrapper, .scene3-container').forEach(wrapper => {
+      wrapper.addEventListener('scroll', updateScrollIndicator);
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/layout-guide-demo.html
+++ b/examples/css/demos/layout-guide-demo.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS 布局方案对比演示</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.6; padding: 20px; background: #f8f9fa; }
+    h1, h2, h3 { margin-bottom: 10px; color: #333; }
+    section { background: #fff; border-radius: 8px; padding: 20px; margin-bottom: 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+    .demo-label { font-size: 12px; color: #666; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .demo-box { background: #e9ecef; border-radius: 4px; padding: 12px; min-height: 60px; margin-bottom: 16px; }
+
+    /* Flex 演示 */
+    .flex-nav { display: flex; justify-content: space-between; align-items: center; background: #2c3e50; border-radius: 6px; padding: 0 16px; }
+    .flex-nav .logo { color: #fff; font-weight: 700; font-size: 18px; }
+    .flex-nav .links { display: flex; gap: 16px; }
+    .flex-nav a { color: #ecf0f1; text-decoration: none; font-size: 14px; }
+
+    .flex-cards { display: flex; gap: 12px; flex-wrap: wrap; }
+    .card { flex: 1; min-width: 140px; background: #3498db; color: #fff; border-radius: 6px; padding: 16px; text-align: center; }
+
+    /* Grid 演示 */
+    .grid-page { display: grid; grid-template-columns: 200px 1fr 200px; grid-template-rows: 60px 1fr 40px; gap: 12px; min-height: 280px; }
+    .grid-header { grid-column: 1 / -1; background: #2c3e50; color: #fff; border-radius: 6px; display: flex; align-items: center; padding: 0 16px; }
+    .grid-sidebar { background: #3498db; color: #fff; border-radius: 6px; padding: 16px; }
+    .grid-content { background: #ecf0f1; border-radius: 6px; padding: 16px; }
+    .grid-aside { background: #9b59b6; color: #fff; border-radius: 6px; padding: 16px; }
+    .grid-footer { grid-column: 1 / -1; background: #34495e; color: #fff; border-radius: 6px; display: flex; align-items: center; padding: 0 16px; font-size: 13px; }
+
+    /* auto-fit grid */
+    .grid-auto { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
+    .grid-auto .card { background: #27ae60; color: #fff; border-radius: 6px; padding: 20px; text-align: center; min-height: 80px; display: flex; align-items: center; justify-content: center; }
+
+    /* Subgrid 对齐 */
+    .subgrid-demo { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 12px; }
+    .subgrid-card { grid-column: span 3; display: grid; grid-template-columns: subgrid; gap: 12px; background: #fff; border: 1px solid #ddd; border-radius: 6px; padding: 12px; }
+    .subgrid-item { background: #3498db; color: #fff; border-radius: 4px; padding: 10px; font-size: 13px; text-align: center; }
+
+    /* clamp 响应式 */
+    .clamp-box { width: clamp(200px, 50%, 500px); background: linear-gradient(135deg, #667eea, #764ba2); color: #fff; border-radius: 8px; padding: 20px; text-align: center; margin: 0 auto; }
+    .clamp-text { font-size: clamp(14px, 3vw, 24px); }
+
+    /* 对比表 */
+    .compare-table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+    .compare-table th, .compare-table td { border: 1px solid #dee2e6; padding: 10px 12px; text-align: left; font-size: 14px; }
+    .compare-table th { background: #f8f9fa; font-weight: 600; }
+    .compare-table tr:nth-child(even) { background: #f8f9fa; }
+    .tag { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 600; }
+    .tag-flex { background: #e8f4fd; color: #3498db; }
+    .tag-grid { background: #e8f8f0; color: #27ae60; }
+    .tag-old { background: #fde8e8; color: #e74c3c; }
+  </style>
+</head>
+<body>
+
+<section>
+  <h2>Flexbox vs Grid vs Table 方案对比</h2>
+  <table class="compare-table">
+    <thead>
+      <tr><th>方案</th><th>维度</th><th>最佳用例</th><th>局限性</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><span class="tag tag-flex">Flexbox</span></td><td>一维（主轴/交叉轴）</td><td>导航栏、卡片组、垂直居中</td><td>不擅长多行多列复杂结构</td></tr>
+      <tr><td><span class="tag tag-grid">CSS Grid</span></td><td>二维（行/列）</td><td>页面整体布局、响应式网格</td><td>学习曲线稍陡</td></tr>
+      <tr><td><span class="tag tag-old">Table</span></td><td>行/列固定结构</td><td>纯数据表格（报表）</td><td>不响应式、语义差</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section>
+  <div class="demo-label">Flexbox — 导航栏（space-between）</div>
+  <div class="demo-box">
+    <nav class="flex-nav">
+      <div class="logo">Logo</div>
+      <div class="links">
+        <a href="#">首页</a>
+        <a href="#">产品</a>
+        <a href="#">关于</a>
+        <a href="#">联系</a>
+      </div>
+    </nav>
+  </div>
+  <div class="demo-label">Flexbox — 卡片组（flex-wrap）</div>
+  <div class="demo-box">
+    <div class="flex-cards">
+      <div class="card">卡片一</div>
+      <div class="card">卡片二</div>
+      <div class="card">卡片三</div>
+      <div class="card">卡片四</div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="demo-label">CSS Grid — 经典三栏布局</div>
+  <div class="demo-box">
+    <div class="grid-page">
+      <div class="grid-header">Header（grid-column: 1 / -1）</div>
+      <div class="grid-sidebar">Sidebar 左侧</div>
+      <div class="grid-content">Main Content</div>
+      <div class="grid-aside">Sidebar 右侧</div>
+      <div class="grid-footer">Footer（grid-column: 1 / -1）</div>
+    </div>
+  </div>
+  <div class="demo-label">CSS Grid — auto-fit 自适应列数</div>
+  <div class="demo-box">
+    <div class="grid-auto">
+      <div class="card">项目一</div>
+      <div class="card">项目二</div>
+      <div class="card">项目三</div>
+      <div class="card">项目四</div>
+      <div class="card">项目五</div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="demo-label">clamp() — 无媒体查询自适应（调整窗口宽度查看）</div>
+  <div class="demo-box">
+    <div class="clamp-box">
+      <div class="clamp-text">clamp(200px, 50%, 500px)</div>
+      <div style="font-size:13px; margin-top:8px; color:rgba(255,255,255,0.8)">宽度随窗口自动调整</div>
+    </div>
+  </div>
+  <div style="display:grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap:12px; margin-top:12px;">
+    <div style="background:#e74c3c; color:#fff; border-radius:6px; padding:16px; text-align:center;">
+      <div style="font-size:clamp(12px, 2vw, 18px);">clamp 字号</div>
+      <div style="font-size:12px; opacity:0.8; margin-top:4px;">响应式文本</div>
+    </div>
+    <div style="background:#3498db; color:#fff; border-radius:6px; padding:16px; display:flex; align-items:center; justify-content:center;">
+      <div style="width:clamp(60px, 30%, 120px); height:60px; background:rgba(255,255,255,0.3); border-radius:50%;"></div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="demo-label">Subgrid — 卡片内部对齐（Chrome 117+, Safari 16+）</div>
+  <div class="demo-box">
+    <div class="subgrid-demo">
+      <div class="subgrid-card">
+        <div class="subgrid-item">标题对齐</div>
+        <div class="subgrid-item">描述文字</div>
+        <div class="subgrid-item">按钮</div>
+      </div>
+      <div class="subgrid-card">
+        <div class="subgrid-item">更长的标题内容</div>
+        <div class="subgrid-item">更短的描述</div>
+        <div class="subgrid-item">按钮</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+</body>
+</html>

--- a/examples/css/demos/relative-fixed-positioning-demo.html
+++ b/examples/css/demos/relative-fixed-positioning-demo.html
@@ -1,0 +1,785 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>相对固定定位 — 交互演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { 
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', sans-serif; 
+      background: #0d1117; 
+      color: #c9d1d9; 
+      min-height: 100vh; 
+      padding: 24px; 
+    }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 14px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 1000px; margin: 0 auto; }
+    
+    /* Section styling */
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; display: flex; align-items: center; gap: 8px; }
+    .section h2::before { content: ''; display: inline-block; width: 4px; height: 16px; background: #58a6ff; border-radius: 2px; }
+    .section h3 { font-size: 14px; color: #8b949e; margin: 16px 0 8px; }
+    
+    /* Demo viewport */
+    .demo-viewport { 
+      background: #21262d; 
+      border: 1px solid #30363d; 
+      border-radius: 6px; 
+      overflow: hidden; 
+      margin-bottom: 12px;
+    }
+    .demo-header {
+      background: #30363d;
+      padding: 8px 12px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .demo-header span { font-size: 12px; color: #8b949e; }
+    .demo-dot { width: 10px; height: 10px; border-radius: 50%; }
+    .demo-dot.red { background: #ff5f56; }
+    .demo-dot.yellow { background: #ffbd2e; }
+    .demo-dot.green { background: #27c93f; }
+    .demo-content { padding: 16px; position: relative; }
+    
+    /* Buttons */
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .btn { 
+      padding: 6px 12px; 
+      background: #21262d; 
+      border: 1px solid #30363d; 
+      border-radius: 4px; 
+      color: #c9d1d9; 
+      font-size: 12px; 
+      cursor: pointer; 
+      transition: all 0.15s;
+    }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    
+    /* Code blocks */
+    .code-block { 
+      background: #0d1117; 
+      border: 1px solid #30363d; 
+      border-radius: 4px; 
+      padding: 12px; 
+      font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace; 
+      font-size: 12px; 
+      overflow-x: auto; 
+      white-space: pre-wrap; 
+      word-break: break-all; 
+      color: #79c0ff; 
+    }
+    
+    /* Description */
+    .desc { font-size: 12px; color: #6e7681; margin-top: 8px; line-height: 1.5; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 12px; padding: 12px; background: #161b22; border-radius: 4px; border-left: 3px solid #58a6ff; }
+    
+    /* Demo-specific elements */
+    .outer-box {
+      width: 100%;
+      height: 280px;
+      background: #0d1117;
+      border: 2px dashed #30363d;
+      border-radius: 4px;
+      position: relative;
+      overflow: hidden;
+    }
+    
+    .middle-box {
+      width: 70%;
+      height: 220px;
+      background: #161b22;
+      border: 2px dashed #58a6ff;
+      border-radius: 4px;
+      margin: 30px auto;
+      position: relative;
+      transition: all 0.3s ease;
+    }
+    
+    .middle-box.transform-applied {
+      transform: translateX(0);
+    }
+    
+    .middle-box.scale-applied {
+      transform: scale(1);
+    }
+    
+    .middle-box.relative-applied {
+      position: relative;
+    }
+    
+    .middle-box.perspective-applied {
+      perspective: 1000px;
+    }
+    
+    .fixed-element {
+      position: fixed;
+      padding: 8px 16px;
+      background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
+      color: white;
+      font-size: 12px;
+      font-weight: 600;
+      border-radius: 4px;
+      box-shadow: 0 4px 12px rgba(231, 76, 60, 0.4);
+      z-index: 100;
+      cursor: pointer;
+      transition: all 0.3s ease;
+      white-space: nowrap;
+    }
+    
+    .fixed-element:hover {
+      transform: scale(1.05);
+      box-shadow: 0 6px 16px rgba(231, 76, 60, 0.5);
+    }
+    
+    .fixed-element.in-middle {
+      top: 10px;
+      left: 10px;
+    }
+    
+    .fixed-element.in-viewport {
+      top: 10px;
+      right: 10px;
+    }
+    
+    .label-marker {
+      position: absolute;
+      font-size: 10px;
+      padding: 2px 6px;
+      border-radius: 2px;
+      color: white;
+    }
+    
+    .label-marker.viewport-label {
+      top: 4px;
+      left: 4px;
+      background: #f0883e;
+    }
+    
+    .label-marker.middle-label {
+      top: 4px;
+      right: 4px;
+      background: #58a6ff;
+    }
+    
+    /* Interactive playground */
+    .playground {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+    }
+    
+    .playground-left, .playground-right {
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 4px;
+      padding: 16px;
+    }
+    
+    .playground-left h4, .playground-right h4 {
+      font-size: 13px;
+      color: #8b949e;
+      margin-bottom: 12px;
+    }
+    
+    .css-input {
+      width: 100%;
+      min-height: 100px;
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 4px;
+      padding: 12px;
+      font-family: 'SF Mono', Monaco, monospace;
+      font-size: 12px;
+      color: #79c0ff;
+      resize: vertical;
+      margin-bottom: 12px;
+    }
+    
+    .css-input:focus {
+      outline: none;
+      border-color: #58a6ff;
+    }
+    
+    /* Scrollable container demo */
+    .scroll-demo-container {
+      width: 100%;
+      height: 300px;
+      background: #21262d;
+      border: 2px dashed #58a6ff;
+      border-radius: 4px;
+      overflow: auto;
+      position: relative;
+    }
+    
+    .scroll-content {
+      height: 600px;
+      padding: 16px;
+      position: relative;
+    }
+    
+    .scroll-inner-box {
+      width: 200px;
+      height: 400px;
+      background: #161b22;
+      border: 2px dashed #3fb950;
+      border-radius: 4px;
+      margin: 0 auto;
+      position: relative;
+      transform: translateX(0);
+    }
+    
+    .scroll-fixed {
+      position: fixed;
+      background: #3fb950;
+      color: #0d1117;
+      font-size: 12px;
+      font-weight: 600;
+      padding: 8px 16px;
+      border-radius: 4px;
+      box-shadow: 0 4px 12px rgba(63, 185, 80, 0.4);
+      z-index: 50;
+    }
+    
+    /* Scenario cards */
+    .scenario-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 16px;
+    }
+    
+    .scenario-card {
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      padding: 16px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+    
+    .scenario-card:hover {
+      border-color: #58a6ff;
+      transform: translateY(-2px);
+    }
+    
+    .scenario-card h4 {
+      font-size: 14px;
+      color: #f0f6fc;
+      margin-bottom: 8px;
+    }
+    
+    .scenario-card p {
+      font-size: 12px;
+      color: #8b949e;
+      line-height: 1.5;
+    }
+    
+    /* Animation demo */
+    .anim-target {
+      width: 60px;
+      height: 60px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11px;
+      color: white;
+      font-weight: 600;
+      position: relative;
+      transform: translateX(0);
+      transition: transform 0.3s ease;
+    }
+    
+    .anim-target:hover {
+      transform: translateX(150px);
+    }
+    
+    /* Status indicator */
+    .status-bar {
+      display: flex;
+      gap: 16px;
+      padding: 12px 16px;
+      background: #21262d;
+      border-radius: 4px;
+      margin-bottom: 16px;
+    }
+    
+    .status-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+    }
+    
+    .status-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+    }
+    
+    .status-dot.active { background: #3fb950; }
+    .status-dot.inactive { background: #f85149; }
+    
+    .status-label { color: #8b949e; }
+    .status-value { color: #f0f6fc; font-weight: 500; }
+    
+    /* Tab styles */
+    .tabs { display: flex; gap: 4px; margin-bottom: 16px; border-bottom: 1px solid #30363d; }
+    .tab { padding: 8px 16px; font-size: 13px; color: #8b949e; cursor: pointer; border-bottom: 2px solid transparent; transition: all 0.15s; }
+    .tab:hover { color: #c9d1d9; }
+    .tab.active { color: #58a6ff; border-bottom-color: #58a6ff; }
+    
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+    
+    /* Comparison table */
+    .comparison-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+    
+    .comparison-table th,
+    .comparison-table td {
+      padding: 10px 12px;
+      text-align: left;
+      border-bottom: 1px solid #30363d;
+    }
+    
+    .comparison-table th {
+      background: #21262d;
+      color: #f0f6fc;
+      font-weight: 600;
+    }
+    
+    .comparison-table td { color: #c9d1d9; }
+    .comparison-table tr:hover td { background: #161b22; }
+    
+    .tag {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 11px;
+      font-weight: 500;
+    }
+    
+    .tag-red { background: rgba(248, 81, 73, 0.2); color: #f85149; }
+    .tag-green { background: rgba(63, 185, 80, 0.2); color: #3fb950; }
+    .tag-blue { background: rgba(56, 139, 253, 0.2); color: #58a6ff; }
+    .tag-yellow { background: rgba(210, 168, 69, 0.2); color: #d2a869; }
+    
+    @media (max-width: 768px) {
+      .playground { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>相对固定定位 — 交互演示</h1>
+    <p class="subtitle">理解 transform 如何改变 fixed 定位上下文，实现"相对于父元素固定"效果</p>
+    
+    <!-- Status Bar -->
+    <div class="status-bar">
+      <div class="status-item">
+        <span class="status-dot active"></span>
+        <span class="status-label">视口定位上下文</span>
+        <span class="status-value" id="viewport-status">激活</span>
+      </div>
+      <div class="status-item">
+        <span class="status-dot inactive" id="transform-indicator"></span>
+        <span class="status-label">Transform 上下文</span>
+        <span class="status-value" id="transform-status">未激活</span>
+      </div>
+    </div>
+    
+    <!-- Section 1: Basic Demo -->
+    <div class="section">
+      <h2>基础演示</h2>
+      <p class="desc">点击按钮切换父容器的 transform 状态，观察红色 fixed 元素的位置变化。</p>
+      
+      <div class="controls" id="transform-controls">
+        <button class="btn active" data-transform="none">无 transform</button>
+        <button class="btn" data-transform="translateX(0)">transform: translateX(0)</button>
+        <button class="btn" data-transform="scale(1)">transform: scale(1)</button>
+        <button class="btn" data-transform="perspective(1000px)">transform: perspective()</button>
+        <button class="btn" data-transform="relative">position: relative</button>
+      </div>
+      
+      <div class="demo-viewport">
+        <div class="demo-header">
+          <span class="demo-dot red"></span>
+          <span class="demo-dot yellow"></span>
+          <span class="demo-dot green"></span>
+          <span style="margin-left: auto; font-size: 11px; color: #6e7681;">视口边界</span>
+        </div>
+        <div class="demo-content">
+          <div class="outer-box" id="outer-box">
+            <div class="middle-box" id="middle-box">
+              <span class="label-marker middle-label">中间容器</span>
+              <div class="fixed-element in-middle" id="fixed-red">Fixed 元素</div>
+            </div>
+            <span class="label-marker viewport-label">外层容器</span>
+            <div class="fixed-element in-viewport" id="fixed-green">视口固定</div>
+          </div>
+        </div>
+      </div>
+      
+      <div class="code-block" id="current-css">/* 当前状态 */
+.middle-box {
+  transform: none;
+}</div>
+      
+      <div class="info" id="behavior-note">
+        <strong>预期行为：</strong>当 transform 为 none 时，红色 Fixed 元素应该相对于视口定位（显示在右上角）。点击按钮应用 transform 后，红色元素会移动到中间容器的左上角。
+      </div>
+    </div>
+    
+    <!-- Section 2: Interactive Playground -->
+    <div class="section">
+      <h2>CSS Playground</h2>
+      <p class="desc">在左侧输入 CSS 规则，右侧实时预览效果。</p>
+      
+      <div class="playground">
+        <div class="playground-left">
+          <h4>CSS 规则</h4>
+          <textarea class="css-input" id="css-input" spellcheck="false">/* 修改父容器样式 */
+.parent-transform {
+  transform: translateX(0);
+  background: #1a1f26;
+  padding: 20px;
+}
+
+/* 修改 Fixed 子元素样式 */
+.my-fixed {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  background: #e74c3c;
+  padding: 12px 20px;
+  color: white;
+  border-radius: 6px;
+  font-weight: 600;
+  box-shadow: 0 4px 12px rgba(231, 76, 60, 0.4);
+}</textarea>
+          <button class="btn" id="apply-css" style="width: 100%; padding: 10px;">应用 CSS</button>
+        </div>
+        <div class="playground-right">
+          <h4>预览区域</h4>
+          <div style="background: #0d1117; border: 1px solid #30363d; border-radius: 4px; height: 200px; position: relative; overflow: hidden;">
+            <div class="parent-transform" id="playground-parent" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 60%; height: 70%; background: #161b22; border: 2px dashed #58a6ff; border-radius: 4px;">
+              <div class="my-fixed" id="playground-fixed">Fixed</div>
+            </div>
+          </div>
+          <div class="code-block" id="applied-code" style="margin-top: 12px;">/* 等待应用... */</div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Section 3: Scroll Demo -->
+    <div class="section">
+      <h2>滚动容器中的 Fixed</h2>
+      <p class="desc">当 transform 创建了新的定位上下文后，滚动父容器时 fixed 元素不会跟随滚动，而是相对于该容器固定。</p>
+      
+      <div class="scroll-demo-container" id="scroll-container">
+        <div class="scroll-content">
+          <div class="scroll-inner-box" id="scroll-inner">
+            <div class="scroll-fixed" id="scroll-fixed" style="top: 20px; left: 20px;">滚动固定元素</div>
+            <p style="color: #8b949e; font-size: 12px; padding: 60px 16px; text-align: center;">向下滚动查看效果<br>绿色方块内的固定元素会保持位置</p>
+          </div>
+        </div>
+      </div>
+      
+      <div class="controls" style="margin-top: 12px;">
+        <button class="btn" id="scroll-info">滚动位置: 0</button>
+      </div>
+    </div>
+    
+    <!-- Section 4: Scenarios -->
+    <div class="section">
+      <h2>典型使用场景</h2>
+      
+      <div class="scenario-grid">
+        <div class="scenario-card" data-scenario="sticky-header">
+          <h4>🎯 吸顶导航</h4>
+          <p>导航栏在滚动到顶部时固定，滚动时保持在视口顶部。</p>
+        </div>
+        <div class="scenario-card" data-scenario="fab">
+          <h4>🔘 浮动操作按钮</h4>
+          <p>固定在视口某个位置，常用于主操作如"新建"、"分享"。</p>
+        </div>
+        <div class="scenario-card" data-scenario="badge">
+          <h4>🏷️ 卡片角标</h4>
+          <p>固定在父容器的角落，如"新品"、"热门"等标签。</p>
+        </div>
+        <div class="scenario-card" data-scenario="sidebar">
+          <h4>📌 吸附侧边栏</h4>
+          <p>侧边栏固定在视口，但相对于某个内容区域定位。</p>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Section 5: Comparison -->
+    <div class="section">
+      <h2>定位方式对比</h2>
+      
+      <div class="tabs">
+        <div class="tab active" data-tab="position-table">定位属性对比</div>
+        <div class="tab" data-tab="containing-block">包含块规则</div>
+        <div class="tab" data-tab="common-pitfalls">常见坑点</div>
+      </div>
+      
+      <div class="tab-content active" id="position-table">
+        <table class="comparison-table">
+          <thead>
+            <tr>
+              <th>定位方式</th>
+              <th>定位上下文</th>
+              <th>随滚动移动</th>
+              <th>适用场景</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span class="tag tag-blue">static</span></td>
+              <td>正常文档流</td>
+              <td><span class="tag tag-green">是</span></td>
+              <td>默认布局</td>
+            </tr>
+            <tr>
+              <td><span class="tag tag-blue">relative</span></td>
+              <td>自身原始位置</td>
+              <td><span class="tag tag-green">是</span></td>
+              <td>微调位置、创建子元素定位上下文</td>
+            </tr>
+            <tr>
+              <td><span class="tag tag-blue">absolute</span></td>
+              <td>最近已定位祖先</td>
+              <td><span class="tag tag-green">是</span></td>
+              <td>绝对定位浮层、下拉菜单</td>
+            </tr>
+            <tr>
+              <td><span class="tag tag-red">fixed</span></td>
+              <td>视口（无 transform 祖先）</td>
+              <td><span class="tag tag-red">否</span></td>
+              <td>固定导航、浮动按钮、模态框</td>
+            </tr>
+            <tr>
+              <td><span class="tag tag-yellow">fixed + transform</span></td>
+              <td>transform 祖先</td>
+              <td><span class="tag tag-red">否</span>（相对于祖先固定）</td>
+              <td>相对父容器固定、吸附效果</td>
+            </tr>
+            <tr>
+              <td><span class="tag tag-blue">sticky</span></td>
+              <td>最近滚动容器</td>
+              <td><span class="tag tag-yellow">条件</span></td>
+              <td>表头吸附、分类导航</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      
+      <div class="tab-content" id="containing-block">
+        <div class="code-block" position: relative;
+  width: 300px;
+  height: 200px;
+  background: #161b22;
+  border: 2px solid #58a6ff;
+}
+
+/* transform 创建新的包含块 */
+.transform-parent {
+  transform: translateX(0);
+  /* 或 scale(1), perspective(), filter() */
+}
+
+/* fixed 相对于 .transform-parent 定位 */
+.fixed-child {
+  position: fixed;
+  top: 0;
+  left: 0;
+  /* 不再相对于视口，而是相对于 .transform-parent */
+}
+</div>
+        <p class="desc" style="margin-top: 12px;">注意：transform、perspective、filter 属性会改变 absolute 和 fixed 的定位上下文。</p>
+      </div>
+      
+      <div class="tab-content" id="common-pitfalls">
+        <table class="comparison-table">
+          <thead>
+            <tr>
+              <th>坑点</th>
+              <th>问题描述</th>
+              <th>解决方案</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>性能问题</td>
+              <td>过多 transform 导致合成层爆炸</td>
+              <td>限制使用，合理分层</td>
+            </tr>
+            <tr>
+              <td>文字模糊</td>
+              <td>transform 触发亚像素渲染</td>
+              <td>使用 translateZ(0) 强制 GPU</td>
+            </tr>
+            <tr>
+              <td>滚动越界</td>
+              <td>fixed 元素随滚动"跑出"父容器</td>
+              <td>JS 动态计算位置</td>
+            </tr>
+            <tr>
+              <td>z-index 层叠</td>
+              <td>transform 创建独立层叠上下文</td>
+              <td>统一规划 z-index 层级</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    
+    <!-- Section 6: Animation Demo -->
+    <div class="section">
+      <h2>动画中的 Transform</h2>
+      <p class="desc">hover 下面的元素，观察 transform 动画效果。保持 transform 状态同时实现 fixed 定位。</p>
+      
+      <div style="background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 40px; display: flex; align-items: center; justify-content: center; gap: 40px;">
+        <div class="anim-target" style="position: relative;">
+          <span>Hover Me</span>
+        </div>
+        <div style="position: relative; transform: translateX(0);">
+          <div class="anim-target" style="position: fixed; top: 0; left: 0; background: linear-gradient(135deg, #3fb950 0%, #2d8a3e 100%);">
+            <span>Fixed + Transform</span>
+          </div>
+          <div style="width: 200px; height: 100px; background: #161b22; border: 2px dashed #3fb950; border-radius: 4px; margin-left: 80px; margin-top: 40px;"></div>
+        </div>
+      </div>
+    </div>
+    
+    <p class="info">
+      <strong>总结：</strong>transform 属性会改变 fixed 的定位上下文，使其相对于应用了 transform 的祖先元素定位，而非视口。这允许我们实现"相对父元素固定"的布局效果，是现代前端实现吸附、浮动等交互的重要技术。
+    </p>
+  </div>
+
+  <script>
+    // ===== Transform Controls =====
+    const transformControls = document.getElementById('transform-controls');
+    const middleBox = document.getElementById('middle-box');
+    const fixedRed = document.getElementById('fixed-red');
+    const fixedGreen = document.getElementById('fixed-green');
+    const currentCss = document.getElementById('current-css');
+    const behaviorNote = document.getElementById('behavior-note');
+    const viewportStatus = document.getElementById('viewport-status');
+    const transformStatus = document.getElementById('transform-status');
+    const transformIndicator = document.getElementById('transform-indicator');
+    
+    transformControls.addEventListener('click', (e) => {
+      if (e.target.classList.contains('btn')) {
+        // Update active button
+        transformControls.querySelectorAll('.btn').forEach(b => b.classList.remove('active'));
+        e.target.classList.add('active');
+        
+        const transformValue = e.target.dataset.transform;
+        
+        // Apply transform to middle box
+        if (transformValue === 'none') {
+          middleBox.className = 'middle-box';
+          behaviorNote.innerHTML = '<strong>预期行为：</strong>当 transform 为 none 时，红色 Fixed 元素应该相对于视口定位（显示在右上角）。点击按钮应用 transform 后，红色元素会移动到中间容器的左上角。';
+          transformIndicator.className = 'status-dot inactive';
+          transformStatus.textContent = '未激活';
+        } else if (transformValue === 'relative') {
+          middleBox.className = 'middle-box relative-applied';
+          behaviorNote.innerHTML = '<strong>预期行为：</strong>position: relative 只是创建了定位上下文，不影响 fixed 的视口定位。';
+          transformIndicator.className = 'status-dot inactive';
+          transformStatus.textContent = '未激活（relative）';
+        } else {
+          middleBox.style.transform = transformValue;
+          behaviorNote.innerHTML = `<strong>预期行为：</strong>transform: ${transformValue} 创建了新的定位上下文，红色 Fixed 元素现在相对于中间容器定位！`;
+          transformIndicator.className = 'status-dot active';
+          transformStatus.textContent = '已激活';
+        }
+        
+        currentCss.textContent = `/* 当前状态 */
+.middle-box {
+  transform: ${transformValue};
+}`;
+      }
+    });
+    
+    // ===== CSS Playground =====
+    const cssInput = document.getElementById('css-input');
+    const applyCssBtn = document.getElementById('apply-css');
+    const playgroundParent = document.getElementById('playground-parent');
+    const playgroundFixed = document.getElementById('playground-fixed');
+    const appliedCode = document.getElementById('applied-code');
+    
+    applyCssBtn.addEventListener('click', () => {
+      try {
+        const css = cssInput.value;
+        // Extract rules for parent and fixed
+        const parentMatch = css.match(/\.parent-transform\s*\{([^}]+)\}/);
+        const fixedMatch = css.match(/\.my-fixed\s*\{([^}]+)\}/);
+        
+        if (parentMatch) {
+          const rules = parentMatch[1].trim();
+          playgroundParent.style.cssText += rules;
+        }
+        
+        if (fixedMatch) {
+          const rules = fixedMatch[1].trim();
+          playgroundFixed.style.cssText += rules;
+        }
+        
+        appliedCode.textContent = css;
+      } catch (err) {
+        appliedCode.textContent = 'CSS 解析错误: ' + err.message;
+      }
+    });
+    
+    // ===== Scroll Demo =====
+    const scrollContainer = document.getElementById('scroll-container');
+    const scrollFixed = document.getElementById('scroll-fixed');
+    const scrollInfo = document.getElementById('scroll-info');
+    
+    scrollContainer.addEventListener('scroll', () => {
+      const scrollTop = scrollContainer.scrollTop;
+      scrollInfo.textContent = `滚动位置: ${scrollTop}px`;
+      
+      // The fixed element stays in place because it has its own containing block
+    });
+    
+    // ===== Tabs =====
+    document.querySelectorAll('.tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        const tabId = tab.dataset.tab;
+        
+        // Update active tab
+        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        tab.classList.add('active');
+        
+        // Show correct content
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        document.getElementById(tabId).classList.add('active');
+      });
+    });
+    
+    // ===== Scenarios =====
+    document.querySelectorAll('.scenario-card').forEach(card => {
+      card.addEventListener('click', () => {
+        const scenario = card.dataset.scenario;
+        alert(`场景: ${scenario}\n\n这是一个演示卡片，点击可跳转到对应的完整示例。`);
+      });
+    });
+    
+    // ===== Initial State =====
+    console.log('相对固定定位演示已加载');
+    console.log('提示: 尝试点击 "transform: translateX(0)" 按钮观察 fixed 元素的位置变化');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## 任务完成

**原始问题**：元素相对视图窗口固定但是位置相对于某一元素的布局实现？

### 新增文件

- docs/css/fixed-relative-positioning.md（3.2KB 技术文档）
- examples/css/demos/fixed-relative-positioning.html（14.7KB 交互演示）

### 核心结论

1. fixed 的定位上下文是视口，不受父元素 position 影响
2. transform 会改变 fixed 的定位上下文 — 这是实现相对固定的关键
3. 父元素添加 transform: translate(0) 可创建新的包含块
4. sticky 只在容器内有效，适合表格头等场景