### PR TITLE
feat: CSS Scroll Snap 完整教程

### DIFF
--- a/docs/css/fixed-relative-positioning.md
+++ b/docs/css/fixed-relative-positioning.md
@@ -1,0 +1,190 @@
+# CSS 固定定位：相对视图窗口 vs 相对元素
+
+## 核心问题
+
+> 如何实现一个元素既**相对视图窗口固定**（如 `position: fixed`），又**相对于某一元素定位**（如相对于父容器偏移）？
+
+这看似矛盾，但有多种解决方案。
+
+## Position 定位体系回顾
+
+| 值 | 定位上下文 | 文档流 |
+|----|-----------|--------|
+| `static` | 正常文档流 | 保留 |
+| `relative` | 自身原位置 | 保留 |
+| `absolute` | 最近定位祖先 | 脱离 |
+| `fixed` | 视口窗口 | 脱离 |
+| `sticky` | 视口 + 滚动容器混合 | 保留 |
+
+## 问题根源
+
+`position: fixed` 的定位上下文是**视口**（viewport），而非父元素。这是 CSS 规范定义的行为。
+
+```css
+.parent {
+  position: relative; /* 有用吗？*/
+}
+.child {
+  position: fixed;
+  top: 0; /* 相对于视口，不是 .parent */
+}
+```
+
+无论 `.parent` 设置什么定位，`.child` 的 `fixed` 始终相对于视口定位。
+
+## 解决方案
+
+### 方案一：transform 欺骗法（推荐）
+
+**原理**：transform 会创建新的包含块（Containing Block），使 `fixed` 相对于被 transform 的元素定位。
+
+```css
+.container {
+  position: relative;
+  transform: translate(0); /* 激活新的定位上下文 */
+}
+.fixed-element {
+  position: fixed;
+  top: 0;
+  /* 现在相对于 .container 定位 */
+}
+```
+
+**适用场景**：侧边栏固定、跟随按钮、浮层定位
+
+### 方案二：absolute + JS 计算
+
+**原理**：使用 `absolute` 定位，通过 JavaScript 动态计算相对于目标元素的位置。
+
+```js
+function positionFixedRelativeTo(element, target) {
+  const rect = target.getBoundingClientRect();
+  element.style.position = 'absolute';
+  element.style.top = rect.top + 'px';
+  element.style.left = rect.left + 'px';
+}
+```
+
+**适用场景**：复杂交互、需要实时跟随
+
+### 方案三：position: sticky（伪固定）
+
+**原理**：在滚动容器内"粘"在某一位置，但会随容器滚动。
+
+```css
+.sticky-element {
+  position: sticky;
+  top: 10px;
+}
+```
+
+**限制**：只在父容器滚动范围内有效，父容器滚出视口后不再固定。
+
+### 方案四：JS + ResizeObserver 监听
+
+**原理**：监听目标元素位置变化，实时更新 fixed 元素位置。
+
+```js
+const observer = new ResizeObserver(entries => {
+  for (const entry of entries) {
+    updatePosition(entry.target);
+  }
+});
+observer.observe(targetElement);
+```
+
+## 实战场景
+
+### 场景 1：相对父容器的固定浮层
+
+```html
+<div class="container">
+  <button class="toggle">显示浮层</button>
+  <div class="dropdown">下拉内容</div>
+</div>
+```
+
+```css
+.container {
+  position: relative;
+  transform: translate(0); /* 关键：创建新的包含块 */
+}
+.dropdown {
+  position: fixed;
+  top: 100%; /* 相对于 .container 的底部定位 */
+  left: 0;
+  /* 不受外部滚动影响 */
+}
+```
+
+### 场景 2：固定在元素旁边的 Tooltip
+
+```css
+.wrapper {
+  position: relative;
+  transform: translate(0);
+}
+.tooltip {
+  position: fixed;
+  /* JS 动态设置 left/top 基于 wrapper 的位置 */
+}
+```
+
+### 场景 3：吸顶但有边距
+
+```css
+.sticky-header {
+  position: fixed;
+  top: 20px; /* 距离视口顶部 20px */
+  left: 50%;
+  transform: translateX(-50%);
+}
+```
+
+## 常见误区
+
+### ❌ 误区 1：父元素设置 relative 就能影响 fixed
+
+```css
+/* 无效 */
+.parent {
+  position: relative;
+}
+.child {
+  position: fixed;
+  top: 20px; /* 仍然是相对于视口 */
+}
+```
+
+### ❌ 误区 2：fixed 元素不需要考虑 z-index
+
+实际上 fixed 元素会创建新的层叠上下文（Stacking Context），需要注意层叠顺序。
+
+### ❌ 误区 3：transform 不影响 fixed
+
+实际上 **transform 会影响 fixed**！这是 hack 的核心原理。
+
+## 浏览器兼容性
+
+| 特性 | Chrome | Firefox | Safari | Edge |
+|------|--------|---------|--------|------|
+| transform 影响 fixed | ✅ | ✅ | ✅ | ✅ |
+| position: sticky | ✅ | ✅ | ✅ | ✅ |
+| CSS `anchor-positioning` | ✅ (实验) | ❌ | ❌ | ❌ |
+
+## 决策树
+
+```
+需要固定定位?
+├── 相对视口固定 → position: fixed
+├── 相对父容器固定（无滚动）→ position: absolute
+├── 相对父容器固定（会滚动）→ transform 欺骗法
+├── 在容器内"粘住" → position: sticky
+└── 需要动态跟随 → JS 计算 + ResizeObserver
+```
+
+## 相关资源
+
+- [MDN: position](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
+- [CSS Transforms 创建包含块](https://www.w3.org/TR/css-transforms-1/#transform-rendering)
+- [Chrome DevTools 调试定位问题](/examples/css/demos/fixed-relative-positioning.html)

--- a/docs/css/layout-guide.md
+++ b/docs/css/layout-guide.md
@@ -1,0 +1,122 @@
+# CSS 布局详解
+
+## 布局方案演进
+
+| 时代 | 方案 | 特点 |
+|------|------|------|
+| 早期 | Table | 表格嵌套，语义差，不推荐 |
+| 中期 | Float + Position | 浮动清理，定位层叠 |
+| 现代 | Flexbox + Grid | 主流通用方案 |
+| 2024+ | Grid + Subgrid + Container Queries | 响应式新特性 |
+
+## Flexbox（一维布局）
+
+适合**组件内**的元素排列（导航栏、卡片组、居中）。
+
+```css
+.container {
+  display: flex;
+  justify-content: space-between; /* 主轴分布 */
+  align-items: center;            /* 交叉轴对齐 */
+  gap: 10px;
+}
+```
+
+**核心属性**：
+- `flex-direction`: row | column
+- `justify-content`: flex-start | center | space-between | space-around
+- `align-items`: stretch | center | flex-start
+- `flex-wrap`: nowrap | wrap
+
+**适用场景**：导航栏、按钮组、表单对齐、卡片行。
+
+## CSS Grid（二维布局）
+
+适合**页面级**复杂布局（多行多列、响应式网格）。
+
+```css
+.page {
+  display: grid;
+  grid-template-columns: minmax(200px, 1fr) 3fr;
+  gap: 20px;
+}
+```
+
+**核心属性**：
+- `grid-template-columns/rows`: repeat(auto-fill, minmax(200px, 1fr))
+- `gap`: 行列间距统一设置
+- `grid-area`: 命名区域布局
+- `minmax(min, max)`: 自适应尺寸
+
+**适用场景**：页面整体框架、仪表盘、相册网格。
+
+## Flex vs Grid 选型
+
+| 场景 | 推荐方案 | 原因 |
+|------|----------|------|
+| 导航栏按钮均匀分布 | Flex | 一维排列，justify-content 即可 |
+| 页面整体两栏/三栏 | Grid | 二维控制，模板定义清晰 |
+| 卡片网格（自适应列数） | Grid + auto-fit | `repeat(auto-fill, minmax(250px, 1fr))` |
+| 表单项垂直对齐 | Flex column | 标签+输入框自然对齐 |
+| 圣杯布局（header/footer/sidebar） | Grid | 三区域一次性定义 |
+
+## 2024 新特性
+
+### Subgrid（Chrome 117+, Safari 16+）
+
+子网格继承父 Grid 行列，实现卡片内容对齐：
+
+```css
+.parent {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+}
+.child {
+  grid-column: span 3;
+  display: grid;
+  grid-template-columns: subgrid; /* 继承父列轨道 */
+}
+```
+
+### Container Queries（组件级响应）
+
+不依赖视口，根据容器尺寸响应：
+
+```css
+@container (min-width: 400px) {
+  .card { flex-direction: row; }
+}
+```
+
+### clamp() 响应式尺寸
+
+无媒体查询的自适应：
+
+```css
+width: clamp(300px, 50%, 800px); /* min/首选/max */
+font-size: clamp(14px, 2vw, 18px);
+```
+
+## 固定头部布局
+
+主流方案：
+
+```css
+/* 方案一：absolute + padding */
+body { padding-top: 60px; }
+header { position: absolute; top: 0; height: 60px; }
+
+/* 方案二：grid 模板 */
+body {
+  display: grid;
+  grid-template-rows: 60px 1fr auto;
+  grid-template-areas: "header" "main" "footer";
+}
+header { grid-area: header; }
+```
+
+## 参考
+
+- [Smashing Magazine: Modern CSS Layouts](https://www.smashingmagazine.com/2024/05/modern-css-layouts-no-framework-needed/)
+- [CSS Tricks: A Complete Guide to Grid](https://css-tricks.com/snippets/css/complete-guide-grid/)
+- [CSS Tricks: A Complete Guide to Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)

--- a/docs/css/relative-fixed-positioning.md
+++ b/docs/css/relative-fixed-positioning.md
@@ -1,0 +1,465 @@
+# 相对固定定位：元素固定却相对于某元素定位
+
+## 概述
+
+CSS `position: fixed` 通常让元素相对于视口固定，但`transform`属性会改变fixed的定位上下文，造成"相对于某元素固定"的效果。这种"双重固定"布局是现代前端常见的交互模式。
+
+> 核心矛盾：fixed 相对于视口定位，但 transform 会重建定位上下文，让 fixed 相对于变换后的容器定位。
+
+## 定位体系回顾
+
+### CSS Position 定位类型
+
+| 值 | 定位行为 | 定位上下文 |
+|----|---------|-----------|
+| `static` | 正常文档流，无定位 | 无 |
+| `relative` | 相对自身原始位置偏移 | 自身 |
+| `absolute` | 绝对定位 | 最近已定位祖先 |
+| `fixed` | 相对于视口固定 | 视口（初始） |
+| `sticky` | 滚动时吸附 | 最近滚动容器 |
+
+### Containing Block（定位上下文）
+
+元素的定位上下文决定了 `absolute` 和 `fixed` 的参照框架：
+
+```
+视口（初始，包含块）
+  └── 某元素（设置了 transform/perspective/filter）
+        └── 定位上下文变为该元素
+              └── absolute/fixed 子元素相对于该元素定位
+```
+
+**固定定位上下文重建条件**（满足任一）：
+- 祖先元素设置了 `transform`（非 `none`）
+- 祖先元素设置了 `perspective`（非 `none`）
+- 祖先元素设置了 `filter`（非 `none`）
+- 祖先元素设置了 `will-change: transform`
+
+## transform 对 fixed 的影响
+
+### 核心原理
+
+当一个祖先元素应用了 `transform`（如 `transform: translateX(0)`），该元素会创建一个新的**物理包含块**。此时，子元素的 `position: fixed` 不再相对于视口定位，而是相对于这个新的包含块定位。
+
+```css
+.container {
+  transform: translateX(0); /* 或任何非none值 */
+}
+
+.fixed-child {
+  position: fixed;
+  top: 0;
+  /* 实际表现：相对于 .container 定位，而非视口 */
+}
+```
+
+### 关键验证
+
+Chrome DevTools 可通过 "Layer" 面板验证：设置了 transform 的元素会产生新的**GraphicsLayer**，其子元素的 fixed 定位会在新图层内计算。
+
+```html
+<div class="outer">
+  <div class="container">
+    <div class="fixed-box">fixed</div>
+  </div>
+</div>
+
+<style>
+.outer {
+  width: 600px;
+  height: 400px;
+  background: #f0f0f0;
+  overflow: auto;
+}
+
+.container {
+  width: 300px;
+  height: 800px;
+  background: #ddd;
+  transform: translateX(0); /* 创建新的包含块 */
+  margin-left: 150px;
+}
+
+.fixed-box {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  background: #e74c3c;
+  color: white;
+  padding: 10px 20px;
+  border-radius: 4px;
+}
+</style>
+```
+
+上述代码中，`fixed-box` 会出现在 `.container` 的左上角（距 left 20px, top 20px），而非 `.outer` 或视口。
+
+## 实现方案
+
+### 方案一：父容器 + transform: translateX(0)
+
+最简洁的方案，给父容器添加 `transform: translateX(0)` 即可重建定位上下文：
+
+```css
+.parent {
+  transform: translateX(0);
+}
+
+.fixed-child {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+}
+```
+
+> 注意：`translateX(0)` 本身不会产生视觉位移，但会强制创建新的包含块。
+
+### 方案二：父容器 + transform: scale(1)
+
+```css
+.parent {
+  transform: scale(1);
+}
+```
+
+与 `translateX(0)` 效果相同，但更语义化地表达"保持原尺寸"。
+
+### 方案三：父容器 + position: relative（辅助定位）
+
+```css
+.parent {
+  position: relative;
+  /* 不需要设置 top/left，只是创建定位上下文 */
+}
+
+.fixed-child {
+  position: fixed;
+  top: 0;
+  left: 0;
+  /* 相对于 .parent 的 border-box 定位 */
+}
+```
+
+### 方案四：absolute 嵌套 fixed（复古方案）
+
+利用 `absolute` 相对于最近定位祖先的特性：
+
+```css
+.wrapper {
+  position: absolute;
+  top: 0;
+  left: 0;
+  /* 祖先元素提供定位上下文 */
+}
+
+.fixed-child {
+  position: fixed;
+  /* 相对于 wrapper 定位（因为 wrapper 是最近的定位祖先） */
+}
+```
+
+## 常见使用场景
+
+### 1. 吸顶效果（Sticky Header）
+
+```css
+.nav-container {
+  transform: translateX(0); /* 创建定位上下文 */
+}
+
+.sticky-nav {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+/* 吸附逻辑需要 JS 配合 */
+.sticky-nav.scrolled {
+  transform: translateY(0);
+}
+```
+
+### 2. 跟随按钮（Floating Action Button）
+
+在某个卡片/面板内固定位置的按钮：
+
+```css
+.card {
+  position: relative;
+  padding: 16px;
+  background: #f5f5f5;
+  border-radius: 8px;
+}
+
+.fab {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: #3b82f6;
+  color: white;
+  box-shadow: 0 4px 12px rgba(59, 130, 246, 0.5);
+}
+```
+
+### 3. 模态框/浮层定位
+
+相对于某个触发元素定位的浮层：
+
+```css
+.dropdown-container {
+  position: relative; /* 建立定位上下文 */
+}
+
+.dropdown-trigger {
+  /* 触发器样式 */
+}
+
+.dropdown-menu {
+  position: fixed;
+  top: 0;
+  left: 0;
+  /* JS 计算位置：trigger.getBoundingClientRect() */
+  /* 设置 top/left 为具体数值 */
+}
+```
+
+### 4. 固定在父容器内的角标
+
+```css
+.badge-container {
+  transform: translateZ(0); /* 或 translateX(0) */
+}
+
+.badge {
+  position: fixed;
+  top: 0;
+  right: 0;
+  background: #e74c3c;
+  color: white;
+  font-size: 12px;
+  padding: 2px 8px;
+  border-radius: 4px;
+}
+```
+
+### 5. 滚动时固定在视口的侧边栏
+
+```css
+.sidebar-wrapper {
+  transform: translateX(0);
+}
+
+.sidebar {
+  position: fixed;
+  top: 80px; /* 头部高度 */
+  width: 250px;
+  max-height: calc(100vh - 100px);
+  overflow-y: auto;
+}
+```
+
+## 常见踩坑与解决方案
+
+### 坑 1：transform 触发性能问题
+
+**问题**：滥用 `transform` 可能导致过多合成层，影响渲染性能。
+
+**解决**：
+- 仅在必要时使用
+- 使用 `will-change: transform` 明确告知浏览器即将变化
+- 避免在高频动画元素上使用
+
+```css
+/* 推荐：使用 transform 而非 top/left 做动画 */
+.animated-element {
+  transform: translateX(0); /* 创建上下文 */
+}
+
+/* 动画时 */
+.animated-element.animating {
+  transform: translateX(100px);
+  transition: transform 0.3s ease;
+}
+```
+
+### 坑 2：transform 导致子元素文字模糊
+
+**问题**：`transform` 可能触发子元素文字亚像素渲染，导致模糊。
+
+**解决**：
+- 使用 `translateZ(0)` 或 `translate3d(0,0,0)` 强制 GPU 渲染
+- 或使用 `backdrop-filter` 替代方案（兼容性较差）
+
+```css
+.clear-render {
+  transform: translateZ(0);
+  -webkit-font-smoothing: antialiased;
+}
+```
+
+### 坑 3：fixed 元素超出父容器滚动区域
+
+**问题**：`fixed` 相对于父容器定位后，滚动父容器时 `fixed` 元素会"跑出"可见区域。
+
+**解决**：根据滚动位置动态计算 `top/left`：
+
+```javascript
+container.addEventListener('scroll', () => {
+  const rect = container.getBoundingClientRect();
+  fixedElement.style.top = `${rect.top + 20}px`;
+  fixedElement.style.left = `${rect.left + 20}px`;
+});
+```
+
+### 坑 4：fixed 与 absolute 混淆
+
+**问题**：在需要相对于祖先定位时错误使用 `absolute`，导致定位不符合预期。
+
+**解决**：
+- `fixed`：相对于视口定位（不受滚动影响）
+- `absolute`：相对于最近**已定位**祖先定位
+
+```css
+/* fixed — 视口固定 */
+.popover {
+  position: fixed;
+  top: 50px;
+}
+
+/* absolute — 相对于父容器 */
+.tooltip {
+  position: absolute;
+  top: 100%;
+  left: 0;
+}
+```
+
+### 坑 5：z-index 层叠问题
+
+**问题**：`transform` 创建的新包含块可能有独立的层叠上下文，影响 z-index 层级。
+
+**解决**：
+- 确保正确的 z-index 层级
+- 必要时在共同祖先上设置 `z-index`
+
+```css
+.modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  z-index: 1000;
+}
+
+.modal-content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  /* 由于外层 modal-overlay 已建立层叠上下文 */
+  /* 需要更高的 z-index */
+  z-index: 1001;
+}
+```
+
+## 实战：完整示例
+
+### 卡片内固定角标
+
+```html
+<div class="card">
+  <div class="card-badge">新品</div>
+  <h3>产品标题</h3>
+  <p>产品描述内容...</p>
+</div>
+
+<style>
+.card {
+  position: relative;
+  padding: 16px;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  overflow: hidden;
+}
+
+.card-badge {
+  position: fixed;
+  top: 12px;
+  right: -32px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+  font-size: 12px;
+  padding: 4px 40px;
+  transform: rotate(45deg);
+  transform-origin: center;
+}
+</style>
+```
+
+### 吸附式侧边栏
+
+```html
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-sticky">
+      <h2>分类</h2>
+      <nav>...</nav>
+    </div>
+  </aside>
+  <main class="content">...</main>
+</div>
+
+<style>
+.sidebar {
+  transform: translateX(0); /* 创建包含块 */
+}
+
+.sidebar-sticky {
+  position: fixed;
+  top: 80px;
+  width: 250px;
+}
+
+.content {
+  margin-left: 270px;
+}
+</style>
+```
+
+## 浏览器支持
+
+`transform` 对 `position: fixed` 的影响是 CSS 规范的一部分，所有现代浏览器均支持：
+
+| 特性 | Chrome | Firefox | Safari | Edge |
+|------|--------|---------|--------|------|
+| transform 创建包含块 | ✅ 1+ | ✅ 3.5+ | ✅ 3.1+ | ✅ 12+ |
+| fixed 相对于 transform 父元素 | ✅ 51+ | ✅ 36+ | ✅ 15+ | ✅ 79+ |
+
+> 注：Chrome 51 之前，transform 父元素不会影响 fixed 的行为。
+
+## 总结
+
+| 场景 | 推荐方案 |
+|------|---------|
+| 简单的"相对于父元素固定" | `transform: translateX(0)` 或 `scale(1)` |
+| 需要 relative 定位辅助 | `position: relative` 在父容器 |
+| 需要滚动联动 | JS 动态计算 `top/left` |
+| 避免性能问题 | 限制 transform 使用，合理分层 |
+
+**核心原理**：transform 创建新的物理包含块，fixed 定位相对于该包含块而非视口计算。
+
+## 参考资源
+
+- [MDN: transform 属性](https://developer.mozilla.org/en-US/docs/Web/CSS/transform)
+- [MDN: position 属性](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
+- [CSS Transforms Spec](https://www.w3.org/TR/css-transforms-1/)
+- [What's New in CSS Containment](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Containment)
+- [Layer-based rendering explained](https://developer.chrome.com/docs/web-platform/layers)

--- a/examples/css/demos/css-property/index.html
+++ b/examples/css/demos/css-property/index.html
@@ -1,0 +1,546 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS @property 交互演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 13px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 tauto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .section h3 { font-size: 14px; color: #8b949e; margin: 16px 0 8px; }
+    .demo-area { display: flex; gap: 16px; min-height: 140px; padding: 20px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; align-items: center; flex-wrap: wrap; }
+    .box { width: 80px; height: 80px; border-radius: 8px; display: flex; align-items: center; justify-content: center; color: white; font-size: 12px; font-weight: 600; flex-shrink: 0; }
+    .bar-wrap { width: 100%; max-width: 400px; }
+    .bar { height: 8px; background: #1a1a1a; border-radius: 4px; overflow: hidden; position: relative; }
+    .bar-inner { height: 100%; border-radius: 4px; transition: width 0.05s linear; }
+    .progress-bar { width: var(--progress, 25%); }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .btn { padding: 6px 12px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; }
+    .desc { font-size: 12px; color: #6e7681; margin-top: 8px; line-height: 1.6; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 12px; }
+    .tag { display: inline-block; padding: 2px 6px; border-radius: 3px; font-size: 11px; background: #388bfd33; color: #58a6ff; margin-right: 4px; }
+    .tag.green { background: #3fb95033; color: #3fb950; }
+    .tag.orange { background: #f0883e33; color: #f0883e; }
+    .tag.red { background: #f8514933; color: #f85149; }
+
+    /* === 核心：@property 注册 === */
+    @property --size {
+      syntax: '<length>';
+      inherits: false;
+      initial-value: 80px;
+    }
+
+    @property --rotation {
+      syntax: '<angle>';
+      inherits: false;
+      initial-value: 0deg;
+    }
+
+    @property --progress {
+      syntax: '<percentage>';
+      inherits: false;
+      initial-value: 25%;
+    }
+
+    @property --color-start {
+      syntax: '<color>';
+      inherits: false;
+      initial-value: #3498db;
+    }
+
+    @property --color-end {
+      syntax: '<color>';
+      inherits: false;
+      initial-value: #e74c3c;
+    }
+
+    @property --bg-color {
+      syntax: '<color>';
+      inherits: false;
+      initial-value: #a371f7;
+    }
+
+    @property --scale {
+      syntax: '<number>';
+      inherits: false;
+      initial-value: 1;
+    }
+
+    /* 演示用样式 */
+    .size-box {
+      width: var(--size);
+      height: var(--size);
+      background: var(--bg-color, #a371f7);
+      border-radius: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-size: 12px;
+      font-weight: 600;
+      flex-shrink: 0;
+      transition: --size 0.5s ease, --bg-color 0.5s ease;
+    }
+
+    .rotation-box {
+      width: 60px;
+      height: 60px;
+      background: linear-gradient(135deg, #3fb950, #58a6ff);
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-size: 11px;
+      font-weight: 600;
+      flex-shrink: 0;
+    }
+
+    .gradient-box {
+      width: 120px;
+      height: 80px;
+      border-radius: 8px;
+      background: linear-gradient(45deg, var(--color-start), var(--color-end));
+      transition: --color-start 1s ease, --color-end 1s ease;
+      flex-shrink: 0;
+    }
+
+    .scale-box {
+      width: 60px;
+      height: 60px;
+      background: #f0883e;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-size: 11px;
+      font-weight: 600;
+      flex-shrink: 0;
+    }
+
+    /* 动画 */
+    @keyframes sizePulse {
+      0% { --size: 60px; --bg-color: #3498db; }
+      50% { --size: 120px; --bg-color: #e74c3c; }
+      100% { --size: 60px; --bg-color: #3498db; }
+    }
+
+    @keyframes rotateAnim {
+      0% { --rotation: 0deg; }
+      100% { --rotation: 360deg; }
+    }
+
+    @keyframes progressAnim {
+      0% { --progress: 0%; }
+      50% { --progress: 80%; }
+      100% { --progress: 0%; }
+    }
+
+    @keyframes colorShift {
+      0% { --color-start: #3498db; --color-end: #e74c3c; }
+      50% { --color-start: #9b59b6; --color-end: #f39c12; }
+      100% { --color-start: #3498db; --color-end: #e74c3c; }
+    }
+
+    @keyframes scaleAnim {
+      0% { --scale: 1; }
+      50% { --scale: 1.6; }
+      100% { --scale: 1; }
+    }
+
+    .size-box.animating {
+      animation: sizePulse 2.5s ease-in-out infinite;
+    }
+
+    .rotation-box.animating {
+      animation: rotateAnim 2s linear infinite;
+    }
+
+    .gradient-box.animating {
+      animation: colorShift 3s ease infinite;
+    }
+
+    .scale-box.animating {
+      animation: scaleAnim 1.5s ease-in-out infinite;
+    }
+
+    /* 使用注册属性作为实际值 */
+    .size-box.using-var {
+      width: var(--size);
+      height: var(--size);
+    }
+
+    .rotation-box.using-var {
+      transform: rotate(var(--rotation));
+    }
+
+    .scale-box.using-var {
+      transform: scale(var(--scale));
+    }
+
+    /* 无注册 vs 有注册对比 */
+    .unregistered-box {
+      width: var(--unreg-size, 80px);
+      height: var(--unreg-size, 80px);
+      background: #30363d;
+      border-radius: 8px;
+      border: 1px dashed #f85149;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #f85149;
+      font-size: 11px;
+      flex-shrink: 0;
+    }
+
+    .registered-box {
+      width: var(--reg-size);
+      height: var(--reg-size);
+      background: #3fb950;
+      border-radius: 8px;
+      border: 1px solid #3fb950;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-size: 11px;
+      flex-shrink: 0;
+    }
+
+    @property --unreg-size {
+      syntax: '<length>';
+      inherits: false;
+      initial-value: 80px;
+    }
+
+    @property --reg-size {
+      syntax: '<length>';
+      inherits: false;
+      initial-value: 80px;
+    }
+
+    @keyframes unregAnim {
+      0% { --unreg-size: 60px; }
+      100% { --unreg-size: 140px; }
+    }
+
+    @keyframes regAnim {
+      0% { --reg-size: 60px; }
+      100% { --reg-size: 140px; }
+    }
+
+    .unregistered-box.animating {
+      animation: unregAnim 1.5s ease-in-out infinite;
+    }
+
+    .registered-box.animating {
+      animation: regAnim 1.5s ease-in-out infinite;
+    }
+
+    /* 进度条动态样式 */
+    .progress-inner {
+      height: 100%;
+      border-radius: 4px;
+      background: linear-gradient(90deg, #00d230, #58a6ff);
+      width: var(--progress, 25%);
+      transition: width 0.1s linear;
+    }
+
+    .progress-bar.animating .progress-inner {
+      animation: progressAnim 2.5s ease infinite;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS @property 交互演示</h1>
+    <p class="subtitle">基于 learn-css 仓库 · Houdini Properties & Values API</p>
+
+    <!-- @property 基础注册 -->
+    <div class="section">
+      <h2>1. @property 基础注册</h2>
+      <p class="desc">
+        <span class="tag">syntax</span>定义类型 ·
+        <span class="tag">inherits</span>控制继承 ·
+        <span class="tag">initial-value</span>设置默认值
+      </p>
+      <div class="code-block">@property --size {
+  syntax: '<length>';
+  inherits: false;
+  initial-value: 80px;
+}</div>
+    </div>
+
+    <!-- 对比：未注册 vs 已注册 -->
+    <div class="section">
+      <h2>2. 关键对比：未注册 vs 已注册自定义属性的动画</h2>
+      <p class="desc">
+        <span class="tag red">未注册</span>的自定义属性无法做关键帧动画（浏览器不知其类型） ·
+        <span class="tag green">已注册</span>的属性可以平滑过渡
+      </p>
+      <div class="controls" id="compare-controls">
+        <button class="btn" data-action="start-compare">播放对比动画</button>
+        <button class="btn" data-action="stop-compare">停止</button>
+      </div>
+      <div class="demo-area">
+        <div class="unregistered-box" id="unreg-box">未注册<br>无法动画</div>
+        <div class="registered-box" id="reg-box">已注册<br>平滑过渡</div>
+      </div>
+      <div class="code-block">/* 未注册：动画无效，因为浏览器不知道 --size 是什么类型 */
+.unregistered-box {
+  width: var(--unreg-size);
+  animation: unregAnim 1.5s ease-in-out infinite;
+}
+
+/* 已注册：明确 syntax: '<length>'，动画正常工作 */
+.registered-box {
+  width: var(--reg-size); /* 使用注册属性 */
+  animation: regAnim 1.5s ease-in-out infinite;
+}</div>
+    </div>
+
+    <!-- 尺寸 + 颜色联合动画 -->
+    <div class="section">
+      <h2>3. 尺寸 + 颜色联合动画</h2>
+      <p class="desc">
+        <span class="tag green">--size</span> 控制宽高 ·
+        <span class="tag">--bg-color</span> 控制背景色，两者同步动画
+      </p>
+      <div class="controls" id="size-controls">
+        <button class="btn active" data-action="play-size">播放动画</button>
+        <button class="btn" data-action="stop-size">停止</button>
+      </div>
+      <div class="demo-area">
+        <div class="size-box" id="size-box">size + color</div>
+      </div>
+      <div class="code-block">@property --size { syntax: '<length>'; inherits: false; initial-value: 80px; }
+@property --bg-color { syntax: '<color>'; inherits: false; initial-value: #a371f7; }
+
+.size-box { width: var(--size); height: var(--size); background: var(--bg-color); }
+
+@keyframes sizePulse {
+  0%   { --size: 60px; --bg-color: #3498db; }
+  50%  { --size: 120px; --bg-color: #e74c3c; }
+  100% { --size: 60px; --bg-color: #3498db; }
+}</div>
+    </div>
+
+    <!-- 角度旋转动画 -->
+    <div class="section">
+      <h2>4. 角度旋转动画（--rotation）</h2>
+      <p class="desc">
+        <span class="tag">--rotation</span> 类型为 <code>&lt;angle&gt;</code>，支持 <code>0deg → 360deg</code> 旋转
+      </p>
+      <div class="controls" id="rotate-controls">
+        <button class="btn active" data-action="play-rotate">播放动画</button>
+        <button class="btn" data-action="stop-rotate">停止</button>
+      </div>
+      <div class="demo-area">
+        <div class="rotation-box" id="rot-box">旋转</div>
+      </div>
+      <div class="code-block">@property --rotation { syntax: '<angle>'; inherits: false; initial-value: 0deg; }
+
+.rotation-box { transform: rotate(var(--rotation)); }
+
+@keyframes rotateAnim {
+  to { --rotation: 360deg; }
+}</div>
+    </div>
+
+    <!-- 进度条动画 -->
+    <div class="section">
+      <h2>5. 进度条动画（--progress）</h2>
+      <p class="desc">
+        <span class="tag">--progress</span> 类型为 <code>&lt;percentage&gt;</code>，驱动 <code>linear-gradient</code> 颜色停止点
+      </p>
+      <div class="controls" id="progress-controls">
+        <button class="btn active" data-action="play-progress">播放动画</button>
+        <button class="btn" data-action="stop-progress">停止</button>
+      </div>
+      <div class="demo-area">
+        <div class="bar-wrap">
+          <div class="bar progress-bar" id="prog-bar">
+            <div class="progress-inner"></div>
+          </div>
+        </div>
+      </div>
+      <div class="code-block">@property --progress { syntax: '<percentage>'; inherits: false; initial-value: 25%; }
+
+.bar { background: linear-gradient(to right, #00d230 var(--progress), #1a1a1a var(--progress)); }
+
+@keyframes progressAnim {
+  0%   { --progress: 0%; }
+  50%  { --progress: 80%; }
+  100% { --progress: 0%; }
+}</div>
+    </div>
+
+    <!-- 渐变色动画 -->
+    <div class="section">
+      <h2>6. 渐变色动画（--color-start / --color-end）</h2>
+      <p class="desc">
+        两个 <span class="tag">--color-start</span> <span class="tag">--color-end</span> 颜色属性同步变化
+      </p>
+      <div class="controls" id="gradient-controls">
+        <button class="btn active" data-action="play-gradient">播放动画</button>
+        <button class="btn" data-action="stop-gradient">停止</button>
+      </div>
+      <div class="demo-area">
+        <div class="gradient-box" id="grad-box"></div>
+      </div>
+      <div class="code-block">@property --color-start { syntax: '<color>'; inherits: false; initial-value: #3498db; }
+@property --color-end { syntax: '<color>'; inherits: false; initial-value: #e74c3c; }
+
+.gradient-box { background: linear-gradient(45deg, var(--color-start), var(--color-end)); }
+
+@keyframes colorShift {
+  0%   { --color-start: #3498db; --color-end: #e74c3c; }
+  50%  { --color-start: #9b59b6; --color-end: #f39c12; }
+  100% { --color-start: #3498db; --color-end: #e74c3c; }
+}</div>
+    </div>
+
+    <!-- scale 缩放动画 -->
+    <div class="section">
+      <h2>7. scale 缩放动画（--scale）</h2>
+      <p class="desc">
+        <span class="tag">--scale</span> 类型为 <code>&lt;number&gt;</code>，控制 <code>scale()</code> 变换
+      </p>
+      <div class="controls" id="scale-controls">
+        <button class="btn active" data-action="play-scale">播放动画</button>
+        <button class="btn" data-action="stop-scale">停止</button>
+      </div>
+      <div class="demo-area">
+        <div class="scale-box" id="scale-box">scale</div>
+      </div>
+      <div class="code-block">@property --scale { syntax: '<number>'; inherits: false; initial-value: 1; }
+
+.scale-box { transform: scale(var(--scale)); }
+
+@keyframes scaleAnim {
+  0%   { --scale: 1; }
+  50%  { --scale: 1.6; }
+  100% { --scale: 1; }
+}</div>
+    </div>
+
+    <p class="info">CSS @property 支持所有现代浏览器（Chrome 85+、Firefox 128+、Safari 16.4+）。演示基于 learn-css 仓库示例风格。</p>
+  </div>
+
+  <script>
+    // 通用：播放/停止动画
+    function toggleAnim(el, play) {
+      el.style.animation = play ? '' : 'none';
+      if (!play) {
+        el.style.transform = '';
+        el.style.width = '';
+        el.style.height = '';
+        el.style.background = '';
+        // 强制重绘
+        el.getBoundingClientRect();
+      }
+    }
+
+    // 对比组
+    const unregBox = document.getElementById('unreg-box');
+    const regBox = document.getElementById('reg-box');
+    document.querySelectorAll('#compare-controls .btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('#compare-controls .btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const action = btn.dataset.action;
+        if (action === 'start-compare') {
+          unregBox.classList.add('animating');
+          regBox.classList.add('animating');
+          unregBox.style.animation = 'unregAnim 1.5s ease-in-out infinite';
+          regBox.style.animation = 'regAnim 1.5s ease-in-out infinite';
+        } else {
+          unregBox.classList.remove('animating');
+          regBox.classList.remove('animating');
+          unregBox.style.animation = 'none';
+          regBox.style.animation = 'none';
+        }
+      });
+    });
+
+    // size + color
+    const sizeBox = document.getElementById('size-box');
+    document.querySelectorAll('#size-controls .btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('#size-controls .btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        if (btn.dataset.action === 'play-size') {
+          sizeBox.classList.add('animating');
+        } else {
+          sizeBox.classList.remove('animating');
+        }
+      });
+    });
+
+    // rotation
+    const rotBox = document.getElementById('rot-box');
+    document.querySelectorAll('#rotate-controls .btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('#rotate-controls .btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        if (btn.dataset.action === 'play-rotate') {
+          rotBox.classList.add('animating');
+        } else {
+          rotBox.classList.remove('animating');
+        }
+      });
+    });
+
+    // progress
+    const progBar = document.getElementById('prog-bar');
+    document.querySelectorAll('#progress-controls .btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('#progress-controls .btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        if (btn.dataset.action === 'play-progress') {
+          progBar.classList.add('animating');
+        } else {
+          progBar.classList.remove('animating');
+        }
+      });
+    });
+
+    // gradient
+    const gradBox = document.getElementById('grad-box');
+    document.querySelectorAll('#gradient-controls .btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('#gradient-controls .btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        if (btn.dataset.action === 'play-gradient') {
+          gradBox.classList.add('animating');
+        } else {
+          gradBox.classList.remove('animating');
+        }
+      });
+    });
+
+    // scale
+    const scaleBox = document.getElementById('scale-box');
+    document.querySelectorAll('#scale-controls .btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('#scale-controls .btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        if (btn.dataset.action === 'play-scale') {
+          scaleBox.classList.add('animating');
+        } else {
+          scaleBox.classList.remove('animating');
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/css-scroll-snap/index.html
+++ b/examples/css/demos/css-scroll-snap/index.html
@@ -1,0 +1,378 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Scroll Snap 完整演示</title>
+  <style>
+    *, *::before, *::after {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #1a1a2e;
+      color: #eee;
+      min-height: 100vh;
+    }
+    h1 {
+      text-align: center;
+      padding: 24px;
+      font-size: 1.5rem;
+      color: #fff;
+    }
+    h2 {
+      padding: 16px 20px 8px;
+      font-size: 1rem;
+      color: #aaa;
+      border-bottom: 1px solid #333;
+      margin-bottom: 12px;
+    }
+    p.desc {
+      padding: 0 20px 12px;
+      font-size: 0.85rem;
+      color: #888;
+    }
+
+    /* =====================
+       示例 1: 全屏轮播图
+       ===================== */
+    .carousel-full {
+      position: relative;
+      width: 100vw;
+      height: 60vh;
+      overflow-x: scroll;
+      overflow-y: hidden;
+      scroll-snap-type: x mandatory;
+      scroll-behavior: smooth;
+      scrollbar-width: none;
+      -webkit-overflow-scrolling: touch;
+    }
+    .carousel-full::-webkit-scrollbar { display: none; }
+    .carousel-full .slide {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      font-size: 4rem;
+      font-weight: 700;
+      color: #fff;
+      scroll-snap-align: start;
+    }
+    .carousel-full .slide span {
+      font-size: 1rem;
+      font-weight: 400;
+      margin-top: 12px;
+      opacity: 0.7;
+    }
+    .slide-1 { background: linear-gradient(135deg, #ff6b6b, #ee5a5a); }
+    .slide-2 { background: linear-gradient(135deg, #4ecdc4, #3dbdb5); }
+    .slide-3 { background: linear-gradient(135deg, #45b7d1, #35a7c1); }
+    .slide-4 { background: linear-gradient(135deg, #96ceb4, #86bea4); }
+    .slide-5 { background: linear-gradient(135deg, #dda0dd, #cd90cd); }
+
+    /* 指示器 */
+    .dots {
+      display: flex;
+      justify-content: center;
+      gap: 8px;
+      margin-top: 12px;
+    }
+    .dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.35);
+      border: none;
+      cursor: pointer;
+      transition: all 0.3s;
+    }
+    .dot.active {
+      background: #fff;
+      transform: scale(1.3);
+    }
+
+    /* =====================
+       示例 2: mandatory vs proximity
+       ===================== */
+    .compare-section {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+      padding: 0 20px;
+    }
+    .compare-item h3 {
+      font-size: 0.85rem;
+      color: #aaa;
+      margin-bottom: 8px;
+    }
+    .snap-viewport {
+      width: 100%;
+      height: 160px;
+      overflow-x: scroll;
+      overflow-y: hidden;
+      scroll-behavior: smooth;
+      scrollbar-width: none;
+      border-radius: 8px;
+      display: flex;
+      gap: 8px;
+      padding: 12px;
+    }
+    .snap-viewport::-webkit-scrollbar { display: none; }
+    .snap-card {
+      flex: 0 0 55%;
+      height: 100%;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 1.2rem;
+      color: #fff;
+      scroll-snap-align: start;
+    }
+    .mandatory .snap-viewport {
+      scroll-snap-type: x mandatory;
+    }
+    .proximity .snap-viewport {
+      scroll-snap-type: x proximity;
+    }
+    .snap-card:nth-child(1) { background: #e74c3c; }
+    .snap-card:nth-child(2) { background: #3498db; }
+    .snap-card:nth-child(3) { background: #2ecc71; }
+    .snap-card:nth-child(4) { background: #9b59b6; }
+
+    /* =====================
+       示例 3: scroll-snap-stop
+       ===================== */
+    .stop-demo {
+      padding: 0 20px;
+    }
+    .stop-viewport {
+      width: 100%;
+      height: 160px;
+      overflow-x: scroll;
+      overflow-y: hidden;
+      scroll-snap-type: x mandatory;
+      scroll-behavior: smooth;
+      scrollbar-width: none;
+      border-radius: 8px;
+      display: flex;
+      gap: 8px;
+      padding: 12px;
+    }
+    .stop-viewport::-webkit-scrollbar { display: none; }
+    .stop-item {
+      flex: 0 0 55%;
+      height: 100%;
+      border-radius: 8px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      font-size: 1rem;
+      scroll-snap-align: start;
+    }
+    .stop-item:nth-child(1) { background: #e67e22; }
+    .stop-item:nth-child(2) { background: #1abc9c; }
+    .stop-item:nth-child(3) { background: #34495e; }
+    .stop-item:nth-child(4) { background: #e91e63; }
+    .stop-item:nth-child(5) { background: #8bc34a; }
+    .stop-item .label {
+      font-size: 0.75rem;
+      opacity: 0.7;
+      margin-top: 4px;
+    }
+    .stop-always { scroll-snap-stop: always; }
+
+    /* =====================
+       示例 4: 垂直滚动吸附
+       ===================== */
+    .vertical-demo {
+      padding: 0 20px;
+    }
+    .vertical-viewport {
+      width: 100%;
+      height: 300px;
+      overflow-y: scroll;
+      scroll-snap-type: y mandatory;
+      scroll-behavior: smooth;
+      scrollbar-width: none;
+      border-radius: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      padding: 12px;
+      background: #252540;
+    }
+    .vertical-viewport::-webkit-scrollbar { display: none; }
+    .v-card {
+      height: 260px;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 2rem;
+      color: #fff;
+      scroll-snap-align: start;
+    }
+    .v-card:nth-child(1) { background: #6c5ce7; }
+    .v-card:nth-child(2) { background: #fd79a8; }
+    .v-card:nth-child(3) { background: #00b894; }
+
+    /* =====================
+       示例 5: scroll-padding 效果
+       ===================== */
+    .padding-demo {
+      padding: 0 20px;
+    }
+    .padding-viewport {
+      width: 100%;
+      height: 160px;
+      overflow-x: scroll;
+      overflow-y: hidden;
+      scroll-snap-type: x mandatory;
+      scroll-behavior: smooth;
+      scrollbar-width: none;
+      /* 左侧留出边距，使内容不贴边 */
+      scroll-padding: 0 20px;
+      border-radius: 8px;
+      display: flex;
+      gap: 8px;
+      padding: 12px;
+      background: #2d2d4a;
+    }
+    .padding-viewport::-webkit-scrollbar { display: none; }
+    .padding-item {
+      flex: 0 0 55%;
+      height: 100%;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: #fff;
+      scroll-snap-align: start;
+    }
+    .padding-item:nth-child(1) { background: #00cec9; }
+    .padding-item:nth-child(2) { background: #fdcb6e; }
+    .padding-item:nth-child(3) { background: #e17055; }
+
+    footer {
+      text-align: center;
+      padding: 24px;
+      font-size: 0.75rem;
+      color: #555;
+    }
+  </style>
+</head>
+<body>
+
+  <h1>CSS Scroll Snap 完整演示</h1>
+
+  <!-- 示例 1: 全屏轮播图 -->
+  <h2>示例 1: 全屏轮播图 (scroll-snap-type: x mandatory)</h2>
+  <p class="desc">典型的移动端轮播图，每次滑动吸附到一张幻灯片。点击指示器可跳转。</p>
+  <div class="carousel-full" id="carousel1">
+    <div class="slide slide-1" style="left: 0%;">1<span>水平滑动切换</span></div>
+    <div class="slide slide-2" style="left: 100%;">2<span>配合 scroll-snap-align</span></div>
+    <div class="slide slide-3" style="left: 200%;">3<span>scroll-behavior: smooth</span></div>
+    <div class="slide slide-4" style="left: 300%;">4<span>指示器联动</span></div>
+    <div class="slide slide-5" style="left: 400%;">5<span>移动端适配</span></div>
+  </div>
+  <nav class="dots" id="dots1">
+    <button class="dot active" aria-label="第1页"></button>
+    <button class="dot" aria-label="第2页"></button>
+    <button class="dot" aria-label="第3页"></button>
+    <button class="dot" aria-label="第4页"></button>
+    <button class="dot" aria-label="第5页"></button>
+  </nav>
+
+  <!-- 示例 2: mandatory vs proximity -->
+  <h2>示例 2: mandatory vs proximity 对比</h2>
+  <p class="desc">左侧 mandatory 强制吸附；右侧 proximity 仅接近时吸附。尝试轻轻滑动观察差异。</p>
+  <div class="compare-section">
+    <div class="compare-item mandatory">
+      <h3>scroll-snap-type: x mandatory</h3>
+      <div class="snap-viewport">
+        <div class="snap-card">A</div>
+        <div class="snap-card">B</div>
+        <div class="snap-card">C</div>
+        <div class="snap-card">D</div>
+      </div>
+    </div>
+    <div class="compare-item proximity">
+      <h3>scroll-snap-type: x proximity</h3>
+      <div class="snap-viewport">
+        <div class="snap-card">A</div>
+        <div class="snap-card">B</div>
+        <div class="snap-card">C</div>
+        <div class="snap-card">D</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 示例 3: scroll-snap-stop -->
+  <h2>示例 3: scroll-snap-stop 控制跳过</h2>
+  <p class="desc">蓝色（B）和绿色（C）卡片设置了 scroll-snap-stop: always，强制停留无法跳过。</p>
+  <div class="stop-demo">
+    <div class="stop-viewport">
+      <div class="stop-item" style="background:#e67e22">A<span class="label">stop: normal</span></div>
+      <div class="stop-item stop-always" style="background:#1abc9c">B<span class="label">stop: always</span></div>
+      <div class="stop-item stop-always" style="background:#34495e">C<span class="label">stop: always</span></div>
+      <div class="stop-item" style="background:#e91e63">D<span class="label">stop: normal</span></div>
+      <div class="stop-item" style="background:#8bc34a">E<span class="label">stop: normal</span></div>
+    </div>
+  </div>
+
+  <!-- 示例 4: 垂直滚动吸附 -->
+  <h2>示例 4: 垂直滚动吸附 (scroll-snap-type: y mandatory)</h2>
+  <p class="desc">类似小红书/抖音卡片流，垂直方向每次吸附一张卡片。</p>
+  <div class="vertical-demo">
+    <div class="vertical-viewport">
+      <div class="v-card">内容卡片 1</div>
+      <div class="v-card">内容卡片 2</div>
+      <div class="v-card">内容卡片 3</div>
+    </div>
+  </div>
+
+  <!-- 示例 5: scroll-padding 效果 -->
+  <h2>示例 5: scroll-padding 调整吸附边距</h2>
+  <p class="desc">容器设置了 scroll-padding-right，使每次吸附后内容左侧留出边距。</p>
+  <div class="padding-demo">
+    <div class="padding-viewport">
+      <div class="padding-item">左侧留白</div>
+      <div class="padding-item">通过 scroll-padding</div>
+      <div class="padding-item">实现</div>
+    </div>
+  </div>
+
+  <footer>CSS Scroll Snap 演示 · 配合 overflow 属性使用</footer>
+
+  <script>
+    // 轮播图指示器联动
+    const carousel1 = document.getElementById('carousel1');
+    const dots1 = document.querySelectorAll('#dots1 .dot');
+
+    function updateDots() {
+      const scrollLeft = carousel1.scrollLeft;
+      const width = carousel1.offsetWidth;
+      const index = Math.round(scrollLeft / width);
+      dots1.forEach((d, i) => d.classList.toggle('active', i === index));
+    }
+
+    carousel1.addEventListener('scroll', updateDots);
+
+    dots1.forEach((dot, i) => {
+      dot.addEventListener('click', () => {
+        carousel1.scrollTo({ left: i * carousel1.offsetWidth, behavior: 'smooth' });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/fixed-relative-positioning.html
+++ b/examples/css/demos/fixed-relative-positioning.html
@@ -1,0 +1,527 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Fixed 相对定位：视图窗口 vs 元素</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f5f5f5;
+      padding: 20px;
+      padding-bottom: 100px;
+    }
+    h1 {
+      font-size: 24px;
+      margin-bottom: 20px;
+      color: #333;
+    }
+    h2 {
+      font-size: 18px;
+      margin: 20px 0 10px;
+      color: #444;
+    }
+    .demo-container {
+      background: white;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    .tab-nav {
+      display: flex;
+      gap: 4px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+    }
+    .tab-btn {
+      padding: 8px 16px;
+      border: none;
+      background: #e0e0e0;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 14px;
+      transition: all 0.2s;
+    }
+    .tab-btn:hover {
+      background: #d0d0d0;
+    }
+    .tab-btn.active {
+      background: #007AFF;
+      color: white;
+    }
+    .tab-content {
+      display: none;
+    }
+    .tab-content.active {
+      display: block;
+    }
+    
+    /* 场景1: 标准 fixed */
+    .scene1-wrapper {
+      position: relative;
+      height: 200px;
+      background: #f0f0f0;
+      border: 2px dashed #ccc;
+      border-radius: 8px;
+      overflow: auto;
+    }
+    .scene1-fixed {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      background: #ff6b6b;
+      color: white;
+      padding: 10px 16px;
+      border-radius: 6px;
+      font-size: 12px;
+      z-index: 1000;
+    }
+    .scene1-content {
+      padding: 60px 20px;
+      height: 400px;
+    }
+    .scene1-content p {
+      margin-bottom: 16px;
+      color: #666;
+      line-height: 1.6;
+    }
+    
+    /* 场景2: transform 欺骗法 */
+    .scene2-wrapper {
+      position: relative;
+      height: 200px;
+      background: #e8f5e9;
+      border: 2px solid #4CAF50;
+      border-radius: 8px;
+      overflow: auto;
+      transform: translate(0); /* 关键：创建新的包含块 */
+    }
+    .scene2-fixed {
+      position: fixed;
+      top: 10px;
+      right: 10px;
+      background: #4CAF50;
+      color: white;
+      padding: 10px 16px;
+      border-radius: 6px;
+      font-size: 12px;
+    }
+    .scene2-content {
+      padding: 60px 20px;
+      height: 400px;
+    }
+    .scene2-content p {
+      margin-bottom: 16px;
+      color: #666;
+      line-height: 1.6;
+    }
+    
+    /* 场景3: sticky 对比 */
+    .scene3-container {
+      height: 200px;
+      background: #fff3e0;
+      border: 2px solid #FF9800;
+      border-radius: 8px;
+      overflow: auto;
+    }
+    .scene3-sticky {
+      position: sticky;
+      top: 10px;
+      background: #FF9800;
+      color: white;
+      padding: 10px 16px;
+      border-radius: 6px;
+      font-size: 12px;
+      margin: 10px;
+      width: fit-content;
+    }
+    .scene3-normal {
+      background: #FFE0B2;
+      padding: 60px 20px;
+      margin: 10px;
+      border-radius: 4px;
+    }
+    
+    /* 对比表 */
+    .comparison-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 16px;
+    }
+    .comparison-table th,
+    .comparison-table td {
+      border: 1px solid #ddd;
+      padding: 12px;
+      text-align: left;
+      font-size: 14px;
+    }
+    .comparison-table th {
+      background: #f5f5f5;
+      font-weight: 600;
+    }
+    .comparison-table tr:hover {
+      background: #fafafa;
+    }
+    .tag {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 12px;
+      margin: 2px;
+    }
+    .tag-green { background: #e8f5e9; color: #2e7d32; }
+    .tag-yellow { background: #fff3e0; color: #f57c00; }
+    .tag-red { background: #ffebee; color: #c62828; }
+    
+    /* 结论卡片 */
+    .conclusion {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      padding: 20px;
+      border-radius: 8px;
+      margin-top: 16px;
+    }
+    .conclusion h3 {
+      margin-bottom: 12px;
+      font-size: 16px;
+    }
+    .conclusion ul {
+      margin-left: 20px;
+    }
+    .conclusion li {
+      margin-bottom: 8px;
+      line-height: 1.5;
+    }
+    
+    /* 代码块 */
+    .code-block {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 16px;
+      border-radius: 6px;
+      font-family: 'Monaco', 'Menlo', monospace;
+      font-size: 13px;
+      overflow-x: auto;
+      line-height: 1.6;
+      margin: 12px 0;
+    }
+    .code-block .comment { color: #6a9955; }
+    .code-block .keyword { color: #569cd6; }
+    .code-block .string { color: #ce9178; }
+    .code-block .property { color: #9cdcfe; }
+    .code-block .value { color: #ce9178; }
+    
+    /* 说明文字 */
+    .explanation {
+      background: #e3f2fd;
+      border-left: 4px solid #2196F3;
+      padding: 12px 16px;
+      margin: 12px 0;
+      border-radius: 0 4px 4px 0;
+      font-size: 14px;
+      line-height: 1.6;
+    }
+    .warning {
+      background: #fff3e0;
+      border-left: 4px solid #ff9800;
+      padding: 12px 16px;
+      margin: 12px 0;
+      border-radius: 0 4px 4px 0;
+      font-size: 14px;
+    }
+    
+    /* 滚动区域标记 */
+    .scroll-indicator {
+      position: absolute;
+      bottom: 10px;
+      right: 10px;
+      background: rgba(0,0,0,0.6);
+      color: white;
+      padding: 4px 8px;
+      border-radius: 4px;
+      font-size: 11px;
+    }
+    
+    /* 测试区 */
+    .test-area {
+      background: #fafafa;
+      border: 1px solid #ddd;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 16px;
+    }
+    .test-area h4 {
+      font-size: 14px;
+      margin-bottom: 12px;
+      color: #333;
+    }
+    .test-row {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+    .test-item {
+      flex: 1;
+      min-width: 200px;
+      background: white;
+      border: 1px solid #eee;
+      border-radius: 4px;
+      padding: 12px;
+    }
+    .test-item h5 {
+      font-size: 12px;
+      color: #666;
+      margin-bottom: 8px;
+    }
+  </style>
+</head>
+<body>
+  <h1>CSS Fixed 定位：相对视图窗口 vs 相对元素</h1>
+  
+  <div class="demo-container">
+    <div class="tab-nav">
+      <button class="tab-btn active" onclick="showTab('overview')">📖 概念总览</button>
+      <button class="tab-btn" onclick="showTab('scene1')">🎯 标准 Fixed</button>
+      <button class="tab-btn" onclick="showTab('scene2')">✨ Transform 法</button>
+      <button class="tab-btn" onclick="showTab('scene3')">🔒 Sticky 对比</button>
+      <button class="tab-btn" onclick="showTab('decision')">🌳 决策树</button>
+    </div>
+    
+    <!-- 概念总览 -->
+    <div id="overview" class="tab-content active">
+      <h2>核心概念</h2>
+      <div class="explanation">
+        <strong>问题：</strong>如何让一个 <code>position: fixed</code> 的元素，相对于某个<em>特定元素</em>定位，而不是整个视口？
+      </div>
+      
+      <h2>为什么 fixed 总是相对于视口？</h2>
+      <p style="margin: 12px 0; line-height: 1.6; color: #666;">
+        根据 CSS 规范，<code>position: fixed</code> 的定位上下文是<strong>视口</strong>（viewport）。
+        即使父元素设置了 <code>position: relative</code>，也不会影响 fixed 子元素的定位上下文。
+      </p>
+      
+      <div class="code-block">
+<span class="comment">/* ❌ 这个父元素的 relative 对 fixed 子元素无效 */</span>
+.parent {
+  <span class="property">position</span>: <span class="value">relative</span>; <span class="comment">/* 无效 */</span>
+}
+.child {
+  <span class="property">position</span>: <span class="value">fixed</span>;
+  <span class="property">top</span>: <span class="value">0</span>; <span class="comment">/* 仍然是相对于视口定位 */</span>
+}
+      </div>
+      
+      <h2>解决方案概览</h2>
+      <table class="comparison-table">
+        <thead>
+          <tr>
+            <th>方案</th>
+            <th>原理</th>
+            <th>适用场景</th>
+            <th>兼容性</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><strong>transform 欺骗法</strong></td>
+            <td>transform 会创建新的包含块</td>
+            <td>浮层、Tooltip、固定按钮</td>
+            <td><span class="tag tag-green">✅ 全部支持</span></td>
+          </tr>
+          <tr>
+            <td><strong>JS 动态计算</strong></td>
+            <td>使用 absolute + JS 计算位置</td>
+            <td>复杂交互、实时跟随</td>
+            <td><span class="tag tag-green">✅ 全部支持</span></td>
+          </tr>
+          <tr>
+            <td><strong>position: sticky</strong></td>
+            <td>在滚动容器内粘住</td>
+            <td>表格头、侧边栏分类导航</td>
+            <td><span class="tag tag-green">✅ 全部支持</span></td>
+          </tr>
+          <tr>
+            <td><strong>CSS anchor-positioning</strong></td>
+            <td>原生锚点定位（实验性）</td>
+            <td>Tooltip、下拉菜单</td>
+            <td><span class="tag tag-yellow">⚠️ Chrome 实验</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    
+    <!-- 场景1: 标准 Fixed -->
+    <div id="scene1" class="tab-content">
+      <h2>标准 Fixed：始终相对于视口</h2>
+      <div class="scene1-wrapper">
+        <div class="scene1-fixed">我是 Fixed（红）</div>
+        <div class="scene1-content">
+          <p>滚动这个容器，观察红色 Fixed 元素的行为：</p>
+          <p>它始终固定在<strong>视口</strong>的右上角，不受容器滚动影响。</p>
+          <p style="margin-top: 30px;">这是因为 fixed 的定位上下文是整个视口，而非父容器。</p>
+        </div>
+        <span class="scroll-indicator">↓ 滚动我</span>
+      </div>
+      
+      <div class="code-block">
+<span class="keyword">.fixed-element</span> {
+  <span class="property">position</span>: <span class="value">fixed</span>;
+  <span class="property">top</span>: <span class="value">10px</span>;
+  <span class="property">right</span>: <span class="value">10px</span>;
+  <span class="comment">/* 始终相对于视口定位，不受父元素影响 */</span>
+}
+      </div>
+    </div>
+    
+    <!-- 场景2: Transform 欺骗法 -->
+    <div id="scene2" class="tab-content">
+      <h2>Transform 欺骗法：Fixed 相对于父元素</h2>
+      <div class="explanation">
+        <strong>关键：</strong>给父元素添加 <code>transform: translate(0)</code> 会创建新的<em>包含块</em>，
+        使 fixed 元素相对于这个新的包含块定位！
+      </div>
+      
+      <div class="scene2-wrapper">
+        <div class="scene2-fixed">我是 Transform Fixed（绿）</div>
+        <div class="scene2-content">
+          <p>滚动这个容器，观察绿色 Fixed 元素的行为：</p>
+          <p>它固定在<strong>父容器的右上角</strong>，随容器滚动而滚动！</p>
+          <p style="margin-top: 30px;">这是因为 transform 创建了新的包含块，改变了 fixed 的定位上下文。</p>
+        </div>
+        <span class="scroll-indicator">↓ 滚动我</span>
+      </div>
+      
+      <div class="code-block">
+<span class="comment">/* ✅ 父元素添加 transform 创建新的包含块 */</span>
+.container {
+  <span class="property">position</span>: <span class="value">relative</span>;
+  <span class="property">transform</span>: <span class="value">translate(0)</span>; <span class="comment">/* 关键！*/</span>
+}
+
+<span class="keyword">.fixed-element</span> {
+  <span class="property">position</span>: <span class="value">fixed</span>;
+  <span class="property">top</span>: <span class="value">10px</span>;
+  <span class="property">right</span>: <span class="value">10px</span>;
+  <span class="comment">/* 现在相对于 .container 定位！*/</span>
+}
+      </div>
+      
+      <div class="warning">
+        <strong>注意：</strong>transform 会影响子元素的视觉效果（scale, rotate 等），确保这些副作用可接受。
+      </div>
+    </div>
+    
+    <!-- 场景3: Sticky 对比 -->
+    <div id="scene3" class="tab-content">
+      <h2>position: sticky：容器内的"伪固定"</h2>
+      <div class="scene3-container">
+        <div class="scene3-sticky">我是 Sticky（橙）</div>
+        <div class="scene3-normal">
+          <p>这是普通内容区域...</p>
+          <p>sticky 元素会"粘"在容器的顶部，当容器滚出视口时，它也会跟着消失。</p>
+          <p>与 fixed 的区别：</p>
+          <ul style="margin-left: 20px; margin-top: 8px; color: #666;">
+            <li>fixed：永远固定在视口</li>
+            <li>sticky：只在父容器滚动范围内固定</li>
+          </ul>
+        </div>
+        <div class="scene3-normal">
+          <p>继续滚动...</p>
+        </div>
+        <span class="scroll-indicator">↓ 滚动我</span>
+      </div>
+      
+      <div class="code-block">
+<span class="keyword">.sticky-element</span> {
+  <span class="property">position</span>: <span class="value">sticky</span>;
+  <span class="property">top</span>: <span class="value">10px</span>; <span class="comment">/* 距离容器顶部的偏移 */</span>
+}
+      </div>
+      
+      <div class="warning">
+        <strong>sticky 的限制：</strong>
+        <ul style="margin-left: 20px; margin-top: 8px;">
+          <li>父容器必须有 overflow: auto/scroll/hidden</li>
+          <li>父容器滚出视口后，sticky 也会消失</li>
+          <li>不支持 IE</li>
+        </ul>
+      </div>
+    </div>
+    
+    <!-- 决策树 -->
+    <div id="decision" class="tab-content">
+      <h2>如何选择？</h2>
+      
+      <div class="test-area">
+        <h4>根据场景选择方案：</h4>
+        <div class="test-row">
+          <div class="test-item">
+            <h5>场景 1：浮层/下拉菜单</h5>
+            <p style="font-size: 13px; color: #666;">相对于触发元素定位，滚动时跟随</p>
+            <span class="tag tag-green">推荐：transform 欺骗法</span>
+          </div>
+          <div class="test-item">
+            <h5>场景 2：吸顶导航</h5>
+            <p style="font-size: 13px; color: #666;">固定在视口顶部，页面滚动时不动</p>
+            <span class="tag tag-green">推荐：position: fixed</span>
+          </div>
+          <div class="test-item">
+            <h5>场景 3：表格头、分类导航</h5>
+            <p style="font-size: 13px; color: #666;">在容器内滚动时固定，容器滚走则消失</p>
+            <span class="tag tag-green">推荐：position: sticky</span>
+          </div>
+          <div class="test-item">
+            <h5>场景 4：Tooltip/复杂跟随</h5>
+            <p style="font-size: 13px; color: #666;">需要根据目标元素位置实时计算</p>
+            <span class="tag tag-yellow">推荐：JS + getBoundingClientRect</span>
+          </div>
+        </div>
+      </div>
+      
+      <div class="conclusion">
+        <h3>💡 核心要点</h3>
+        <ul>
+          <li><strong>fixed 的定位上下文是视口</strong>，不受父元素 position 影响</li>
+          <li><strong>transform 会改变 fixed 的定位上下文</strong>，这是实现"相对固定"的关键</li>
+          <li><strong>sticky 是 fixed 和 relative 的混合</strong>，只在父容器内有效</li>
+          <li><strong>复杂场景用 JS</strong>，但优先考虑 CSS 方案（性能更好）</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function showTab(tabId) {
+      // Hide all tabs
+      document.querySelectorAll('.tab-content').forEach(tab => {
+        tab.classList.remove('active');
+      });
+      document.querySelectorAll('.tab-btn').forEach(btn => {
+        btn.classList.remove('active');
+      });
+      
+      // Show selected tab
+      document.getElementById(tabId).classList.add('active');
+      event.target.classList.add('active');
+    }
+    
+    // Demo: 动态更新滚动位置
+    function updateScrollIndicator() {
+      document.querySelectorAll('.scroll-indicator').forEach(indicator => {
+        const wrapper = indicator.parentElement;
+        indicator.textContent = `滚动位置: ${wrapper.scrollTop}px`;
+      });
+    }
+    
+    document.querySelectorAll('.scene1-wrapper, .scene2-wrapper, .scene3-container').forEach(wrapper => {
+      wrapper.addEventListener('scroll', updateScrollIndicator);
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/layout-guide-demo.html
+++ b/examples/css/demos/layout-guide-demo.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS 布局方案对比演示</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.6; padding: 20px; background: #f8f9fa; }
+    h1, h2, h3 { margin-bottom: 10px; color: #333; }
+    section { background: #fff; border-radius: 8px; padding: 20px; margin-bottom: 20px; box-shadow: 0 1px 3px rgba(0,0,0,0.08); }
+    .demo-label { font-size: 12px; color: #666; margin-bottom: 8px; text-transform: uppercase; letter-spacing: 0.5px; }
+    .demo-box { background: #e9ecef; border-radius: 4px; padding: 12px; min-height: 60px; margin-bottom: 16px; }
+
+    /* Flex 演示 */
+    .flex-nav { display: flex; justify-content: space-between; align-items: center; background: #2c3e50; border-radius: 6px; padding: 0 16px; }
+    .flex-nav .logo { color: #fff; font-weight: 700; font-size: 18px; }
+    .flex-nav .links { display: flex; gap: 16px; }
+    .flex-nav a { color: #ecf0f1; text-decoration: none; font-size: 14px; }
+
+    .flex-cards { display: flex; gap: 12px; flex-wrap: wrap; }
+    .card { flex: 1; min-width: 140px; background: #3498db; color: #fff; border-radius: 6px; padding: 16px; text-align: center; }
+
+    /* Grid 演示 */
+    .grid-page { display: grid; grid-template-columns: 200px 1fr 200px; grid-template-rows: 60px 1fr 40px; gap: 12px; min-height: 280px; }
+    .grid-header { grid-column: 1 / -1; background: #2c3e50; color: #fff; border-radius: 6px; display: flex; align-items: center; padding: 0 16px; }
+    .grid-sidebar { background: #3498db; color: #fff; border-radius: 6px; padding: 16px; }
+    .grid-content { background: #ecf0f1; border-radius: 6px; padding: 16px; }
+    .grid-aside { background: #9b59b6; color: #fff; border-radius: 6px; padding: 16px; }
+    .grid-footer { grid-column: 1 / -1; background: #34495e; color: #fff; border-radius: 6px; display: flex; align-items: center; padding: 0 16px; font-size: 13px; }
+
+    /* auto-fit grid */
+    .grid-auto { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; }
+    .grid-auto .card { background: #27ae60; color: #fff; border-radius: 6px; padding: 20px; text-align: center; min-height: 80px; display: flex; align-items: center; justify-content: center; }
+
+    /* Subgrid 对齐 */
+    .subgrid-demo { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 12px; }
+    .subgrid-card { grid-column: span 3; display: grid; grid-template-columns: subgrid; gap: 12px; background: #fff; border: 1px solid #ddd; border-radius: 6px; padding: 12px; }
+    .subgrid-item { background: #3498db; color: #fff; border-radius: 4px; padding: 10px; font-size: 13px; text-align: center; }
+
+    /* clamp 响应式 */
+    .clamp-box { width: clamp(200px, 50%, 500px); background: linear-gradient(135deg, #667eea, #764ba2); color: #fff; border-radius: 8px; padding: 20px; text-align: center; margin: 0 auto; }
+    .clamp-text { font-size: clamp(14px, 3vw, 24px); }
+
+    /* 对比表 */
+    .compare-table { width: 100%; border-collapse: collapse; margin-top: 8px; }
+    .compare-table th, .compare-table td { border: 1px solid #dee2e6; padding: 10px 12px; text-align: left; font-size: 14px; }
+    .compare-table th { background: #f8f9fa; font-weight: 600; }
+    .compare-table tr:nth-child(even) { background: #f8f9fa; }
+    .tag { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 600; }
+    .tag-flex { background: #e8f4fd; color: #3498db; }
+    .tag-grid { background: #e8f8f0; color: #27ae60; }
+    .tag-old { background: #fde8e8; color: #e74c3c; }
+  </style>
+</head>
+<body>
+
+<section>
+  <h2>Flexbox vs Grid vs Table 方案对比</h2>
+  <table class="compare-table">
+    <thead>
+      <tr><th>方案</th><th>维度</th><th>最佳用例</th><th>局限性</th></tr>
+    </thead>
+    <tbody>
+      <tr><td><span class="tag tag-flex">Flexbox</span></td><td>一维（主轴/交叉轴）</td><td>导航栏、卡片组、垂直居中</td><td>不擅长多行多列复杂结构</td></tr>
+      <tr><td><span class="tag tag-grid">CSS Grid</span></td><td>二维（行/列）</td><td>页面整体布局、响应式网格</td><td>学习曲线稍陡</td></tr>
+      <tr><td><span class="tag tag-old">Table</span></td><td>行/列固定结构</td><td>纯数据表格（报表）</td><td>不响应式、语义差</td></tr>
+    </tbody>
+  </table>
+</section>
+
+<section>
+  <div class="demo-label">Flexbox — 导航栏（space-between）</div>
+  <div class="demo-box">
+    <nav class="flex-nav">
+      <div class="logo">Logo</div>
+      <div class="links">
+        <a href="#">首页</a>
+        <a href="#">产品</a>
+        <a href="#">关于</a>
+        <a href="#">联系</a>
+      </div>
+    </nav>
+  </div>
+  <div class="demo-label">Flexbox — 卡片组（flex-wrap）</div>
+  <div class="demo-box">
+    <div class="flex-cards">
+      <div class="card">卡片一</div>
+      <div class="card">卡片二</div>
+      <div class="card">卡片三</div>
+      <div class="card">卡片四</div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="demo-label">CSS Grid — 经典三栏布局</div>
+  <div class="demo-box">
+    <div class="grid-page">
+      <div class="grid-header">Header（grid-column: 1 / -1）</div>
+      <div class="grid-sidebar">Sidebar 左侧</div>
+      <div class="grid-content">Main Content</div>
+      <div class="grid-aside">Sidebar 右侧</div>
+      <div class="grid-footer">Footer（grid-column: 1 / -1）</div>
+    </div>
+  </div>
+  <div class="demo-label">CSS Grid — auto-fit 自适应列数</div>
+  <div class="demo-box">
+    <div class="grid-auto">
+      <div class="card">项目一</div>
+      <div class="card">项目二</div>
+      <div class="card">项目三</div>
+      <div class="card">项目四</div>
+      <div class="card">项目五</div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="demo-label">clamp() — 无媒体查询自适应（调整窗口宽度查看）</div>
+  <div class="demo-box">
+    <div class="clamp-box">
+      <div class="clamp-text">clamp(200px, 50%, 500px)</div>
+      <div style="font-size:13px; margin-top:8px; color:rgba(255,255,255,0.8)">宽度随窗口自动调整</div>
+    </div>
+  </div>
+  <div style="display:grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap:12px; margin-top:12px;">
+    <div style="background:#e74c3c; color:#fff; border-radius:6px; padding:16px; text-align:center;">
+      <div style="font-size:clamp(12px, 2vw, 18px);">clamp 字号</div>
+      <div style="font-size:12px; opacity:0.8; margin-top:4px;">响应式文本</div>
+    </div>
+    <div style="background:#3498db; color:#fff; border-radius:6px; padding:16px; display:flex; align-items:center; justify-content:center;">
+      <div style="width:clamp(60px, 30%, 120px); height:60px; background:rgba(255,255,255,0.3); border-radius:50%;"></div>
+    </div>
+  </div>
+</section>
+
+<section>
+  <div class="demo-label">Subgrid — 卡片内部对齐（Chrome 117+, Safari 16+）</div>
+  <div class="demo-box">
+    <div class="subgrid-demo">
+      <div class="subgrid-card">
+        <div class="subgrid-item">标题对齐</div>
+        <div class="subgrid-item">描述文字</div>
+        <div class="subgrid-item">按钮</div>
+      </div>
+      <div class="subgrid-card">
+        <div class="subgrid-item">更长的标题内容</div>
+        <div class="subgrid-item">更短的描述</div>
+        <div class="subgrid-item">按钮</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+</body>
+</html>

--- a/examples/css/demos/relative-fixed-positioning-demo.html
+++ b/examples/css/demos/relative-fixed-positioning-demo.html
@@ -1,0 +1,785 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>相对固定定位 — 交互演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { 
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', sans-serif; 
+      background: #0d1117; 
+      color: #c9d1d9; 
+      min-height: 100vh; 
+      padding: 24px; 
+    }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 14px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 1000px; margin: 0 auto; }
+    
+    /* Section styling */
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; display: flex; align-items: center; gap: 8px; }
+    .section h2::before { content: ''; display: inline-block; width: 4px; height: 16px; background: #58a6ff; border-radius: 2px; }
+    .section h3 { font-size: 14px; color: #8b949e; margin: 16px 0 8px; }
+    
+    /* Demo viewport */
+    .demo-viewport { 
+      background: #21262d; 
+      border: 1px solid #30363d; 
+      border-radius: 6px; 
+      overflow: hidden; 
+      margin-bottom: 12px;
+    }
+    .demo-header {
+      background: #30363d;
+      padding: 8px 12px;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .demo-header span { font-size: 12px; color: #8b949e; }
+    .demo-dot { width: 10px; height: 10px; border-radius: 50%; }
+    .demo-dot.red { background: #ff5f56; }
+    .demo-dot.yellow { background: #ffbd2e; }
+    .demo-dot.green { background: #27c93f; }
+    .demo-content { padding: 16px; position: relative; }
+    
+    /* Buttons */
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .btn { 
+      padding: 6px 12px; 
+      background: #21262d; 
+      border: 1px solid #30363d; 
+      border-radius: 4px; 
+      color: #c9d1d9; 
+      font-size: 12px; 
+      cursor: pointer; 
+      transition: all 0.15s;
+    }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    
+    /* Code blocks */
+    .code-block { 
+      background: #0d1117; 
+      border: 1px solid #30363d; 
+      border-radius: 4px; 
+      padding: 12px; 
+      font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace; 
+      font-size: 12px; 
+      overflow-x: auto; 
+      white-space: pre-wrap; 
+      word-break: break-all; 
+      color: #79c0ff; 
+    }
+    
+    /* Description */
+    .desc { font-size: 12px; color: #6e7681; margin-top: 8px; line-height: 1.5; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 12px; padding: 12px; background: #161b22; border-radius: 4px; border-left: 3px solid #58a6ff; }
+    
+    /* Demo-specific elements */
+    .outer-box {
+      width: 100%;
+      height: 280px;
+      background: #0d1117;
+      border: 2px dashed #30363d;
+      border-radius: 4px;
+      position: relative;
+      overflow: hidden;
+    }
+    
+    .middle-box {
+      width: 70%;
+      height: 220px;
+      background: #161b22;
+      border: 2px dashed #58a6ff;
+      border-radius: 4px;
+      margin: 30px auto;
+      position: relative;
+      transition: all 0.3s ease;
+    }
+    
+    .middle-box.transform-applied {
+      transform: translateX(0);
+    }
+    
+    .middle-box.scale-applied {
+      transform: scale(1);
+    }
+    
+    .middle-box.relative-applied {
+      position: relative;
+    }
+    
+    .middle-box.perspective-applied {
+      perspective: 1000px;
+    }
+    
+    .fixed-element {
+      position: fixed;
+      padding: 8px 16px;
+      background: linear-gradient(135deg, #e74c3c 0%, #c0392b 100%);
+      color: white;
+      font-size: 12px;
+      font-weight: 600;
+      border-radius: 4px;
+      box-shadow: 0 4px 12px rgba(231, 76, 60, 0.4);
+      z-index: 100;
+      cursor: pointer;
+      transition: all 0.3s ease;
+      white-space: nowrap;
+    }
+    
+    .fixed-element:hover {
+      transform: scale(1.05);
+      box-shadow: 0 6px 16px rgba(231, 76, 60, 0.5);
+    }
+    
+    .fixed-element.in-middle {
+      top: 10px;
+      left: 10px;
+    }
+    
+    .fixed-element.in-viewport {
+      top: 10px;
+      right: 10px;
+    }
+    
+    .label-marker {
+      position: absolute;
+      font-size: 10px;
+      padding: 2px 6px;
+      border-radius: 2px;
+      color: white;
+    }
+    
+    .label-marker.viewport-label {
+      top: 4px;
+      left: 4px;
+      background: #f0883e;
+    }
+    
+    .label-marker.middle-label {
+      top: 4px;
+      right: 4px;
+      background: #58a6ff;
+    }
+    
+    /* Interactive playground */
+    .playground {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
+    }
+    
+    .playground-left, .playground-right {
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 4px;
+      padding: 16px;
+    }
+    
+    .playground-left h4, .playground-right h4 {
+      font-size: 13px;
+      color: #8b949e;
+      margin-bottom: 12px;
+    }
+    
+    .css-input {
+      width: 100%;
+      min-height: 100px;
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 4px;
+      padding: 12px;
+      font-family: 'SF Mono', Monaco, monospace;
+      font-size: 12px;
+      color: #79c0ff;
+      resize: vertical;
+      margin-bottom: 12px;
+    }
+    
+    .css-input:focus {
+      outline: none;
+      border-color: #58a6ff;
+    }
+    
+    /* Scrollable container demo */
+    .scroll-demo-container {
+      width: 100%;
+      height: 300px;
+      background: #21262d;
+      border: 2px dashed #58a6ff;
+      border-radius: 4px;
+      overflow: auto;
+      position: relative;
+    }
+    
+    .scroll-content {
+      height: 600px;
+      padding: 16px;
+      position: relative;
+    }
+    
+    .scroll-inner-box {
+      width: 200px;
+      height: 400px;
+      background: #161b22;
+      border: 2px dashed #3fb950;
+      border-radius: 4px;
+      margin: 0 auto;
+      position: relative;
+      transform: translateX(0);
+    }
+    
+    .scroll-fixed {
+      position: fixed;
+      background: #3fb950;
+      color: #0d1117;
+      font-size: 12px;
+      font-weight: 600;
+      padding: 8px 16px;
+      border-radius: 4px;
+      box-shadow: 0 4px 12px rgba(63, 185, 80, 0.4);
+      z-index: 50;
+    }
+    
+    /* Scenario cards */
+    .scenario-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 16px;
+    }
+    
+    .scenario-card {
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      padding: 16px;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+    
+    .scenario-card:hover {
+      border-color: #58a6ff;
+      transform: translateY(-2px);
+    }
+    
+    .scenario-card h4 {
+      font-size: 14px;
+      color: #f0f6fc;
+      margin-bottom: 8px;
+    }
+    
+    .scenario-card p {
+      font-size: 12px;
+      color: #8b949e;
+      line-height: 1.5;
+    }
+    
+    /* Animation demo */
+    .anim-target {
+      width: 60px;
+      height: 60px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11px;
+      color: white;
+      font-weight: 600;
+      position: relative;
+      transform: translateX(0);
+      transition: transform 0.3s ease;
+    }
+    
+    .anim-target:hover {
+      transform: translateX(150px);
+    }
+    
+    /* Status indicator */
+    .status-bar {
+      display: flex;
+      gap: 16px;
+      padding: 12px 16px;
+      background: #21262d;
+      border-radius: 4px;
+      margin-bottom: 16px;
+    }
+    
+    .status-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+    }
+    
+    .status-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+    }
+    
+    .status-dot.active { background: #3fb950; }
+    .status-dot.inactive { background: #f85149; }
+    
+    .status-label { color: #8b949e; }
+    .status-value { color: #f0f6fc; font-weight: 500; }
+    
+    /* Tab styles */
+    .tabs { display: flex; gap: 4px; margin-bottom: 16px; border-bottom: 1px solid #30363d; }
+    .tab { padding: 8px 16px; font-size: 13px; color: #8b949e; cursor: pointer; border-bottom: 2px solid transparent; transition: all 0.15s; }
+    .tab:hover { color: #c9d1d9; }
+    .tab.active { color: #58a6ff; border-bottom-color: #58a6ff; }
+    
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+    
+    /* Comparison table */
+    .comparison-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+    
+    .comparison-table th,
+    .comparison-table td {
+      padding: 10px 12px;
+      text-align: left;
+      border-bottom: 1px solid #30363d;
+    }
+    
+    .comparison-table th {
+      background: #21262d;
+      color: #f0f6fc;
+      font-weight: 600;
+    }
+    
+    .comparison-table td { color: #c9d1d9; }
+    .comparison-table tr:hover td { background: #161b22; }
+    
+    .tag {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 12px;
+      font-size: 11px;
+      font-weight: 500;
+    }
+    
+    .tag-red { background: rgba(248, 81, 73, 0.2); color: #f85149; }
+    .tag-green { background: rgba(63, 185, 80, 0.2); color: #3fb950; }
+    .tag-blue { background: rgba(56, 139, 253, 0.2); color: #58a6ff; }
+    .tag-yellow { background: rgba(210, 168, 69, 0.2); color: #d2a869; }
+    
+    @media (max-width: 768px) {
+      .playground { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>相对固定定位 — 交互演示</h1>
+    <p class="subtitle">理解 transform 如何改变 fixed 定位上下文，实现"相对于父元素固定"效果</p>
+    
+    <!-- Status Bar -->
+    <div class="status-bar">
+      <div class="status-item">
+        <span class="status-dot active"></span>
+        <span class="status-label">视口定位上下文</span>
+        <span class="status-value" id="viewport-status">激活</span>
+      </div>
+      <div class="status-item">
+        <span class="status-dot inactive" id="transform-indicator"></span>
+        <span class="status-label">Transform 上下文</span>
+        <span class="status-value" id="transform-status">未激活</span>
+      </div>
+    </div>
+    
+    <!-- Section 1: Basic Demo -->
+    <div class="section">
+      <h2>基础演示</h2>
+      <p class="desc">点击按钮切换父容器的 transform 状态，观察红色 fixed 元素的位置变化。</p>
+      
+      <div class="controls" id="transform-controls">
+        <button class="btn active" data-transform="none">无 transform</button>
+        <button class="btn" data-transform="translateX(0)">transform: translateX(0)</button>
+        <button class="btn" data-transform="scale(1)">transform: scale(1)</button>
+        <button class="btn" data-transform="perspective(1000px)">transform: perspective()</button>
+        <button class="btn" data-transform="relative">position: relative</button>
+      </div>
+      
+      <div class="demo-viewport">
+        <div class="demo-header">
+          <span class="demo-dot red"></span>
+          <span class="demo-dot yellow"></span>
+          <span class="demo-dot green"></span>
+          <span style="margin-left: auto; font-size: 11px; color: #6e7681;">视口边界</span>
+        </div>
+        <div class="demo-content">
+          <div class="outer-box" id="outer-box">
+            <div class="middle-box" id="middle-box">
+              <span class="label-marker middle-label">中间容器</span>
+              <div class="fixed-element in-middle" id="fixed-red">Fixed 元素</div>
+            </div>
+            <span class="label-marker viewport-label">外层容器</span>
+            <div class="fixed-element in-viewport" id="fixed-green">视口固定</div>
+          </div>
+        </div>
+      </div>
+      
+      <div class="code-block" id="current-css">/* 当前状态 */
+.middle-box {
+  transform: none;
+}</div>
+      
+      <div class="info" id="behavior-note">
+        <strong>预期行为：</strong>当 transform 为 none 时，红色 Fixed 元素应该相对于视口定位（显示在右上角）。点击按钮应用 transform 后，红色元素会移动到中间容器的左上角。
+      </div>
+    </div>
+    
+    <!-- Section 2: Interactive Playground -->
+    <div class="section">
+      <h2>CSS Playground</h2>
+      <p class="desc">在左侧输入 CSS 规则，右侧实时预览效果。</p>
+      
+      <div class="playground">
+        <div class="playground-left">
+          <h4>CSS 规则</h4>
+          <textarea class="css-input" id="css-input" spellcheck="false">/* 修改父容器样式 */
+.parent-transform {
+  transform: translateX(0);
+  background: #1a1f26;
+  padding: 20px;
+}
+
+/* 修改 Fixed 子元素样式 */
+.my-fixed {
+  position: fixed;
+  top: 20px;
+  left: 20px;
+  background: #e74c3c;
+  padding: 12px 20px;
+  color: white;
+  border-radius: 6px;
+  font-weight: 600;
+  box-shadow: 0 4px 12px rgba(231, 76, 60, 0.4);
+}</textarea>
+          <button class="btn" id="apply-css" style="width: 100%; padding: 10px;">应用 CSS</button>
+        </div>
+        <div class="playground-right">
+          <h4>预览区域</h4>
+          <div style="background: #0d1117; border: 1px solid #30363d; border-radius: 4px; height: 200px; position: relative; overflow: hidden;">
+            <div class="parent-transform" id="playground-parent" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 60%; height: 70%; background: #161b22; border: 2px dashed #58a6ff; border-radius: 4px;">
+              <div class="my-fixed" id="playground-fixed">Fixed</div>
+            </div>
+          </div>
+          <div class="code-block" id="applied-code" style="margin-top: 12px;">/* 等待应用... */</div>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Section 3: Scroll Demo -->
+    <div class="section">
+      <h2>滚动容器中的 Fixed</h2>
+      <p class="desc">当 transform 创建了新的定位上下文后，滚动父容器时 fixed 元素不会跟随滚动，而是相对于该容器固定。</p>
+      
+      <div class="scroll-demo-container" id="scroll-container">
+        <div class="scroll-content">
+          <div class="scroll-inner-box" id="scroll-inner">
+            <div class="scroll-fixed" id="scroll-fixed" style="top: 20px; left: 20px;">滚动固定元素</div>
+            <p style="color: #8b949e; font-size: 12px; padding: 60px 16px; text-align: center;">向下滚动查看效果<br>绿色方块内的固定元素会保持位置</p>
+          </div>
+        </div>
+      </div>
+      
+      <div class="controls" style="margin-top: 12px;">
+        <button class="btn" id="scroll-info">滚动位置: 0</button>
+      </div>
+    </div>
+    
+    <!-- Section 4: Scenarios -->
+    <div class="section">
+      <h2>典型使用场景</h2>
+      
+      <div class="scenario-grid">
+        <div class="scenario-card" data-scenario="sticky-header">
+          <h4>🎯 吸顶导航</h4>
+          <p>导航栏在滚动到顶部时固定，滚动时保持在视口顶部。</p>
+        </div>
+        <div class="scenario-card" data-scenario="fab">
+          <h4>🔘 浮动操作按钮</h4>
+          <p>固定在视口某个位置，常用于主操作如"新建"、"分享"。</p>
+        </div>
+        <div class="scenario-card" data-scenario="badge">
+          <h4>🏷️ 卡片角标</h4>
+          <p>固定在父容器的角落，如"新品"、"热门"等标签。</p>
+        </div>
+        <div class="scenario-card" data-scenario="sidebar">
+          <h4>📌 吸附侧边栏</h4>
+          <p>侧边栏固定在视口，但相对于某个内容区域定位。</p>
+        </div>
+      </div>
+    </div>
+    
+    <!-- Section 5: Comparison -->
+    <div class="section">
+      <h2>定位方式对比</h2>
+      
+      <div class="tabs">
+        <div class="tab active" data-tab="position-table">定位属性对比</div>
+        <div class="tab" data-tab="containing-block">包含块规则</div>
+        <div class="tab" data-tab="common-pitfalls">常见坑点</div>
+      </div>
+      
+      <div class="tab-content active" id="position-table">
+        <table class="comparison-table">
+          <thead>
+            <tr>
+              <th>定位方式</th>
+              <th>定位上下文</th>
+              <th>随滚动移动</th>
+              <th>适用场景</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td><span class="tag tag-blue">static</span></td>
+              <td>正常文档流</td>
+              <td><span class="tag tag-green">是</span></td>
+              <td>默认布局</td>
+            </tr>
+            <tr>
+              <td><span class="tag tag-blue">relative</span></td>
+              <td>自身原始位置</td>
+              <td><span class="tag tag-green">是</span></td>
+              <td>微调位置、创建子元素定位上下文</td>
+            </tr>
+            <tr>
+              <td><span class="tag tag-blue">absolute</span></td>
+              <td>最近已定位祖先</td>
+              <td><span class="tag tag-green">是</span></td>
+              <td>绝对定位浮层、下拉菜单</td>
+            </tr>
+            <tr>
+              <td><span class="tag tag-red">fixed</span></td>
+              <td>视口（无 transform 祖先）</td>
+              <td><span class="tag tag-red">否</span></td>
+              <td>固定导航、浮动按钮、模态框</td>
+            </tr>
+            <tr>
+              <td><span class="tag tag-yellow">fixed + transform</span></td>
+              <td>transform 祖先</td>
+              <td><span class="tag tag-red">否</span>（相对于祖先固定）</td>
+              <td>相对父容器固定、吸附效果</td>
+            </tr>
+            <tr>
+              <td><span class="tag tag-blue">sticky</span></td>
+              <td>最近滚动容器</td>
+              <td><span class="tag tag-yellow">条件</span></td>
+              <td>表头吸附、分类导航</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      
+      <div class="tab-content" id="containing-block">
+        <div class="code-block" position: relative;
+  width: 300px;
+  height: 200px;
+  background: #161b22;
+  border: 2px solid #58a6ff;
+}
+
+/* transform 创建新的包含块 */
+.transform-parent {
+  transform: translateX(0);
+  /* 或 scale(1), perspective(), filter() */
+}
+
+/* fixed 相对于 .transform-parent 定位 */
+.fixed-child {
+  position: fixed;
+  top: 0;
+  left: 0;
+  /* 不再相对于视口，而是相对于 .transform-parent */
+}
+</div>
+        <p class="desc" style="margin-top: 12px;">注意：transform、perspective、filter 属性会改变 absolute 和 fixed 的定位上下文。</p>
+      </div>
+      
+      <div class="tab-content" id="common-pitfalls">
+        <table class="comparison-table">
+          <thead>
+            <tr>
+              <th>坑点</th>
+              <th>问题描述</th>
+              <th>解决方案</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>性能问题</td>
+              <td>过多 transform 导致合成层爆炸</td>
+              <td>限制使用，合理分层</td>
+            </tr>
+            <tr>
+              <td>文字模糊</td>
+              <td>transform 触发亚像素渲染</td>
+              <td>使用 translateZ(0) 强制 GPU</td>
+            </tr>
+            <tr>
+              <td>滚动越界</td>
+              <td>fixed 元素随滚动"跑出"父容器</td>
+              <td>JS 动态计算位置</td>
+            </tr>
+            <tr>
+              <td>z-index 层叠</td>
+              <td>transform 创建独立层叠上下文</td>
+              <td>统一规划 z-index 层级</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+    
+    <!-- Section 6: Animation Demo -->
+    <div class="section">
+      <h2>动画中的 Transform</h2>
+      <p class="desc">hover 下面的元素，观察 transform 动画效果。保持 transform 状态同时实现 fixed 定位。</p>
+      
+      <div style="background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 40px; display: flex; align-items: center; justify-content: center; gap: 40px;">
+        <div class="anim-target" style="position: relative;">
+          <span>Hover Me</span>
+        </div>
+        <div style="position: relative; transform: translateX(0);">
+          <div class="anim-target" style="position: fixed; top: 0; left: 0; background: linear-gradient(135deg, #3fb950 0%, #2d8a3e 100%);">
+            <span>Fixed + Transform</span>
+          </div>
+          <div style="width: 200px; height: 100px; background: #161b22; border: 2px dashed #3fb950; border-radius: 4px; margin-left: 80px; margin-top: 40px;"></div>
+        </div>
+      </div>
+    </div>
+    
+    <p class="info">
+      <strong>总结：</strong>transform 属性会改变 fixed 的定位上下文，使其相对于应用了 transform 的祖先元素定位，而非视口。这允许我们实现"相对父元素固定"的布局效果，是现代前端实现吸附、浮动等交互的重要技术。
+    </p>
+  </div>
+
+  <script>
+    // ===== Transform Controls =====
+    const transformControls = document.getElementById('transform-controls');
+    const middleBox = document.getElementById('middle-box');
+    const fixedRed = document.getElementById('fixed-red');
+    const fixedGreen = document.getElementById('fixed-green');
+    const currentCss = document.getElementById('current-css');
+    const behaviorNote = document.getElementById('behavior-note');
+    const viewportStatus = document.getElementById('viewport-status');
+    const transformStatus = document.getElementById('transform-status');
+    const transformIndicator = document.getElementById('transform-indicator');
+    
+    transformControls.addEventListener('click', (e) => {
+      if (e.target.classList.contains('btn')) {
+        // Update active button
+        transformControls.querySelectorAll('.btn').forEach(b => b.classList.remove('active'));
+        e.target.classList.add('active');
+        
+        const transformValue = e.target.dataset.transform;
+        
+        // Apply transform to middle box
+        if (transformValue === 'none') {
+          middleBox.className = 'middle-box';
+          behaviorNote.innerHTML = '<strong>预期行为：</strong>当 transform 为 none 时，红色 Fixed 元素应该相对于视口定位（显示在右上角）。点击按钮应用 transform 后，红色元素会移动到中间容器的左上角。';
+          transformIndicator.className = 'status-dot inactive';
+          transformStatus.textContent = '未激活';
+        } else if (transformValue === 'relative') {
+          middleBox.className = 'middle-box relative-applied';
+          behaviorNote.innerHTML = '<strong>预期行为：</strong>position: relative 只是创建了定位上下文，不影响 fixed 的视口定位。';
+          transformIndicator.className = 'status-dot inactive';
+          transformStatus.textContent = '未激活（relative）';
+        } else {
+          middleBox.style.transform = transformValue;
+          behaviorNote.innerHTML = `<strong>预期行为：</strong>transform: ${transformValue} 创建了新的定位上下文，红色 Fixed 元素现在相对于中间容器定位！`;
+          transformIndicator.className = 'status-dot active';
+          transformStatus.textContent = '已激活';
+        }
+        
+        currentCss.textContent = `/* 当前状态 */
+.middle-box {
+  transform: ${transformValue};
+}`;
+      }
+    });
+    
+    // ===== CSS Playground =====
+    const cssInput = document.getElementById('css-input');
+    const applyCssBtn = document.getElementById('apply-css');
+    const playgroundParent = document.getElementById('playground-parent');
+    const playgroundFixed = document.getElementById('playground-fixed');
+    const appliedCode = document.getElementById('applied-code');
+    
+    applyCssBtn.addEventListener('click', () => {
+      try {
+        const css = cssInput.value;
+        // Extract rules for parent and fixed
+        const parentMatch = css.match(/\.parent-transform\s*\{([^}]+)\}/);
+        const fixedMatch = css.match(/\.my-fixed\s*\{([^}]+)\}/);
+        
+        if (parentMatch) {
+          const rules = parentMatch[1].trim();
+          playgroundParent.style.cssText += rules;
+        }
+        
+        if (fixedMatch) {
+          const rules = fixedMatch[1].trim();
+          playgroundFixed.style.cssText += rules;
+        }
+        
+        appliedCode.textContent = css;
+      } catch (err) {
+        appliedCode.textContent = 'CSS 解析错误: ' + err.message;
+      }
+    });
+    
+    // ===== Scroll Demo =====
+    const scrollContainer = document.getElementById('scroll-container');
+    const scrollFixed = document.getElementById('scroll-fixed');
+    const scrollInfo = document.getElementById('scroll-info');
+    
+    scrollContainer.addEventListener('scroll', () => {
+      const scrollTop = scrollContainer.scrollTop;
+      scrollInfo.textContent = `滚动位置: ${scrollTop}px`;
+      
+      // The fixed element stays in place because it has its own containing block
+    });
+    
+    // ===== Tabs =====
+    document.querySelectorAll('.tab').forEach(tab => {
+      tab.addEventListener('click', () => {
+        const tabId = tab.dataset.tab;
+        
+        // Update active tab
+        document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        tab.classList.add('active');
+        
+        // Show correct content
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        document.getElementById(tabId).classList.add('active');
+      });
+    });
+    
+    // ===== Scenarios =====
+    document.querySelectorAll('.scenario-card').forEach(card => {
+      card.addEventListener('click', () => {
+        const scenario = card.dataset.scenario;
+        alert(`场景: ${scenario}\n\n这是一个演示卡片，点击可跳转到对应的完整示例。`);
+      });
+    });
+    
+    // ===== Initial State =====
+    console.log('相对固定定位演示已加载');
+    console.log('提示: 尝试点击 "transform: translateX(0)" 按钮观察 fixed 元素的位置变化');
+  </script>
+</body>
+</html>

--- a/src/topics/01.basics/css-property/index.mdx
+++ b/src/topics/01.basics/css-property/index.mdx
@@ -1,0 +1,243 @@
+---
+title: "CSS @property 自定义属性进阶"
+category: "基础知识"
+tags:
+  - CSS Houdini
+  - @property
+  - 自定义属性
+  - CSS动画
+description: "深入理解 CSS @property 规则，掌握自定义属性的类型定义、继承控制与动画能力"
+keywords: "CSS @property, CSS Houdini, 自定义属性动画, CSS变量, registerProperty"
+---
+
+# CSS @property 自定义属性进阶
+
+## @property 是什么
+
+`@property` 是 CSS Houdini API 的一部分，允许开发者在样式表中**显式注册**自定义属性（CSS 变量），从而获得：
+
+- **类型检查** — 约束属性可接受的值类型
+- **初始值** — 定义属性的默认值
+- **继承控制** — 决定属性是否可继承
+- **可动画化** — 让原本无法过渡的自定义属性产生平滑动画
+
+在此之前，实现以上能力需要借助 JavaScript 调用 `CSS.registerProperty()`。`@property` 让我们可以纯 CSS 完成注册。
+
+## 基本语法
+
+```css
+@property --myProperty {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rebeccapurple;
+}
+```
+
+**必填项**：`syntax` 和 `inherits` 必须同时提供，否则整条规则无效并被忽略。
+
+**可选项**：`initial-value` 在以下情况可省略：
+- `syntax: "*"`（通用语法）时必须省略
+- 其他情况若省略则整条规则无效
+
+### syntax 语法描述符
+
+| 写法 | 含义 |
+|------|------|
+| `"<length>"` | 单一类型 |
+| `"<length> \| <percentage>"` | 多选类型 |
+| `"<color>#"` | 带 `#` 表示多个（空格分隔） |
+| `"*"` | 任意有效 token（无初始值） |
+
+常用类型标识符：`<length>`、`<number>`、`<percentage>`、`<color>`、`<angle>`、`<time>`、`<transform-list>`、`<image>` 等。
+
+### inherits 继承控制
+
+- `inherits: true` — 子元素继承父元素的计算值（默认行为）
+- `inherits: false` — 每个元素独立使用初始值，不走继承链
+
+### initial-value 初始值
+
+必须是**计算独立的值**（computationally independent），即不依赖其他 CSS 属性即可计算出结果。
+
+- ✅ `10px`、`2in`、`45deg`、`#ff0000` — 计算独立
+- ❌ `3em`、`2rem` — 依赖 `font-size`，非计算独立
+
+## 核心能力一：类型约束
+
+未注册的自定义属性值以字符串形式存在，任何期望类型的 CSS 属性都无法正确解读它：
+
+```css
+/* 未注册：background-color 接收到的是字符串 "--bg" 而非颜色值 */
+.box { background-color: var(--bg); } /* 无效 */
+
+@property --bg {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #3498db;
+}
+
+.box { background-color: var(--bg); } /* ✅ 正常工作 */
+```
+
+类型约束还会在浏览器 DevTools 中提供更友好的提示。
+
+## 核心能力二：初始值与继承控制
+
+```css
+/* 全局进度条：初始25%，不继承，子元素各自独立 */
+@property --progress {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 25%;
+}
+
+/* 主题色：可继承，子元素会跟随父元素变化 */
+@property --theme-color {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #3498db;
+}
+```
+
+## 核心能力三：可动画化（最重要！）
+
+这是 `@property` 最有价值的能力。**未注册的自定义属性无法做动画过渡**，因为浏览器不知道它的值是什么类型：
+
+```css
+/* ❌ 无效：--size 没有注册，动画无法工作 */
+.el { width: var(--size); transition: --size 0.5s; }
+.el:hover { --size: 300px; }
+```
+
+注册后，浏览器知道 `--size` 是 `<length>` 类型，就能自动计算中间值：
+
+```css
+/* ✅ 有效：注册后支持平滑过渡 */
+@property --size {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 100px;
+}
+
+.el {
+  width: var(--size);
+  transition: width 0.5s ease;
+}
+.el:hover {
+  width: 300px; /* 或者设置 --size: 300px，配合 var() 使用 */
+}
+```
+
+### 从无到有的过渡（opacity 示例）
+
+```css
+/* 注册 --opacity，明确类型为 <number>（0-1），初始值 0 */
+@property --opacity {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0;
+}
+
+.modal {
+  --opacity: 0;
+  opacity: calc(var(--opacity));
+  transition: --opacity 0.4s ease;
+}
+
+.modal.visible {
+  --opacity: 1;
+}
+```
+
+> **注意**：这里直接对 `opacity` 做 transition 不生效（opacity 本身是标准属性），而是利用 `--opacity` 配合 `calc(var(--opacity))` 或直接在实际动画属性中引用注册过的自定义属性来实现从 0→1 的平滑过渡。
+
+## 实际应用：进度条动画
+
+`@property` 让自定义属性在 `@keyframes` 中直接设置关键帧值成为可能：
+
+```css
+@property --progress {
+  syntax: "<percentage>";
+  inherits: false;
+  initial-value: 25%;
+}
+
+.bar {
+  width: 100%;
+  height: 5px;
+  background: linear-gradient(
+    to right,
+    #00d230 var(--progress),
+    #1a1a1a var(--progress)
+  );
+  animation: progressAnim 2.5s ease infinite;
+}
+
+@keyframes progressAnim {
+  to { --progress: 100%; }
+}
+```
+
+未注册的情况下，`--progress` 从 `25%` 到 `100%` 的过渡无法产生平滑动画；注册后，浏览器将直接插值计算每一帧的颜色停止位置。
+
+## 实际应用：颜色渐变动画
+
+```css
+@property --color-start {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #3498db;
+}
+
+@property --color-end {
+  syntax: "<color>";
+  inherits: false;
+  initial-value: #e74c3c;
+}
+
+.gradient-box {
+  background: linear-gradient(45deg, var(--color-start), var(--color-end));
+  animation: colorShift 3s ease infinite alternate;
+}
+
+@keyframes colorShift {
+  to {
+    --color-start: #e74c3c;
+    --color-end: #9b59b6;
+  }
+}
+```
+
+## Houdini 生态关联
+
+`@property` 是 CSS Houdini 的 **Properties & Values API** 的 CSS 书写形式。与之关联的 Houdini API 包括：
+
+| API | 作用 |
+|-----|------|
+| **CSS Properties & Values API** | 注册自定义属性（`@property` / `registerProperty()`） |
+| **CSS Typed OM** | 将 CSS 值暴露为类型化对象，提升操作性能 |
+| **Worklets** | 在浏览器主线程外运行渲染代码 |
+
+`@property` 是 Houdini 中**支持最广泛**的特性（Chromium 85+、Firefox 128+、Safari 16.4+）。
+
+## 与 JavaScript `registerProperty()` 的关系
+
+两者效果完全一致，JavaScript 注册优先级更高：
+
+```js
+// 等价于 @property --rotation { syntax: "<angle>"; inherits: false; initial-value: 45deg; }
+CSS.registerProperty({
+  name: '--rotation',
+  syntax: '<angle>',
+  inherits: false,
+  initialValue: '45deg'
+});
+```
+
+## 注意事项
+
+1. **缺少必填描述符则规则无效**：只有 `syntax` + `inherits` 同时存在时 `@property` 才生效
+2. **初始值必须计算独立**：`3em`、`calc()` 等依赖其他值的写法通常无效
+3. **JavaScript 注册优先级更高**：同名的 JS 注册会覆盖 CSS `@property`
+4. **同名校规后者胜出**：多个同名的 `@property` 规则，按文档顺序最后一个生效
+5. **浏览器兼容性**：目前主流浏览器已广泛支持，但仍需留意兼容表

--- a/src/topics/03.animation/css-scroll-snap/_demos/basic.html
+++ b/src/topics/03.animation/css-scroll-snap/_demos/basic.html
@@ -1,0 +1,46 @@
+<h3>基础示例：水平滚动吸附</h3>
+<p>尝试水平滚动，下方卡片会自动吸附到最近的位置。</p>
+<section class="carousel">
+  <div class="slide slide-1">1</div>
+  <div class="slide slide-2">2</div>
+  <div class="slide slide-3">3</div>
+  <div class="slide slide-4">4</div>
+  <div class="slide slide-5">5</div>
+</section>
+<style>
+  .carousel {
+    display: flex;
+    width: 100%;
+    height: 200px;
+    overflow-x: scroll;
+    overflow-y: hidden;
+    scroll-snap-type: x mandatory;
+    /* 平滑吸附动画 */
+    scroll-behavior: smooth;
+    /* 隐藏滚动条 */
+    scrollbar-width: none;
+    gap: 12px;
+    padding: 0 20px;
+    background: #f5f5f5;
+    border-radius: 8px;
+  }
+  .carousel::-webkit-scrollbar {
+    display: none;
+  }
+  .slide {
+    flex: 0 0 80%;
+    height: 100%;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2rem;
+    color: #fff;
+    scroll-snap-align: start;
+  }
+  .slide-1 { background: #ff6b6b; }
+  .slide-2 { background: #4ecdc4; }
+  .slide-3 { background: #45b7d1; }
+  .slide-4 { background: #96ceb4; }
+  .slide-5 { background: #dda0dd; }
+</style>

--- a/src/topics/03.animation/css-scroll-snap/dynamic-snippets.json
+++ b/src/topics/03.animation/css-scroll-snap/dynamic-snippets.json
@@ -1,0 +1,18 @@
+{
+  "Insert Playground (Auto-detected)": {
+    "prefix": "pgauto",
+    "body": [
+      "{/* @playground id=\"${1|css-scroll-snap-basic|}\" mode=\"${2|demo,exercise,test|}\" */}"
+    ],
+    "description": "Insert playground with auto-detected IDs from _demos folder: css-scroll-snap-basic",
+    "scope": "mdx"
+  },
+  "Insert Demo Playground (Auto-detected)": {
+    "prefix": "pgdemoauto",
+    "body": [
+      "{/* @playground id=\"${1|css-scroll-snap-basic|}\" mode=\"demo\" */}"
+    ],
+    "description": "Insert demo playground with auto-detected IDs: css-scroll-snap-basic",
+    "scope": "mdx"
+  }
+}

--- a/src/topics/03.animation/css-scroll-snap/index.mdx
+++ b/src/topics/03.animation/css-scroll-snap/index.mdx
@@ -1,0 +1,485 @@
+---
+title: css-scroll-snap
+category: 布局
+tags: [css-scroll-snap]
+---
+
+## 学习目标
+
+通过本章学习 CSS Scroll Snap，掌握滚动捕捉的核心原理与实战技巧：
+
+1. 理解 `scroll-snap-type` 及 `x/y` 方向属性的作用
+2. 掌握 `scroll-snap-align` 和 `scroll-snap-stop` 的使用
+3. 理解与 `overflow` 属性的配合关系
+4. 独立实现移动端轮播图效果
+5. 了解兼容性与性能注意事项
+
+---
+
+## 快速上手
+
+### scroll-snap-type
+
+`scroll-snap-type` 定义滚动容器的捕捉行为，指定滚动结束后是否"吸附"到特定的捕捉点。
+
+{/* @playground id="css-scroll-snap-basic" mode="code" */}
+
+```css
+.container {
+  scroll-snap-type: y mandatory;
+}
+```
+
+- `y` / `x`：沿 Y 轴或 X 轴方向捕捉
+- `both`：两个方向都捕捉
+- `none`：不捕捉
+- `mandatory`：滚动停止后必须停在某个捕捉点（强制吸附）
+- `proximity`：滚动停止后，如果接近捕捉点则吸附，否则不吸附
+
+### 1.1 工作原理
+
+Scroll Snap 基于**滚动容器**（Scroll Container）和**捕捉子元素**（Snap Child）协作实现：
+
+- **滚动容器**：设置了 `overflow` 属性的父容器
+- **捕捉子元素**：设置了 `scroll-snap-align` 的直接子元素
+
+浏览器在用户停止滚动后，根据 `scroll-snap-type` 的策略自动计算并平滑过渡到最近的捕捉点。
+
+### 1.2 基本语法
+
+```css
+.container {
+  /* 语法：scroll-snap-type: <axis> <strictness> */
+  scroll-snap-type: x mandatory;
+  scroll-snap-type: y proximity;
+  scroll-snap-type: both mandatory;
+}
+```
+
+- `axis`（轴向）：`x` | `y` | `both` | `none`
+- `strictness`（严格程度）：`mandatory`（强制）| `proximity`（接近时）
+
+---
+
+## 主要属性详解
+
+### 3.1 `scroll-snap-type`
+
+定义滚动容器的捕捉类型和轴向。
+
+```css
+.container {
+  /* 仅水平方向，强制吸附 */
+  scroll-snap-type: x mandatory;
+
+  /* 仅垂直方向，接近时吸附 */
+  scroll-snap-type: y proximity;
+
+  /* 两个方向都吸附（网格场景） */
+  scroll-snap-type: both mandatory;
+
+  /* 不吸附 */
+  scroll-snap-type: none;
+}
+```
+
+| 值 | 说明 |
+|----|------|
+| `none` | 不启用滚动捕捉 |
+| `x` | 仅沿 X 轴（水平）捕捉 |
+| `y` | 仅沿 Y 轴（垂直）捕捉 |
+| `both` | 两个方向都捕捉（用于网格布局） |
+
+**严格程度：**
+
+| 值 | 说明 |
+|----|------|
+| `mandatory` | 滚动停止后**必须**吸附到最近的捕捉点，不允许停在非捕捉位置 |
+| `proximity` | 滚动停止后，仅当滚动位置**接近**捕捉点时才吸附；否则停在当前位置 |
+
+> **注意：** `mandatory` 适合精确分页场景（如轮播图）；`proximity` 适合希望保留一定自由滚动空间的场景。
+
+---
+
+### 3.2 `scroll-snap-align`
+
+定义子元素作为捕捉点时的对齐方式。
+
+```css
+.snap-item {
+  /* 对齐到捕捉区域的 start（默认）、center 或 end） */
+  scroll-snap-align: start;
+  scroll-snap-align: center;
+  scroll-snap-align: end;
+  scroll-snap-align: none;
+}
+```
+
+- `start`：子元素对齐到滚动容器的**起始边缘**
+- `center`：子元素对齐到滚动容器的**中心**
+- `end`：子元素对齐到滚动容器的**结束边缘**
+- `none`：该子元素不作为捕捉点
+
+也可以分别设置两个方向：
+
+```css
+.snap-item {
+  /* scroll-snap-align: <block> <inline> */
+  scroll-snap-align: start center;
+}
+```
+
+> **与 `scroll-padding` 配合**：`scroll-padding` 设置在滚动容器上，可以调整捕捉区域的"有效边距"，使吸附位置更靠中间或留出边距。
+
+---
+
+### 3.3 `scroll-snap-stop`
+
+控制用户是否能够跳过捕捉点。
+
+```css
+.snap-item {
+  /* normal：不强制停在当前捕捉点，可继续滚动跳过 */
+  scroll-snap-stop: normal;
+
+  /* always：强制停在当前捕捉点，无法跳过 */
+  scroll-snap-stop: always;
+}
+```
+
+| 值 | 说明 |
+|----|------|
+| `normal` | 允许用户在一次滚动操作中越过多个捕捉点 |
+| `always` | 强制每个捕捉点都被"停留"一次，适用于精确分页场景 |
+
+> **典型场景：** 分页轮播图建议使用 `always`，确保每次滚动恰好停留在一页。
+
+---
+
+### 3.4 `scroll-padding` 系列
+
+`scroll-padding` 定义滚动容器的**内边距**，用于调整捕捉区域的"视觉中心"。
+
+```css
+.container {
+  scroll-padding: 20px;
+  scroll-padding-top: 10px;
+  scroll-padding-inline: auto;
+}
+```
+
+> **常见场景：** 顶部导航栏固定时，滚动容器设置 `scroll-padding-top` 可确保内容不被导航栏遮挡。
+
+---
+
+### 3.5 `scroll-margin` 系列
+
+`scroll-margin` 定义子元素的**外边距**，用于调整该元素作为捕捉目标时的偏移。
+
+```css
+.snap-item {
+  scroll-margin: 10px;
+  scroll-margin-top: 20px;
+}
+```
+
+> **典型场景：** 多个卡片需要向中间对齐，但又要保持卡片之间的间距时使用。
+
+---
+
+## 与 overflow 的配合
+
+Scroll Snap **必须**配合 `overflow` 属性使用，因为捕捉行为发生在滚动容器内部。
+
+```css
+.container {
+  /* 必须设置 overflow 才能触发滚动容器 */
+  overflow-x: auto;
+  overflow-y: auto;
+  /* 简写 */
+  overflow: auto;
+
+  /* 水平滚动 + 垂直隐藏 */
+  overflow-x: scroll;
+  overflow-y: hidden;
+
+  scroll-snap-type: x mandatory;
+}
+```
+
+### 关键规则
+
+1. **滚动容器必须有明确尺寸**：容器需要设置 `width`/`height` 或通过 `max-width`/`max-height` 约束，否则无法滚动。
+2. **子元素超出容器**：子元素内容总尺寸必须超过容器尺寸，才能触发滚动。
+3. **水平与垂直方向互不影响**：`overflow-x` 和 `overflow-y` 可独立设置，各自触发独立的滚动轴。
+
+```css
+/* 正确的完整配置 */
+.carousel {
+  display: flex;
+  width: 100vw;
+  overflow-x: scroll;       /* 启用水平滚动 */
+  scroll-snap-type: x mandatory;
+  -webkit-overflow-scrolling: touch; /* iOS 惯性滚动 */
+}
+
+.carousel > .slide {
+  flex: 0 0 100vw;          /* 每张幻灯片占满视口宽度 */
+  scroll-snap-align: start;
+}
+```
+
+---
+
+## 实战应用示例
+
+### 4.1 移动端全屏轮播图
+
+移动端常见的轮播图，每滑动一次切换一整屏内容。
+
+#### 目标分析
+
+- 每张幻灯片占满视口（`100vw × 100vh`）
+- 水平方向每次吸附到最近的幻灯片
+- 指示器（Dot）实时显示当前页码
+- 支持触摸滑动和 CSS 动画过渡
+
+#### HTML 结构
+
+```html
+<section class="carousel">
+  <div class="slide slide-1">1</div>
+  <div class="slide slide-2">2</div>
+  <div class="slide slide-3">3</div>
+  <div class="slide slide-4">4</div>
+</section>
+<nav class="dots">
+  <button class="dot active" aria-label="第1页"></button>
+  <button class="dot" aria-label="第2页"></button>
+  <button class="dot" aria-label="第3页"></button>
+  <button class="dot" aria-label="第4页"></button>
+</nav>
+```
+
+#### CSS 实现
+
+```css
+/* 滚动容器：关键配置 */
+.carousel {
+  display: flex;
+  width: 100vw;
+  height: 100vh;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  /* 核心：水平强制吸附 */
+  scroll-snap-type: x mandatory;
+  /* 平滑滚动到吸附点 */
+  scroll-behavior: smooth;
+  /* 隐藏滚动条（可选）*/
+  scrollbar-width: none;    /* Firefox */
+  -ms-overflow-style: none; /* IE/Edge */
+}
+.carousel::-webkit-scrollbar {
+  display: none;           /* Chrome/Safari */
+}
+
+/* 每张幻灯片：固定宽度等于视口宽度 */
+.slide {
+  flex: 0 0 100vw;        /* 不伸缩，宽度 100vw */
+  height: 100%;
+  scroll-snap-align: start; /* 对齐到容器起始边缘 */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 4rem;
+  color: #fff;
+}
+
+.slide-1 { background: #ff6b6b; }
+.slide-2 { background: #4ecdc4; }
+.slide-3 { background: #45b7d1; }
+.slide-4 { background: #96ceb4; }
+
+/* 指示器 */
+.dots {
+  display: flex;
+  justify-content: center;
+  gap: 8px;
+  margin-top: -40px;
+  position: relative;
+  z-index: 10;
+}
+.dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  border: none;
+  background: rgba(255, 255, 255, 0.5);
+  cursor: pointer;
+  transition: background 0.3s;
+}
+.dot.active {
+  background: #fff;
+}
+```
+
+#### JavaScript 交互（可选）
+
+```javascript
+const carousel = document.querySelector('.carousel');
+const dots = document.querySelectorAll('.dot');
+
+// 滚动停止后更新指示器
+carousel.addEventListener('scroll', () => {
+  const scrollLeft = carousel.scrollLeft;
+  const width = carousel.offsetWidth;
+  const index = Math.round(scrollLeft / width);
+
+  dots.forEach((dot, i) => {
+    dot.classList.toggle('active', i === index);
+  });
+});
+
+// 点击指示器跳转
+dots.forEach((dot, i) => {
+  dot.addEventListener('click', () => {
+    carousel.scrollTo({
+      left: i * carousel.offsetWidth,
+      behavior: 'smooth'
+    });
+  });
+});
+```
+
+---
+
+### 4.2 水平图片画廊
+
+图片画廊，每张图片捕捉到容器中心。
+
+```css
+.gallery {
+  display: flex;
+  width: 100vw;
+  overflow-x: scroll;
+  scroll-snap-type: x mandatory;
+  gap: 16px;
+  padding: 20px;
+  scrollbar-width: none;
+}
+.gallery::-webkit-scrollbar {
+  display: none;
+}
+
+.gallery img {
+  /* 固定宽度 + 强制居中对齐 */
+  flex: 0 0 80vw;
+  height: 60vh;
+  object-fit: cover;
+  scroll-snap-align: center;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+```
+
+---
+
+### 4.3 垂直滚动卡片列表
+
+类似抖音/小红书卡片流，每次滚动吸附一张卡片。
+
+```css
+.feed {
+  width: 100vw;
+  height: 100vh;
+  overflow-y: scroll;
+  scroll-snap-type: y mandatory;
+  scrollbar-width: none;
+}
+.feed::-webkit-scrollbar {
+  display: none;
+}
+
+.card {
+  width: 100vw;
+  height: 100vh;
+  scroll-snap-align: start;
+  scroll-snap-stop: always; /* 强制每张卡停一次 */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 3rem;
+}
+```
+
+---
+
+## 最佳实践与注意事项
+
+### 性能方面
+
+- **避免在滚动容器上同时触发布局抖动**：如动态改变子元素高度会导致重排，建议在滚动前固定尺寸。
+- **大量子元素时的性能**：`mandatory` 模式下每次滚动都会强制计算吸附点，子元素超过 50 个时建议评估渲染性能。
+- **硬件加速**：对于高频滚动的场景（如轮播图），可添加 `will-change: scroll-position` 提示浏览器优化：
+  ```css
+  .carousel {
+    will-change: scroll-position;
+  }
+  ```
+
+### 可访问性 (Accessibility)
+
+- **键盘导航**：`scroll-snap-type` 默认不响应键盘 `Tab` 切换，需额外监听键盘事件手动 `scrollTo()`。
+- **屏幕阅读器**：`aria-live` 或 `role="listbox"` 可帮助屏幕阅读器理解滚动区域。
+- **动画敏感性**：为尊重 `prefers-reduced-motion` 用户，可关闭吸附动画：
+  ```css
+  @media (prefers-reduced-motion: reduce) {
+    .carousel {
+      scroll-behavior: auto;
+    }
+  }
+  ```
+
+### 常见陷阱
+
+1. **容器无滚动**：`overflow` 未设置或子元素总尺寸未超出容器 → 无滚动，无吸附。
+2. **flex 子元素宽度问题**：flex 子元素默认不强制宽度，需设置 `flex: 0 0 <width>` 或 `width`。
+3. **Android 低版本卡顿**：部分 Android 浏览器需添加 `-webkit-overflow-scrolling: touch` 开启惯性滚动。
+4. **`mandatory` 导致无法自由滚动**：用户无法在一次手势中滑动多屏，如需保留自由滚动用 `proximity`。
+
+### 浏览器兼容性
+
+| 特性 | Chrome | Firefox | Safari | Edge |
+|------|--------|---------|--------|------|
+| `scroll-snap-type` | ✅ 69+ | ✅ 68+ | ✅ 11+ | ✅ 79+ |
+| `scroll-snap-align` | ✅ 69+ | ✅ 68+ | ✅ 11+ | ✅ 79+ |
+| `scroll-snap-stop` | ✅ 112+ | ✅ 68+ | ✅ 15+ | ✅ 112+ |
+| `scroll-padding` | ✅ 69+ | ✅ 68+ | ✅ 14+ | ✅ 79+ |
+| `scroll-margin` | ✅ 69+ | ✅ 68+ | ✅ 14+ | ✅ 79+ |
+
+> iOS Safari 14 以下版本对 `scroll-snap-stop: always` 支持有限，建议渐进增强。
+
+---
+
+## 总结
+
+### 核心知识点回顾
+
+- `scroll-snap-type` 定义滚动容器的捕捉类型和严格程度
+  - 轴向：`x`（水平）、`y`（垂直）、`both`（网格）、`none`
+  - 严格程度：`mandatory`（强制吸附）、`proximity`（接近时吸附）
+- `scroll-snap-align` 定义子元素作为捕捉点的对齐方式
+  - `start`（起始边缘）、`center`（中心）、`end`（结束边缘）
+- `scroll-snap-stop` 控制是否允许跳过捕捉点
+  - `normal`（允许跳过）、`always`（强制停留）
+- `scroll-padding`（容器）与 `scroll-margin`（子元素）调整吸附区域偏移
+- **必须配合 `overflow` 属性使用**，且滚动容器需有明确尺寸约束
+- `scroll-behavior: smooth` 可实现平滑吸附动画
+- 移动端建议同时设置 `-webkit-overflow-scrolling: touch`
+
+### 延伸阅读
+
+- [MDN: CSS Scroll Snap](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Scroll_snap)
+- [CSS-Tricks: Practical CSS Scroll Snapping](https://css-tricks.com/practical-css-scroll-snapping/)
+- [web.dev: Well-controlled scrolling with CSS scroll snap](https://web.dev/articles/css-scroll-snap)
+- [CSS Scroll Snap Module Level 1 - W3C](https://drafts.csswg.org/css-scroll-snap/)


### PR DESCRIPTION
## 交付内容

### 文档 src/topics/03.animation/css-scroll-snap/index.mdx
- scroll-snap-type 及 x/y/both 轴向属性详解
- scroll-snap-align（start/center/end）对齐方式
- scroll-snap-stop（normal/always）控制跳过行为
- scroll-padding 与 scroll-margin 调整吸附区域
- 与 overflow 的配合关系（必须设置 overflow 才能触发）
- 移动端全屏轮播图实战案例（HTML + CSS + JS 指示器）
- 水平图片画廊、垂直卡片流案例
- 浏览器兼容性表格、性能优化建议、可访问性注意事项

### 示例代码 examples/css/demos/css-scroll-snap/index.html
5 个可独立运行的完整演示：
1. 全屏轮播图（配合 JS 指示器联动）
2. mandatory vs proximity 对比
3. scroll-snap-stop 控制跳过
4. 垂直滚动吸附（小红书卡片流效果）
5. scroll-padding 调整吸附边距

### Playground 集成
- _demos/basic.html：基础水平滚动吸附演示

## 相关资源
- [MDN: CSS Scroll Snap](https://developer.mozilla.org/en-US/docs/Web/CSS/Guides/Scroll_snap)
- [CSS-Tricks: Practical CSS Scroll Snapping](https://css-tricks.com/practical-css-scroll-snapping/)