### PR TITLE
feat: CSS light-dark() 暗色模式切换函数

### DIFF
--- a/examples/css/demos/css-mask/01-circle-avatar.html
+++ b/examples/css/demos/css-mask/01-circle-avatar.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Mask - 圆形头像裁剪</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+      min-height: 100vh;
+      padding: 40px 20px;
+      color: #fff;
+    }
+
+    h1 {
+      text-align: center;
+      margin-bottom: 40px;
+      font-weight: 300;
+      font-size: 2rem;
+      letter-spacing: 2px;
+    }
+
+    .demo-container {
+      max-width: 900px;
+      margin: 0 auto;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+      gap: 30px;
+    }
+
+    .card {
+      background: rgba(255, 255, 255, 0.05);
+      border-radius: 16px;
+      padding: 30px;
+      text-align: center;
+      backdrop-filter: blur(10px);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    .card h3 {
+      margin-bottom: 20px;
+      font-size: 1rem;
+      color: rgba(255, 255, 255, 0.8);
+      font-weight: 400;
+    }
+
+    /* 基础图片样式 */
+    .avatar-base {
+      width: 150px;
+      height: 150px;
+      object-fit: cover;
+      display: block;
+      margin: 0 auto 15px;
+    }
+
+    /* 案例1：径向渐变圆形遮罩 */
+    .avatar-mask-1 {
+      mask-image: radial-gradient(
+        circle,
+        black 45%,
+        transparent 46%
+      );
+      -webkit-mask-image: radial-gradient(
+        circle,
+        black 45%,
+        transparent 46%
+      );
+    }
+
+    /* 案例2：带边框的圆形遮罩 */
+    .avatar-mask-2 {
+      position: relative;
+      border-radius: 50%;
+      overflow: hidden;
+    }
+
+    .avatar-mask-2::after {
+      content: '';
+      position: absolute;
+      inset: 0;
+      border-radius: 50%;
+      box-shadow: inset 0 0 0 4px rgba(255, 255, 255, 0.5);
+      pointer-events: none;
+    }
+
+    /* 案例3：渐变边缘 - 淡出效果 */
+    .avatar-fade {
+      mask-image: radial-gradient(
+        circle at center,
+        black 0%,
+        black 50%,
+        transparent 75%,
+        transparent 100%
+      );
+      -webkit-mask-image: radial-gradient(
+        circle at center,
+        black 0%,
+        black 50%,
+        transparent 75%,
+        transparent 100%
+      );
+    }
+
+    /* 案例4：椭圆遮罩 */
+    .avatar-oval {
+      mask-image: radial-gradient(
+        ellipse 50% 35% at 50% 50%,
+        black 0%,
+        black 100%,
+        transparent 100%
+      );
+      -webkit-mask-image: radial-gradient(
+        ellipse 50% 35% at 50% 50%,
+        black 0%,
+        black 100%,
+        transparent 100%
+      );
+    }
+
+    .desc {
+      font-size: 0.85rem;
+      color: rgba(255, 255, 255, 0.6);
+      line-height: 1.5;
+    }
+
+    .code-snippet {
+      background: rgba(0, 0, 0, 0.3);
+      border-radius: 8px;
+      padding: 15px;
+      margin-top: 15px;
+      font-family: 'Monaco', 'Consolas', monospace;
+      font-size: 0.75rem;
+      text-align: left;
+      color: #a8dadc;
+      white-space: pre-wrap;
+      overflow-x: auto;
+    }
+  </style>
+</head>
+<body>
+  <h1>CSS Mask 案例一：圆形头像裁剪</h1>
+
+  <div class="demo-container">
+    <!-- 案例1：标准圆形遮罩 -->
+    <div class="card">
+      <h3>径向渐变圆形</h3>
+      <img
+        src="https://picsum.photos/300/300?random=1"
+        alt="示例图片"
+        class="avatar-base avatar-mask-1"
+      >
+      <p class="desc">使用 radial-gradient 创建圆形遮罩，可任意尺寸自适应</p>
+      <div class="code-snippet">mask-image: radial-gradient(
+  circle,
+  black 45%,
+  transparent 46%
+);</div>
+    </div>
+
+    <!-- 案例2：带边框的圆形 -->
+    <div class="card">
+      <h3>带边框效果</h3>
+      <img
+        src="https://picsum.photos/300/300?random=2"
+        alt="示例图片"
+        class="avatar-base avatar-mask-1 avatar-mask-2"
+      >
+      <p class="desc">遮罩 + border-radius + inset shadow 实现边框效果</p>
+      <div class="code-snippet">mask-image: radial-gradient(
+  circle,
+  black 45%,
+  transparent 46%
+);</div>
+    </div>
+
+    <!-- 案例3：渐变淡出 -->
+    <div class="card">
+      <h3>边缘渐隐效果</h3>
+      <img
+        src="https://picsum.photos/300/300?random=3"
+        alt="示例图片"
+        class="avatar-base avatar-fade"
+      >
+      <p class="desc">径向渐变过渡区域实现边缘柔和淡出</p>
+      <div class="code-snippet">mask-image: radial-gradient(
+  circle at center,
+  black 0%,
+  black 50%,
+  transparent 75%,
+  transparent 100%
+);</div>
+    </div>
+
+    <!-- 案例4：椭圆遮罩 -->
+    <div class="card">
+      <h3>椭圆形状遮罩</h3>
+      <img
+        src="https://picsum.photos/300/300?random=4"
+        alt="示例图片"
+        class="avatar-base avatar-oval"
+      >
+      <p class="desc">使用 ellipse 创建椭圆/胶囊形状遮罩</p>
+      <div class="code-snippet">mask-image: radial-gradient(
+  ellipse 50% 35% at 50% 50%,
+  black 0%,
+  black 100%,
+  transparent 100%
+);</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-mask/02-text-gradient.html
+++ b/examples/css/demos/css-mask/02-text-gradient.html
@@ -1,0 +1,316 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Mask - 文字渐变效果</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0f0f1a;
+      min-height: 100vh;
+      padding: 40px 20px;
+      color: #fff;
+    }
+
+    h1 {
+      text-align: center;
+      margin-bottom: 50px;
+      font-weight: 300;
+      font-size: 2rem;
+      letter-spacing: 2px;
+    }
+
+    .demo-container {
+      max-width: 1000px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 60px;
+    }
+
+    .demo-section {
+      background: rgba(255, 255, 255, 0.02);
+      border-radius: 20px;
+      padding: 40px;
+      border: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .demo-section h2 {
+      font-size: 1.2rem;
+      margin-bottom: 30px;
+      color: rgba(255, 255, 255, 0.7);
+      font-weight: 400;
+    }
+
+    /* ========== 案例1：横向渐变遮罩文字 ========== */
+    .text-gradient-h {
+      font-size: 64px;
+      font-weight: 900;
+      display: inline-block;
+      background: linear-gradient(90deg, #667eea, #764ba2, #f64f59, #f64f59, #764ba2, #667eea);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+      mask-image: linear-gradient(
+        90deg,
+        black 0%,
+        black 20%,
+        transparent 40%,
+        transparent 60%,
+        black 80%,
+        black 100%
+      );
+      -webkit-mask-image: linear-gradient(
+        90deg,
+        black 0%,
+        black 20%,
+        transparent 40%,
+        transparent 60%,
+        black 80%,
+        black 100%
+      );
+    }
+
+    /* ========== 案例2：扫描线动画效果 ========== */
+    .text-scan {
+      font-size: 72px;
+      font-weight: 900;
+      display: inline-block;
+      position: relative;
+      background: linear-gradient(180deg, #11998e 0%, #38ef7d 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+    }
+
+    .text-scan::after {
+      content: attr(data-text);
+      position: absolute;
+      left: 0;
+      top: 0;
+      background: linear-gradient(90deg, #38ef7d, #11998e);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+      mask-image: linear-gradient(
+        to right,
+        transparent 0%,
+        black 30%,
+        black 70%,
+        transparent 100%
+      );
+      -webkit-mask-image: linear-gradient(
+        to right,
+        transparent 0%,
+        black 30%,
+        black 70%,
+        transparent 100%
+      );
+      animation: scan 2s ease-in-out infinite;
+    }
+
+    @keyframes scan {
+      0%, 100% { transform: translateX(-100%); }
+      50% { transform: translateX(100%); }
+    }
+
+    /* ========== 案例3：多色渐变文字 ========== */
+    .text-multi {
+      font-size: 56px;
+      font-weight: 900;
+      display: inline-block;
+      background: linear-gradient(
+        135deg,
+        #ff6b6b 0%,
+        #feca57 25%,
+        #48dbfb 50%,
+        #ff9ff3 75%,
+        #ff6b6b 100%
+      );
+      background-size: 200% 200%;
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+      mask-image: linear-gradient(
+        90deg,
+        transparent 0%,
+        black 10%,
+        black 90%,
+        transparent 100%
+      );
+      -webkit-mask-image: linear-gradient(
+        90deg,
+        transparent 0%,
+        black 10%,
+        black 90%,
+        transparent 100%
+      );
+      animation: gradientMove 3s ease infinite;
+    }
+
+    @keyframes gradientMove {
+      0% { background-position: 0% 50%; }
+      50% { background-position: 100% 50%; }
+      100% { background-position: 0% 50%; }
+    }
+
+    /* ========== 案例4：遮罩 Reveal 动画 ========== */
+    .text-reveal-container {
+      position: relative;
+      display: inline-block;
+      overflow: hidden;
+    }
+
+    .text-reveal {
+      font-size: 48px;
+      font-weight: 700;
+      display: block;
+      background: linear-gradient(45deg, #a8edea 0%, #fed6e3 100%);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+      transform: translateY(100%);
+      animation: revealUp 1s ease forwards;
+    }
+
+    .text-reveal-mask {
+      position: absolute;
+      inset: 0;
+      background: #0f0f1a;
+      animation: revealMask 1s ease forwards;
+    }
+
+    @keyframes revealUp {
+      to { transform: translateY(0); }
+    }
+
+    @keyframes revealMask {
+      to { transform: translateY(-100%); }
+    }
+
+    /* ========== 案例5：光晕文字 ========== */
+    .text-glow {
+      font-size: 64px;
+      font-weight: 900;
+      display: inline-block;
+      position: relative;
+      color: #fff;
+      text-shadow: 0 0 40px rgba(255, 107, 107, 0.8);
+    }
+
+    .text-glow::before {
+      content: attr(data-text);
+      position: absolute;
+      left: 0;
+      top: 0;
+      background: linear-gradient(45deg, #ff6b6b, #feca57, #ff6b6b);
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+      mask-image: radial-gradient(
+        ellipse at center,
+        black 0%,
+        black 30%,
+        transparent 60%
+      );
+      -webkit-mask-image: radial-gradient(
+        ellipse at center,
+        black 0%,
+        black 30%,
+        transparent 60%
+      );
+      opacity: 0.8;
+    }
+
+    .desc {
+      text-align: center;
+      margin-top: 20px;
+      font-size: 0.85rem;
+      color: rgba(255, 255, 255, 0.5);
+    }
+
+    .row {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 60px;
+      flex-wrap: wrap;
+    }
+  </style>
+</head>
+<body>
+  <h1>CSS Mask 案例二：文字渐变效果</h1>
+
+  <div class="demo-container">
+    <!-- 案例1：横向渐变遮罩 -->
+    <div class="demo-section">
+      <h2>1. 横向渐变遮罩</h2>
+      <div class="row">
+        <span class="text-gradient-h">GRADIENT</span>
+      </div>
+      <p class="desc">
+        使用 linear-gradient 遮罩实现左右两端透明过渡的效果<br>
+        mask-image 控制文字只在中间 20%-80% 区域可见
+      </p>
+    </div>
+
+    <!-- 案例2：扫描线动画 -->
+    <div class="demo-section">
+      <h2>2. 扫描线动画</h2>
+      <div class="row">
+        <span class="text-scan" data-text="SCAN">SCAN</span>
+      </div>
+      <p class="desc">
+        利用 mask 的半透明特性实现光束扫过文字的动画效果<br>
+        通过 ::after 伪元素叠加，并使用 mask 控制可见区域
+      </p>
+    </div>
+
+    <!-- 案例3：多色渐变动画 -->
+    <div class="demo-section">
+      <h2>3. 多色渐变 + 动态背景</h2>
+      <div class="row">
+        <span class="text-multi">RAINBOW</span>
+      </div>
+      <p class="desc">
+        背景渐变 + mask 遮罩 + background-position 动画<br>
+        实现彩虹渐变流动穿过文字的效果
+      </p>
+    </div>
+
+    <!-- 案例4：遮罩 Reveal 动画 -->
+    <div class="demo-section">
+      <h2>4. 遮罩 Reveal 入场动画</h2>
+      <div class="row">
+        <div class="text-reveal-container">
+          <div class="text-reveal-mask"></div>
+          <span class="text-reveal">REVEAL</span>
+        </div>
+      </div>
+      <p class="desc">
+        文字上方覆盖遮罩层，动画移除遮罩的同时文字上移入场<br>
+        遮罩层下移消失，文字从下方渐入
+      </p>
+    </div>
+
+    <!-- 案例5：光晕文字 -->
+    <div class="demo-section">
+      <h2>5. 光晕中心渐变</h2>
+      <div class="row">
+        <span class="text-glow" data-text="GLOW">GLOW</span>
+      </div>
+      <p class="desc">
+        使用 radial-gradient 遮罩实现中心亮、边缘暗的光晕效果<br>
+        结合 text-shadow 增强氛围感
+      </p>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-scope/index.html
+++ b/examples/css/demos/css-scope/index.html
@@ -1,0 +1,346 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS @scope 特性演示</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #f5f5f5;
+      padding: 24px;
+      line-height: 1.6;
+    }
+
+    h1 { text-align: center; margin-bottom: 32px; color: #333; }
+    h2 { margin: 32px 0 16px; color: #1a1a1a; border-bottom: 2px solid #ddd; padding-bottom: 8px; }
+
+    .demo-section {
+      background: #fff;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 24px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
+      margin-top: 16px;
+    }
+
+    p { margin: 8px 0; }
+
+    /* ============================================
+       演示 1：基础 @scope 用法
+       ============================================ */
+    .card {
+      border: 1px solid #e0e0e0;
+      border-radius: 8px;
+      padding: 16px;
+      background: #fff;
+    }
+
+    @scope (.card) {
+      :scope {
+        background: #e8f5e9;
+        border-color: #4caf50;
+      }
+      .card__title {
+        font-size: 18px;
+        font-weight: bold;
+        color: #2e7d32;
+      }
+      img {
+        border: 3px solid #4caf50;
+        border-radius: 8px;
+      }
+      .card__img {
+        width: 100%;
+        height: 100px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #2e7d32;
+        font-size: 14px;
+      }
+    }
+
+    /* ============================================
+       演示 2：Donut Scope
+       ============================================ */
+    .donut-card {
+      border: 2px solid #e0e0e0;
+      border-radius: 12px;
+      padding: 16px;
+      background: #fff;
+    }
+    .donut-card__body { padding: 16px 0; }
+
+    @scope (.donut-card) to (.donut-card__footer) {
+      img {
+        border: 3px solid #ff9800;
+        background: #fff3e0;
+        padding: 8px;
+        border-radius: 4px;
+      }
+      .highlight-text {
+        background: #fff3e0;
+        color: #e65100;
+        padding: 4px 8px;
+        border-radius: 4px;
+      }
+    }
+
+    /* ============================================
+       演示 3：主题作用域
+       ============================================ */
+    .theme--light { background: #f5f5f5; padding: 16px; border-radius: 8px; }
+    .theme--dark { background: #212121; color: #fff; padding: 16px; border-radius: 8px; }
+
+    @scope (.theme--light) {
+      :scope { background: #f5f5f5; }
+      a { color: #1976d2; font-weight: 500; }
+      .box { background: #fff; border: 1px solid #1976d2; }
+    }
+    @scope (.theme--dark) {
+      :scope { background: #212121; color: #fff; }
+      a { color: #90caf9; font-weight: 500; }
+      .box { background: #424242; border: 1px solid #90caf9; }
+    }
+
+    /* ============================================
+       演示 4：组件样式隔离
+       ============================================ */
+    .btn-container-primary .btn,
+    .btn-container-danger .btn {
+      padding: 10px 20px;
+      border-radius: 6px;
+      border: 2px solid transparent;
+      font-size: 15px;
+      font-weight: 500;
+      cursor: pointer;
+    }
+    @scope (.btn-container-primary) {
+      .btn { background: #2196f3; color: #fff; border-color: #1976d2; }
+      .btn:hover { background: #1976d2; }
+    }
+    @scope (.btn-container-danger) {
+      .btn { background: #f44336; color: #fff; border-color: #d32f2f; }
+      .btn:hover { background: #d32f2f; }
+    }
+
+    /* ============================================
+       演示 5：嵌套组件 &
+       ============================================ */
+    .nested-card {
+      border: 2px solid #9c27b0;
+      border-radius: 12px;
+      padding: 16px;
+      background: #f3e5f5;
+    }
+    @scope (.nested-card) {
+      .title { color: #7b1fa2; font-size: 16px; font-weight: bold; }
+      & & {
+        border-color: #ce93d8;
+        background: #f3e5f5;
+        margin-top: 8px;
+      }
+      & & .title { font-size: 14px; }
+    }
+
+    /* ============================================
+       外部对比
+       ============================================ */
+    .external-box {
+      border: 3px dashed #f44336;
+      padding: 16px;
+      background: #ffebee;
+      border-radius: 8px;
+      margin-top: 16px;
+    }
+
+    .code-block {
+      background: #263238;
+      color: #aed581;
+      padding: 16px;
+      border-radius: 8px;
+      font-family: 'Fira Code', 'Consolas', monospace;
+      font-size: 13px;
+      overflow-x: auto;
+      margin: 16px 0;
+      white-space: pre;
+    }
+
+    .badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 12px;
+      font-weight: bold;
+      margin-left: 8px;
+    }
+    .badge-green { background: #4caf50; color: #fff; }
+    .badge-orange { background: #ff9800; color: #fff; }
+    .badge-blue { background: #2196f3; color: #fff; }
+    .badge-purple { background: #9c27b0; color: #fff; }
+
+    .note {
+      background: #fff3cd;
+      border-left: 4px solid #ffc107;
+      padding: 12px 16px;
+      border-radius: 0 8px 8px 0;
+      margin: 16px 0;
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+  <h1>CSS <code>@scope</code> 特性演示</h1>
+
+  <!-- 演示 1：基础 @scope -->
+  <div class="demo-section">
+    <h2>1. 基础 <code>@scope</code> 用法 <span class="badge badge-green">作用域根</span></h2>
+    <p>通过设置作用域根为 <code>.card</code>，块内的 <code>img</code> 选择器只会影响 <code>.card</code> 内部的图片。</p>
+    <div class="demo-grid">
+      <div class="card">
+        <div class="card__title">Card 标题</div>
+        <div class="card__img">图片区域</div>
+        <p>这是卡片内部的内容</p>
+      </div>
+      <div class="card">
+        <div class="card__title">另一个 Card</div>
+        <div class="card__img">另一个图片区域</div>
+      </div>
+    </div>
+    <div class="external-box">
+      <strong>外部区域（不受 .card 作用域影响）</strong>
+      <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='120' height='60' viewBox='0 0 120 60'><rect fill='%23ff5722' width='120' height='60'/><text x='60' y='35' text-anchor='middle' fill='white' font-size='14'>外部图片</text></svg>" alt="外部图片" style="display:block;margin-top:8px;border-radius:4px;">
+    </div>
+    <div class="code-block">@scope (.card) {
+  :scope { background: #e8f5e9; }
+  .card__title { font-weight: bold; }
+  img { border: 3px solid #4caf50; }
+}</div>
+  </div>
+
+  <!-- 演示 2：Donut Scope -->
+  <div class="demo-section">
+    <h2>2. Donut Scope（带下限的作用域） <span class="badge badge-orange">排除子树</span></h2>
+    <p>通过 <code>to (.donut-card__footer)</code> 设置下限，下限内的元素被排除在作用域外。</p>
+    <div class="donut-card">
+      <div class="card__title" style="color:#e65100;font-weight:bold;">Donut Card</div>
+      <div class="donut-card__body">
+        <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='80' height='40' viewBox='0 0 80 40'><rect fill='%23ff9800' width='80' height='40' rx='4'/><text x='40' y='25' text-anchor='middle' fill='white' font-size='12'>在作用域内</text></svg>" alt="作用域内图片">
+        <p class="highlight-text">高亮文本，在作用域内</p>
+      </div>
+      <div class="donut-card__footer">
+        <img src="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' width='80' height='40' viewBox='0 0 80 40'><rect fill='%239e9e9e' width='80' height='40' rx='4'/><text x='40' y='25' text-anchor='middle' fill='white' font-size='12'>在作用域外</text></svg>" alt="作用域外图片">
+        <p style="color:#999;">这是普通文本，跳出了作用域</p>
+      </div>
+    </div>
+    <div class="code-block">@scope (.donut-card) to (.donut-card__footer) {
+  img { border: 3px solid #ff9800; }
+  .highlight-text { background: #fff3e0; }
+}</div>
+  </div>
+
+  <!-- 演示 3：主题作用域 -->
+  <div class="demo-section">
+    <h2>3. 主题作用域与 Scoping Proximity <span class="badge badge-blue">邻近性</span></h2>
+    <p>CSS 级联新增 <strong>Scoping Proximity</strong> 步骤。嵌套主题时，跳数更少的作用域优先。</p>
+    <div class="theme--light">
+      <p>外部浅色主题：<a href="#">蓝色链接</a></p>
+      <div class="box" style="padding:8px;margin-top:8px;border-radius:4px;">浅色盒子</div>
+      <div class="theme--dark" style="margin-top:16px;">
+        <p>嵌套深色主题：<a href="#">浅蓝色链接</a></p>
+        <div class="box" style="padding:8px;margin-top:8px;border-radius:4px;">深色盒子</div>
+        <div class="theme--light" style="margin-top:16px;">
+          <p>再次嵌套回浅色：<a href="#">蓝色链接（虽被 dark 包裹，但离 .theme--light 更近）</a></p>
+          <div class="box" style="padding:8px;margin-top:8px;border-radius:4px;">浅色盒子（嵌套层离它更近）</div>
+        </div>
+      </div>
+    </div>
+    <div class="code-block">@scope (.theme--light) { a { color: #1976d2; } }
+@scope (.theme--dark) { a { color: #90caf9; } }
+/* 级联顺序: specificity -> scoping-proximity -> order */
+/* 第三个链接离浅色主题 1 跳，离深色 2 跳，浅色优先 */</div>
+  </div>
+
+  <!-- 演示 4：组件样式隔离 -->
+  <div class="demo-section">
+    <h2>4. 组件样式隔离</h2>
+    <p>不同容器的同名类可以有不同的样式，无需 BEM 复杂命名。</p>
+    <div class="demo-grid">
+      <div class="btn-container-primary">
+        <p style="font-size:13px;color:#666;margin-bottom:8px;">.btn-container-primary 内的按钮：</p>
+        <button class="btn">主要按钮</button>
+      </div>
+      <div class="btn-container-danger">
+        <p style="font-size:13px;color:#666;margin-bottom:8px;">.btn-container-danger 内的按钮：</p>
+        <button class="btn">危险按钮</button>
+      </div>
+    </div>
+    <div class="code-block">@scope (.btn-container-primary) { .btn { background: #2196f3; } }
+@scope (.btn-container-danger) { .btn { background: #f44336; } }
+/* 同名 .btn 类在不同作用域内呈现不同样式 */</div>
+  </div>
+
+  <!-- 演示 5：嵌套组件 & -->
+  <div class="demo-section">
+    <h2>5. 嵌套组件与 <code>&</code> 选择器 <span class="badge badge-purple">& 嵌套</span></h2>
+    <p><code>&</code> 可重复使用选择嵌套在同类的元素，<code>:scope</code> 无法做到这一点。</p>
+    <div class="nested-card">
+      <div class="title">第一层卡片</div>
+      <div class="nested-card">
+        <div class="title">第二层卡片（嵌套）</div>
+        <div class="nested-card">
+          <div class="title">第三层卡片（更深嵌套）</div>
+        </div>
+      </div>
+    </div>
+    <div class="code-block">@scope (.nested-card) {
+  .title { color: #7b1fa2; }
+  & & { border-color: #ce93d8; background: #f3e5f5; }
+  & & .title { font-size: 14px; }
+}</div>
+  </div>
+
+  <!-- 演示 6：选择器隔离 ≠ 样式隔离 -->
+  <div class="demo-section">
+    <h2>6. 重要提示：选择器隔离 ≠ 样式隔离</h2>
+    <div class="note">
+      <code>@scope</code> 限制的是<strong>选择器的触及范围</strong>，但<strong>继承属性</strong>（如 <code>color</code>）仍然会穿透下限继承到子元素。
+    </div>
+    <div class="donut-card" style="border-color:#f44336;">
+      <div class="card__title" style="color:#d32f2f;">样式继承示例</div>
+      <div class="donut-card__body">
+        <p style="background:#ffebee;color:#d32f2f;padding:8px;border-radius:4px;">
+          在作用域内，继承了 <code>color: #d32f2f</code>
+        </p>
+      </div>
+      <div class="donut-card__footer">
+        <p style="background:#fce4ec;color:#d32f2f;padding:8px;border-radius:4px;margin-top:8px;">
+          跳出了作用域，但 color 仍然继承自父级
+        </p>
+      </div>
+    </div>
+    <div class="code-block">@scope (.card) to (.card__content) {
+  :scope { color: hotpink; }  /* 继承属性会穿透下限 */
+}</div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const orig = btn.closest('.btn-container-danger') ? '危险按钮' : '主要按钮';
+        btn.textContent = '点击成功 ✓';
+        setTimeout(() => { btn.textContent = orig; }, 1000);
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/design-token/color-tokens.html
+++ b/examples/css/demos/design-token/color-tokens.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>颜色令牌 - Color Tokens</title>
+  <style>
+    :root {
+      --palette-blue-50: #eff6ff; --palette-blue-100: #dbeafe; --palette-blue-200: #bfdbfe; --palette-blue-300: #93c5fd; --palette-blue-400: #60a5fa; --palette-blue-500: #3b82f6; --palette-blue-600: #2563eb; --palette-blue-700: #1d4ed8; --palette-blue-800: #1e40af; --palette-blue-900: #1e3a8a;
+      --palette-gray-50: #f9fafb; --palette-gray-100: #f3f4f6; --palette-gray-200: #e5e7eb; --palette-gray-300: #d1d5db; --palette-gray-400: #9ca3af; --palette-gray-500: #6b7280; --palette-gray-600: #4b5563; --palette-gray-700: #374151; --palette-gray-800: #1f2937; --palette-gray-900: #111827;
+      --color-primary: var(--palette-blue-500); --color-primary-hover: var(--palette-blue-600);
+      --color-surface: var(--palette-gray-50); --color-surface-elevated: #ffffff;
+      --color-text: var(--palette-gray-900); --color-text-muted: var(--palette-gray-500); --color-border: var(--palette-gray-200);
+      --color-success: #10b981; --color-warning: #f59e0b; --color-error: #ef4444;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, sans-serif; background: var(--color-surface); color: var(--color-text); padding: 2rem; line-height: 1.6; }
+    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+    .subtitle { color: var(--color-text-muted); margin-bottom: 2rem; }
+    .section { background: var(--color-surface-elevated); border: 1px solid var(--color-border); border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    .section-title { font-size: 1rem; font-weight: 600; margin-bottom: 1rem; }
+    .swatch-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(100px, 1fr)); gap: 0.75rem; }
+    .swatch { border-radius: 8px; overflow: hidden; border: 1px solid var(--color-border); }
+    .swatch-color { height: 60px; }
+    .swatch-label { padding: 0.5rem; font-size: 0.75rem; font-family: monospace; background: var(--color-surface-elevated); text-align: center; }
+    .color-demo-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr)); gap: 1rem; }
+    .color-card { border-radius: 8px; padding: 1rem; border: 1px solid var(--color-border); }
+    .color-card .label { font-size: 0.875rem; font-weight: 500; margin-bottom: 0.5rem; }
+    .color-card .value { font-size: 0.75rem; font-family: monospace; color: var(--color-text-muted); background: rgba(0,0,0,0.05); padding: 0.25rem 0.5rem; border-radius: 4px; display: inline-block; }
+    .card-primary { background: var(--color-primary); color: #fff; }
+    .card-primary-hover { background: var(--color-primary-hover); color: #fff; }
+    .card-surface { background: var(--color-surface); border: 1px solid var(--color-border); }
+    .card-text { background: var(--color-text); color: #fff; }
+    .card-text-muted { background: var(--color-text-muted); color: #fff; }
+    .card-border { background: var(--color-surface-elevated); border: 1px solid var(--color-border); }
+    .card-success { background: var(--color-success); color: #fff; }
+    .card-warning { background: var(--color-warning); color: #fff; }
+    .card-error { background: var(--color-error); color: #fff; }
+  </style>
+</head>
+<body>
+  <h1>颜色令牌 - Color Tokens</h1>
+  <p class="subtitle">Option Token 定义原始色板 &rarr; Decision Token 定义语义化颜色</p>
+  <div class="section">
+    <div class="section-title">Option Token - 蓝色色板</div>
+    <div class="swatch-grid">
+      <div class="swatch"><div class="swatch-color" style="background: var(--palette-blue-50)"></div><div class="swatch-label">blue-50</div></div>
+      <div class="swatch"><div class="swatch-color" style="background: var(--palette-blue-100)"></div><div class="swatch-label">blue-100</div></div>
+      <div class="swatch"><div class="swatch-color" style="background: var(--palette-blue-200)"></div><div class="swatch-label">blue-200</div></div>
+      <div class="swatch"><div class="swatch-color" style="background: var(--palette-blue-300)"></div><div class="swatch-label">blue-300</div></div>
+      <div class="swatch"><div class="swatch-color" style="background: var(--palette-blue-400)"></div><div class="swatch-label">blue-400</div></div>
+      <div class="swatch"><div class="swatch-color" style="background: var(--palette-blue-500)"></div><div class="swatch-label">blue-500</div></div>
+      <div class="swatch"><div class="swatch-color" style="background: var(--palette-blue-600)"></div><div class="swatch-label">blue-600</div></div>
+      <div class="swatch"><div class="swatch-color" style="background: var(--palette-blue-700)"></div><div class="swatch-label">blue-700</div></div>
+      <div class="swatch"><div class="swatch-color" style="background: var(--palette-blue-800)"></div><div class="swatch-label">blue-800</div></div>
+      <div class="swatch"><div class="swatch-color" style="background: var(--palette-blue-900)"></div><div class="swatch-label">blue-900</div></div>
+    </div>
+  </div>
+  <div class="section">
+    <div class="section-title">Decision Token - 语义化颜色</div>
+    <div class="color-demo-grid">
+      <div class="color-card card-primary"><div class="label">Primary</div><div class="value">var(--color-primary)</div></div>
+      <div class="color-card card-primary-hover"><div class="label">Primary Hover</div><div class="value">var(--color-primary-hover)</div></div>
+      <div class="color-card card-surface"><div class="label">Surface</div><div class="value">var(--color-surface)</div></div>
+      <div class="color-card card-text"><div class="label">Text</div><div class="value">var(--color-text)</div></div>
+      <div class="color-card card-text-muted"><div class="label">Text Muted</div><div class="value">var(--color-text-muted)</div></div>
+      <div class="color-card card-border"><div class="label">Border</div><div class="value">var(--color-border)</div></div>
+      <div class="color-card card-success"><div class="label">Success</div><div class="value">var(--color-success)</div></div>
+      <div class="color-card card-warning"><div class="label">Warning</div><div class="value">var(--color-warning)</div></div>
+      <div class="color-card card-error"><div class="label">Error</div><div class="value">var(--color-error)</div></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/design-token/design-system.html
+++ b/examples/css/demos/design-token/design-system.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>设计系统组件 - Design System Components</title>
+  <style>
+    :root {
+      --color-bg: #ffffff; --color-surface: #f9fafb; --color-surface-elevated: #ffffff;
+      --color-text: #111827; --color-text-muted: #6b7280; --color-text-inverse: #ffffff;
+      --color-border: #e5e7eb; --color-primary: #3b82f6; --color-primary-hover: #2563eb;
+      --color-primary-subtle: #eff6ff; --color-success: #10b981; --color-success-subtle: #ecfdf5;
+      --color-warning: #f59e0b; --color-warning-subtle: #fffbeb; --color-error: #ef4444; --color-error-subtle: #fef2f2;
+      --font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --font-family-mono: 'JetBrains Mono', monospace;
+      --font-size-xs: 0.75rem; --font-size-sm: 0.875rem; --font-size-base: 1rem;
+      --font-size-lg: 1.125rem; --font-size-xl: 1.25rem; --font-size-2xl: 1.5rem;
+      --font-weight-normal: 400; --font-weight-medium: 500; --font-weight-semibold: 600; --font-weight-bold: 700;
+      --line-height-normal: 1.5;
+      --space-1: 0.25rem; --space-2: 0.5rem; --space-3: 0.75rem; --space-4: 1rem; --space-5: 1.25rem; --space-6: 1.5rem; --space-8: 2rem;
+      --radius-sm: 0.25rem; --radius-md: 0.375rem; --radius-lg: 0.5rem; --radius-xl: 0.75rem; --radius-full: 9999px;
+      --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05); --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: var(--font-family); background: var(--color-bg); color: var(--color-text); padding: 2rem; line-height: var(--line-height-normal); }
+    .demo-title { font-size: var(--font-size-2xl); font-weight: var(--font-weight-bold); margin-bottom: var(--space-2); }
+    .demo-subtitle { color: var(--color-text-muted); margin-bottom: var(--space-8); }
+    .demo-section { margin-bottom: var(--space-8); }
+    .demo-section-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: var(--space-4); }
+    .demo-section-desc { color: var(--color-text-muted); font-size: var(--font-size-sm); margin-bottom: var(--space-4); }
+    .btn { display: inline-flex; align-items: center; justify-content: center; gap: var(--space-2); padding: var(--space-2) var(--space-4); font-family: var(--font-family); font-size: var(--font-size-sm); font-weight: var(--font-weight-medium); line-height: 1.5; border-radius: var(--radius-md); border: 1px solid transparent; cursor: pointer; transition: all 0.15s ease; text-decoration: none; }
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .btn-primary { background: var(--color-primary); color: var(--color-text-inverse); }
+    .btn-primary:hover:not(:disabled) { background: var(--color-primary-hover); }
+    .btn-secondary { background: var(--color-surface); color: var(--color-text); border-color: var(--color-border); }
+    .btn-secondary:hover:not(:disabled) { background: var(--color-surface-elevated); }
+    .btn-success { background: var(--color-success); color: var(--color-text-inverse); }
+    .btn-error { background: var(--color-error); color: var(--color-text-inverse); }
+    .btn-lg { padding: var(--space-3) var(--space-6); font-size: var(--font-size-base); }
+    .btn-sm { padding: var(--space-1) var(--space-3); font-size: var(--font-size-xs); }
+    .btn-group { display: flex; gap: var(--space-3); flex-wrap: wrap; align-items: center; }
+    .form-group { margin-bottom: var(--space-4); }
+    .form-label { display: block; font-size: var(--font-size-sm); font-weight: var(--font-weight-medium); margin-bottom: var(--space-2); }
+    .form-error { font-size: var(--font-size-xs); color: var(--color-error); margin-top: var(--space-1); }
+    .input { width: 100%; padding: var(--space-2) var(--space-3); font-family: var(--font-family); font-size: var(--font-size-sm); background: var(--color-bg); border: 1px solid var(--color-border); border-radius: var(--radius-md); color: var(--color-text); transition: border-color 0.15s, box-shadow 0.15s; }
+    .input:focus { outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.15); }
+    .input-error { border-color: var(--color-error); }
+    .input-success { border-color: var(--color-success); }
+    .card { background: var(--color-surface-elevated); border: 1px solid var(--color-border); border-radius: var(--radius-xl); padding: var(--space-6); box-shadow: var(--shadow-sm); }
+    .card-sm { padding: var(--space-4); }
+    .card-title { font-size: var(--font-size-lg); font-weight: var(--font-weight-semibold); margin-bottom: var(--space-2); }
+    .card-text { font-size: var(--font-size-sm); color: var(--color-text-muted); margin-bottom: var(--space-4); }
+    .badge { display: inline-flex; align-items: center; padding: var(--space-1) var(--space-2); font-size: var(--font-size-xs); font-weight: var(--font-weight-medium); border-radius: var(--radius-full); }
+    .badge-primary { background: var(--color-primary-subtle); color: var(--color-primary); }
+    .badge-success { background: var(--color-success-subtle); color: var(--color-success); }
+    .badge-warning { background: var(--color-warning-subtle); color: var(--color-warning); }
+    .badge-error { background: var(--color-error-subtle); color: var(--color-error); }
+    .alert { display: flex; align-items: flex-start; gap: var(--space-3); padding: var(--space-4); border-radius: var(--radius-lg); border: 1px solid; font-size: var(--font-size-sm); }
+    .alert-success { background: var(--color-success-subtle); border-color: var(--color-success); color: #065f46; }
+    .alert-warning { background: var(--color-warning-subtle); border-color: var(--color-warning); color: #92400e; }
+    .alert-error { background: var(--color-error-subtle); border-color: var(--color-error); color: #991b1b; }
+    .alert-info { background: var(--color-primary-subtle); border-color: var(--color-primary); color: #1e40af; }
+    .alert-icon { width: 20px; height: 20px; flex-shrink: 0; }
+    .grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-4); }
+    @media (max-width: 768px) { .grid-3 { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <div class="demo-title">设计系统组件</div>
+  <p class="demo-subtitle">使用 Design Token 构建的一致性 UI 组件</p>
+
+  <div class="demo-section">
+    <div class="demo-section-title">Button 按钮</div>
+    <p class="demo-section-desc">通过 Token 统一管理按钮的尺寸、圆角、间距和颜色状态。</p>
+    <div class="btn-group">
+      <button class="btn btn-primary">主要按钮</button>
+      <button class="btn btn-secondary">次要按钮</button>
+      <button class="btn btn-success">成功</button>
+      <button class="btn btn-error">错误</button>
+      <button class="btn btn-primary" disabled>禁用</button>
+    </div>
+    <div class="btn-group" style="margin-top: 1rem;">
+      <button class="btn btn-primary btn-lg">大按钮</button>
+      <button class="btn btn-primary">默认</button>
+      <button class="btn btn-primary btn-sm">小按钮</button>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <div class="demo-section-title">Input 输入框</div>
+    <p class="demo-section-desc">输入框样式通过 Token 定义，支持多种状态反馈。</p>
+    <div style="max-width: 400px;">
+      <div class="form-group">
+        <label class="form-label">默认状态</label>
+        <input type="text" class="input" placeholder="请输入...">
+      </div>
+      <div class="form-group">
+        <label class="form-label">成功状态</label>
+        <input type="text" class="input input-success" value="输入正确">
+      </div>
+      <div class="form-group">
+        <label class="form-label">错误状态</label>
+        <input type="text" class="input input-error" value="格式错误">
+        <div class="form-error">请输入有效的邮箱地址</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <div class="demo-section-title">Card 卡片</div>
+    <p class="demo-section-desc">卡片组件使用统一的间距和圆角 Token。</p>
+    <div class="grid-3">
+      <div class="card">
+        <div class="card-title">卡片标题</div>
+        <div class="card-text">卡片内容使用语义化间距令牌，保持与其他组件的比例协调。</div>
+        <span class="badge badge-primary">标签</span>
+      </div>
+      <div class="card card-sm">
+        <div class="card-title" style="font-size: var(--font-size-base);">小卡片</div>
+        <div class="card-text" style="font-size: var(--font-size-xs);">紧凑布局，适用于列表项。</div>
+        <span class="badge badge-success">完成</span>
+      </div>
+      <div class="card">
+        <div class="card-title">卡片标题</div>
+        <div class="card-text">支持多种内容组合方式。</div>
+        <div class="btn-group">
+          <button class="btn btn-primary btn-sm">操作</button>
+          <button class="btn btn-secondary btn-sm">取消</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <div class="demo-section-title">Badge 徽标</div>
+    <div class="btn-group">
+      <span class="badge badge-primary">主要</span>
+      <span class="badge badge-success">成功</span>
+      <span class="badge badge-warning">警告</span>
+      <span class="badge badge-error">错误</span>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <div class="demo-section-title">Alert 提示</div>
+    <div style="display: flex; flex-direction: column; gap: 0.75rem; max-width: 500px;">
+      <div class="alert alert-success">
+        <svg class="alert-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"/></svg>
+        <span>操作成功完成，数据已保存。</span>
+      </div>
+      <div class="alert alert-warning">
+        <svg class="alert-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"/></svg>
+        <span>此操作不可撤销，请确认后再继续。</span>
+      </div>
+      <div class="alert alert-error">
+        <svg class="alert-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+        <span>网络连接失败，请检查网络设置。</span>
+      </div>
+      <div class="alert alert-info">
+        <svg class="alert-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+        <span>系统将于今晚 22:00 进行维护升级。</span>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/design-token/spacing-tokens.html
+++ b/examples/css/demos/design-token/spacing-tokens.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>间距令牌 - Spacing Tokens</title>
+  <style>
+    :root {
+      --space-1: 0.25rem; --space-2: 0.5rem; --space-3: 0.75rem; --space-4: 1rem;
+      --space-5: 1.25rem; --space-6: 1.5rem; --space-8: 2rem;
+      --space-10: 2.5rem; --space-12: 3rem; --space-16: 4rem;
+      --spacing-xs: var(--space-1); --spacing-sm: var(--space-2);
+      --spacing-md: var(--space-4); --spacing-lg: var(--space-6);
+      --spacing-xl: var(--space-8); --spacing-2xl: var(--space-12);
+      --radius-md: 0.375rem; --radius-lg: 0.5rem;
+      --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+      --color-primary: #3b82f6;
+      --color-bg: #ffffff; --color-surface: #f9fafb;
+      --color-surface-elevated: #ffffff;
+      --color-text: #111827; --color-text-muted: #6b7280;
+      --color-border: #e5e7eb;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, sans-serif; background: var(--color-bg); color: var(--color-text); padding: 2rem; }
+    h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+    .subtitle { color: var(--color-text-muted); margin-bottom: 2rem; }
+    .section { border: 1px solid var(--color-border); border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; }
+    .section-title { font-size: 0.875rem; font-weight: 600; color: var(--color-text-muted); text-transform: uppercase; margin-bottom: 1rem; }
+    .spacing-row { display: flex; align-items: center; gap: 1rem; margin-bottom: 0.75rem; }
+    .spacing-name { width: 100px; font-family: monospace; font-size: 0.75rem; color: var(--color-text-muted); flex-shrink: 0; }
+    .spacing-bar-container { flex: 1; height: 24px; background: #f3f4f6; border-radius: 4px; overflow: hidden; max-width: 400px; }
+    .spacing-bar { height: 100%; background: var(--color-primary); display: flex; align-items: center; justify-content: flex-end; padding-right: 0.5rem; color: white; font-size: 0.7rem; font-weight: 500; min-width: 24px; }
+    .card { background: var(--color-surface-elevated); border: 1px solid var(--color-border); border-radius: var(--radius-lg); padding: var(--spacing-lg); box-shadow: var(--shadow-sm); }
+    .card-title { font-size: 1.125rem; font-weight: 600; margin-bottom: var(--spacing-sm); }
+    .card-text { color: var(--color-text-muted); font-size: 0.875rem; margin-bottom: var(--spacing-md); }
+    .card-actions { display: flex; gap: var(--spacing-sm); }
+    .btn { padding: var(--spacing-xs) var(--spacing-md); border-radius: var(--radius-md); font-size: 0.875rem; font-weight: 500; cursor: pointer; border: none; }
+    .btn-primary { background: var(--color-primary); color: white; }
+    .btn-outline { background: transparent; border: 1px solid var(--color-border); color: var(--color-text); }
+    .padding-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(130px, 1fr)); gap: 1rem; margin-top: 1rem; }
+    .padding-item { background: #f3f4f6; border: 2px dashed var(--color-primary); border-radius: var(--radius-md); display: flex; flex-direction: column; align-items: center; justify-content: center; font-size: 0.7rem; font-family: monospace; color: var(--color-primary); min-height: 60px; text-align: center; padding: 0.5rem; }
+  </style>
+</head>
+<body>
+  <h1>间距令牌 - Spacing Tokens</h1>
+  <p class="subtitle">统一的间距刻度系统，确保 UI 的一致性</p>
+
+  <div class="section">
+    <div class="section-title">Spacing Scale</div>
+    <div class="spacing-row"><span class="spacing-name">--space-1</span><div class="spacing-bar-container"><div class="spacing-bar" style="width: var(--space-1)">4px</div></div></div>
+    <div class="spacing-row"><span class="spacing-name">--space-2</span><div class="spacing-bar-container"><div class="spacing-bar" style="width: var(--space-2)">8px</div></div></div>
+    <div class="spacing-row"><span class="spacing-name">--space-3</span><div class="spacing-bar-container"><div class="spacing-bar" style="width: var(--space-3)">12px</div></div></div>
+    <div class="spacing-row"><span class="spacing-name">--space-4</span><div class="spacing-bar-container"><div class="spacing-bar" style="width: var(--space-4)">16px</div></div></div>
+    <div class="spacing-row"><span class="spacing-name">--space-5</span><div class="spacing-bar-container"><div class="spacing-bar" style="width: var(--space-5)">20px</div></div></div>
+    <div class="spacing-row"><span class="spacing-name">--space-6</span><div class="spacing-bar-container"><div class="spacing-bar" style="width: var(--space-6)">24px</div></div></div>
+    <div class="spacing-row"><span class="spacing-name">--space-8</span><div class="spacing-bar-container"><div class="spacing-bar" style="width: var(--space-8)">32px</div></div></div>
+    <div class="spacing-row"><span class="spacing-name">--space-10</span><div class="spacing-bar-container"><div class="spacing-bar" style="width: var(--space-10)">40px</div></div></div>
+    <div class="spacing-row"><span class="spacing-name">--space-12</span><div class="spacing-bar-container"><div class="spacing-bar" style="width: var(--space-12)">48px</div></div></div>
+    <div class="spacing-row"><span class="spacing-name">--space-16</span><div class="spacing-bar-container"><div class="spacing-bar" style="width: var(--space-16)">64px</div></div></div>
+  </div>
+
+  <div class="section">
+    <div class="section-title">Semantic Spacing</div>
+    <div class="padding-grid">
+      <div class="padding-item">xs (4px)<br>--spacing-xs</div>
+      <div class="padding-item">sm (8px)<br>--spacing-sm</div>
+      <div class="padding-item">md (16px)<br>--spacing-md</div>
+      <div class="padding-item">lg (24px)<br>--spacing-lg</div>
+      <div class="padding-item">xl (32px)<br>--spacing-xl</div>
+      <div class="padding-item">2xl (48px)<br>--spacing-2xl</div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="section-title">Practical Example</div>
+    <div class="card">
+      <div class="card-title">Card Title</div>
+      <div class="card-text">使用 Design Token 的卡片组件，通过统一间距令牌确保各元素比例协调。</div>
+      <div class="card-actions">
+        <button class="btn btn-primary">主要操作</button>
+        <button class="btn btn-outline">次要操作</button>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/design-token/theme-switching.html
+++ b/examples/css/demos/design-token/theme-switching.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>主题切换 - Theme Switching</title>
+  <style>
+    :root {
+      --color-bg: #ffffff; --color-surface: #f3f4f6;
+      --color-surface-elevated: #ffffff; --color-text: #111827;
+      --color-text-muted: #6b7280; --color-border: #e5e7eb;
+      --color-primary: #3b82f6; --color-primary-hover: #2563eb;
+      --color-success: #10b981; --color-warning: #f59e0b; --color-error: #ef4444;
+      --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+      --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+    }
+    [data-theme="dark"] {
+      --color-bg: #0f172a; --color-surface: #1e293b;
+      --color-surface-elevated: #334155; --color-text: #f1f5f9;
+      --color-text-muted: #94a3b8; --color-border: #334155;
+      --color-primary: #60a5fa; --color-primary-hover: #3b82f6;
+      --color-success: #34d399; --color-warning: #fbbf24; --color-error: #f87171;
+      --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
+      --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.4);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: -apple-system, sans-serif; background: var(--color-bg); color: var(--color-text); padding: 2rem; transition: background 0.3s, color 0.3s; min-height: 100vh; }
+    h1 { font-size: 1.75rem; margin-bottom: 0.5rem; }
+    .subtitle { color: var(--color-text-muted); margin-bottom: 2rem; }
+    .theme-bar { display: flex; align-items: center; gap: 1rem; margin-bottom: 2rem; padding: 1rem 1.5rem; background: var(--color-surface); border-radius: 12px; border: 1px solid var(--color-border); }
+    .theme-bar label { font-size: 0.875rem; font-weight: 500; color: var(--color-text-muted); }
+    .theme-switch { position: relative; width: 52px; height: 28px; background: var(--color-border); border-radius: 14px; cursor: pointer; transition: background 0.3s; }
+    .theme-switch::after { content: ''; position: absolute; top: 3px; left: 3px; width: 22px; height: 22px; background: white; border-radius: 50%; transition: transform 0.3s; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
+    [data-theme="dark"] .theme-switch { background: var(--color-primary); }
+    [data-theme="dark"] .theme-switch::after { transform: translateX(24px); }
+    .theme-label { font-size: 0.875rem; font-family: monospace; color: var(--color-text-muted); min-width: 50px; }
+    .card { background: var(--color-surface-elevated); border: 1px solid var(--color-border); border-radius: 12px; padding: 1.5rem; margin-bottom: 1.5rem; box-shadow: var(--shadow-sm); transition: background 0.3s, border-color 0.3s; }
+    .card-title { font-size: 1.125rem; font-weight: 600; margin-bottom: 0.75rem; }
+    .card-text { color: var(--color-text-muted); font-size: 0.875rem; line-height: 1.6; margin-bottom: 1rem; }
+    .input-field { width: 100%; padding: 0.625rem 0.875rem; background: var(--color-bg); border: 1px solid var(--color-border); border-radius: 8px; font-size: 0.875rem; color: var(--color-text); margin-bottom: 1rem; transition: background 0.3s, border-color 0.3s; }
+    .input-field:focus { outline: none; border-color: var(--color-primary); box-shadow: 0 0 0 3px rgba(59,130,246,0.2); }
+    .btn-group { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+    .btn { padding: 0.5rem 1rem; border-radius: 8px; font-size: 0.875rem; font-weight: 500; cursor: pointer; border: none; transition: all 0.2s; }
+    .btn-primary { background: var(--color-primary); color: #fff; }
+    .btn-primary:hover { background: var(--color-primary-hover); }
+    .btn-success { background: var(--color-success); color: #fff; }
+    .btn-warning { background: var(--color-warning); color: #fff; }
+    .btn-error { background: var(--color-error); color: #fff; }
+    .btn-outline { background: transparent; border: 1px solid var(--color-border); color: var(--color-text); }
+    .color-chips { display: flex; gap: 0.75rem; flex-wrap: wrap; margin-top: 1rem; }
+    .chip { width: 32px; height: 32px; border-radius: 50%; border: 2px solid var(--color-border); transition: transform 0.2s, border-color 0.3s; }
+    .chip:hover { transform: scale(1.1); }
+    .chip-primary { background: var(--color-primary); }
+    .chip-success { background: var(--color-success); }
+    .chip-warning { background: var(--color-warning); }
+    .chip-error { background: var(--color-error); }
+  </style>
+</head>
+<body>
+  <h1>主题切换 - Theme Switching</h1>
+  <p class="subtitle">使用 Design Token 实现亮色/暗色主题切换</p>
+
+  <div class="theme-bar">
+    <label>主题切换</label>
+    <div class="theme-switch" id="theme-switch" role="switch" aria-checked="false" tabindex="0"></div>
+    <span class="theme-label" id="theme-label">light</span>
+  </div>
+
+  <div class="card">
+    <div class="card-title">表单组件</div>
+    <div class="card-text">输入框在亮色和暗色主题下都有良好的对比度和可读性。</div>
+    <input type="text" class="input-field" placeholder="输入框示例...">
+    <input type="email" class="input-field" placeholder="邮箱地址...">
+    <div class="btn-group">
+      <button class="btn btn-primary">主要按钮</button>
+      <button class="btn btn-success">成功按钮</button>
+      <button class="btn btn-warning">警告按钮</button>
+      <button class="btn btn-error">错误按钮</button>
+      <button class="btn btn-outline">描边按钮</button>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-title">语义化颜色</div>
+    <div class="card-text">通过决策令牌（Decision Token）定义语义化颜色，主题切换时自动响应。</div>
+    <div class="color-chips">
+      <div class="chip chip-primary" title="Primary"></div>
+      <div class="chip chip-success" title="Success"></div>
+      <div class="chip chip-warning" title="Warning"></div>
+      <div class="chip chip-error" title="Error"></div>
+    </div>
+  </div>
+
+  <script>
+    const themeSwitch = document.getElementById('theme-switch');
+    const themeLabel = document.getElementById('theme-label');
+    function setTheme(theme) {
+      document.documentElement.dataset.theme = theme;
+      themeLabel.textContent = theme;
+      themeSwitch.setAttribute('aria-checked', theme === 'dark');
+      localStorage.setItem('theme', theme);
+    }
+    const saved = localStorage.getItem('theme');
+    if (saved) { setTheme(saved); }
+    else if (window.matchMedia('(prefers-color-scheme: dark)').matches) { setTheme('dark'); }
+    themeSwitch.addEventListener('click', () => {
+      const current = document.documentElement.dataset.theme || 'light';
+      setTheme(current === 'dark' ? 'light' : 'dark');
+    });
+    themeSwitch.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); themeSwitch.click(); }
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/design-token/typography-tokens.html
+++ b/examples/css/demos/design-token/typography-tokens.html
@@ -1,0 +1,90 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>字体令牌 - Typography Tokens</title>
+  <style>
+    :root {
+      --font-family-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      --font-family-serif: 'Georgia', 'Times New Roman', serif;
+      --font-family-mono: 'JetBrains Mono', 'Fira Code', 'Consolas', monospace;
+      --font-size-xs: 0.75rem; --font-size-sm: 0.875rem; --font-size-base: 1rem;
+      --font-size-lg: 1.125rem; --font-size-xl: 1.25rem; --font-size-2xl: 1.5rem;
+      --font-size-3xl: 1.875rem; --font-size-4xl: 2.25rem;
+      --line-height-tight: 1.25; --line-height-normal: 1.5; --line-height-relaxed: 1.75;
+      --font-weight-normal: 400; --font-weight-medium: 500; --font-weight-semibold: 600; --font-weight-bold: 700;
+      --space-1: 0.25rem; --space-2: 0.5rem; --space-3: 0.75rem; --space-4: 1rem; --space-6: 1.5rem; --space-8: 2rem;
+      --color-text: #111827; --color-text-muted: #6b7280; --color-border: #e5e7eb; --color-bg: #ffffff;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: var(--font-family-sans); background: var(--color-bg); color: var(--color-text); padding: 2rem; line-height: var(--line-height-normal); }
+    h1 { font-size: var(--font-size-2xl); margin-bottom: var(--space-2); }
+    .subtitle { color: var(--color-text-muted); margin-bottom: var(--space-8); }
+    .section { border: 1px solid var(--color-border); border-radius: 12px; padding: var(--space-6); margin-bottom: var(--space-6); }
+    .section-title { font-size: var(--font-size-sm); font-weight: var(--font-weight-semibold); color: var(--color-text-muted); text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: var(--space-4); }
+    .demo-block { margin-bottom: var(--space-6); padding-bottom: var(--space-6); border-bottom: 1px solid var(--color-border); }
+    .size-grid { display: flex; flex-direction: column; gap: var(--space-3); }
+    .size-row { display: flex; align-items: baseline; gap: var(--space-4); }
+    .size-label { width: 160px; font-size: var(--font-size-sm); font-family: var(--font-family-mono); color: var(--color-text-muted); flex-shrink: 0; }
+    .family-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: var(--space-4); }
+    .family-card { padding: var(--space-4); border: 1px solid var(--color-border); border-radius: 8px; }
+    .family-name { font-size: var(--font-size-sm); font-weight: var(--font-weight-medium); margin-bottom: var(--space-2); color: var(--color-text-muted); }
+    .weight-grid { display: flex; flex-wrap: wrap; gap: var(--space-6); }
+    .weight-item { text-align: center; }
+    .weight-value { font-size: var(--font-size-2xl); font-weight: var(--font-weight-bold); margin-bottom: var(--space-1); }
+    .weight-label { font-size: var(--font-size-xs); font-family: var(--font-family-mono); color: var(--color-text-muted); }
+    .lh-grid { display: flex; flex-direction: column; gap: var(--space-4); }
+    .lh-item { display: flex; gap: var(--space-4); align-items: flex-start; }
+    .lh-label { width: 180px; font-size: var(--font-size-sm); font-family: var(--font-family-mono); color: var(--color-text-muted); flex-shrink: 0; padding-top: var(--space-1); }
+    .lh-demo { flex: 1; background: #f9fafb; padding: var(--space-2); border-radius: 4px; font-size: var(--font-size-sm); }
+    .lh-tight { line-height: var(--line-height-tight); }
+    .lh-normal { line-height: var(--line-height-normal); }
+    .lh-relaxed { line-height: var(--line-height-relaxed); }
+  </style>
+</head>
+<body>
+  <h1>字体令牌 - Typography Tokens</h1>
+  <p class="subtitle">统一管理字体族、字号、行高、字重</p>
+  <div class="section">
+    <div class="section-title">Font Sizes</div>
+    <div class="demo-block">
+      <div class="size-grid">
+        <div class="size-row"><span class="size-label">--font-size-xs (12px)</span><span style="font-size: var(--font-size-xs)">Extra Small - 辅助说明文字</span></div>
+        <div class="size-row"><span class="size-label">--font-size-sm (14px)</span><span style="font-size: var(--font-size-sm)">Small - 次要文字、标签</span></div>
+        <div class="size-row"><span class="size-label">--font-size-base (16px)</span><span style="font-size: var(--font-size-base)">Base - 正文内容</span></div>
+        <div class="size-row"><span class="size-label">--font-size-lg (18px)</span><span style="font-size: var(--font-size-lg)">Large - 强调文字</span></div>
+        <div class="size-row"><span class="size-label">--font-size-xl (20px)</span><span style="font-size: var(--font-size-xl)">Extra Large - 小标题</span></div>
+        <div class="size-row"><span class="size-label">--font-size-2xl (24px)</span><span style="font-size: var(--font-size-2xl)">2X Large - 页面标题</span></div>
+        <div class="size-row"><span class="size-label">--font-size-3xl (30px)</span><span style="font-size: var(--font-size-3xl)">3X Large - 区块标题</span></div>
+        <div class="size-row"><span class="size-label">--font-size-4xl (36px)</span><span style="font-size: var(--font-size-4xl)">4X Large - Hero 标题</span></div>
+      </div>
+    </div>
+  </div>
+  <div class="section">
+    <div class="section-title">Font Families</div>
+    <div class="family-grid">
+      <div class="family-card"><div class="family-name">Sans Serif</div><div style="font-family: var(--font-family-sans)">Inter, Apple System, Segoe UI<br>ABCDEFG 0123456789</div></div>
+      <div class="family-card"><div class="family-name">Serif</div><div style="font-family: var(--font-family-serif)">Georgia, Times New Roman<br>ABCDEFG 0123456789</div></div>
+      <div class="family-card"><div class="family-name">Monospace</div><div style="font-family: var(--font-family-mono); font-size: var(--font-size-sm)">JetBrains Mono, Fira Code<br>ABCDEFG 0123456789</div></div>
+    </div>
+  </div>
+  <div class="section">
+    <div class="section-title">Font Weights</div>
+    <div class="weight-grid">
+      <div class="weight-item"><div class="weight-value" style="font-weight: var(--font-weight-normal)">Aa</div><div class="weight-label">400 Normal</div></div>
+      <div class="weight-item"><div class="weight-value" style="font-weight: var(--font-weight-medium)">Aa</div><div class="weight-label">500 Medium</div></div>
+      <div class="weight-item"><div class="weight-value" style="font-weight: var(--font-weight-semibold)">Aa</div><div class="weight-label">600 Semibold</div></div>
+      <div class="weight-item"><div class="weight-value" style="font-weight: var(--font-weight-bold)">Aa</div><div class="weight-label">700 Bold</div></div>
+    </div>
+  </div>
+  <div class="section">
+    <div class="section-title">Line Heights</div>
+    <div class="lh-grid">
+      <div class="lh-item"><span class="lh-label">--line-height-tight (1.25)</span><div class="lh-demo lh-tight">紧凑行高，适用于标题。段落之间间距较小。</div></div>
+      <div class="lh-item"><span class="lh-label">--line-height-normal (1.5)</span><div class="lh-demo lh-normal">标准行高，适用于正文。段落之间有适度呼吸空间。</div></div>
+      <div class="lh-item"><span class="lh-label">--line-height-relaxed (1.75)</span><div class="lh-demo lh-relaxed">宽松行高，适用于长篇文章。段落之间有充足呼吸空间，提升阅读体验。</div></div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/flex-properties.html
+++ b/examples/css/demos/flexbox-deep/flex-properties.html
@@ -1,0 +1,305 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flex 项目属性示例</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      padding: 40px;
+      background: #f5f5f5;
+    }
+
+    h2 {
+      margin: 30px 0 15px;
+      color: #333;
+      font-size: 18px;
+    }
+
+    h3 {
+      margin: 15px 0 10px;
+      color: #666;
+      font-size: 14px;
+    }
+
+    .section {
+      background: #fff;
+      padding: 20px;
+      border-radius: 8px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .container {
+      background: #e8f4ff;
+      border: 2px dashed #4a90d9;
+      border-radius: 8px;
+      min-height: 80px;
+      padding: 15px;
+      display: flex;
+      gap: 10px;
+    }
+
+    .item {
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: bold;
+      border-radius: 8px;
+      padding: 15px;
+      font-size: 18px;
+    }
+
+    /* flex-grow 示例 */
+    .grow-0 { flex-grow: 0; }
+    .grow-1 { flex-grow: 1; }
+    .grow-2 { flex-grow: 2; }
+    .grow-3 { flex-grow: 3; }
+
+    /* flex-shrink 示例 */
+    .shrink-0 { flex-shrink: 0; }
+    .shrink-1 { flex-shrink: 1; }
+    .shrink-2 { flex-shrink: 2; }
+
+    /* flex-basis 示例 */
+    .basis-100 { flex-basis: 100px; }
+    .basis-200 { flex-basis: 200px; }
+    .basis-auto { flex-basis: auto; }
+
+    /* flex 简写 */
+    .flex-1 { flex: 1; }
+    .flex-2 { flex: 2; }
+    .flex-1-1-auto { flex: 1 1 auto; }
+    .flex-0-0-200 { flex: 0 0 200px; }
+
+    /* align-self */
+    .self-start { align-self: flex-start; }
+    .self-center { align-self: center; }
+    .self-end { align-self: flex-end; }
+    .self-stretch { align-self: stretch; }
+
+    /* 等宽网格 */
+    .equal-grid {
+      display: flex;
+      gap: 20px;
+    }
+    .equal-grid .card {
+      flex: 1;
+      padding: 20px;
+      background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+      color: white;
+      border-radius: 8px;
+      text-align: center;
+    }
+
+    /* 响应式网格 */
+    .responsive-grid {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 20px;
+    }
+    .responsive-grid .card {
+      flex: 1 1 250px;
+      max-width: 350px;
+      padding: 30px;
+      background: linear-gradient(135deg, #4facfe 0%, #00f2fe 100%);
+      color: white;
+      border-radius: 8px;
+      text-align: center;
+    }
+
+    .label {
+      font-size: 12px;
+      color: #999;
+      margin-top: 8px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Flex 项目属性示例</h1>
+
+  <!-- flex-grow -->
+  <div class="section">
+    <h2>flex-grow: 放大比例</h2>
+    <p class="label">容器宽度 600px，项目初始宽度 80px，剩余空间按比例分配</p>
+
+    <h3>全部 flex-grow: 0 (默认，不放大)</h3>
+    <div class="container" style="width: 600px;">
+      <div class="item grow-0" style="width: 80px;">80px</div>
+      <div class="item grow-0" style="width: 80px;">80px</div>
+      <div class="item grow-0" style="width: 80px;">80px</div>
+    </div>
+
+    <h3>一个项目 flex-grow: 1 (占据全部剩余空间)</h3>
+    <div class="container" style="width: 600px;">
+      <div class="item grow-0" style="width: 80px;">80px</div>
+      <div class="item grow-1">grow: 1</div>
+      <div class="item grow-0" style="width: 80px;">80px</div>
+    </div>
+
+    <h3>三个项目分别 flex-grow: 1, 2, 3 (按比例分配)</h3>
+    <div class="container" style="width: 600px;">
+      <div class="item grow-1">1</div>
+      <div class="item grow-2">2</div>
+      <div class="item grow-3">3</div>
+    </div>
+
+    <h3>全部 flex-grow: 1 (均分剩余空间)</h3>
+    <div class="container" style="width: 600px;">
+      <div class="item flex-1">1</div>
+      <div class="item flex-1">1</div>
+      <div class="item flex-1">1</div>
+    </div>
+  </div>
+
+  <!-- flex-shrink -->
+  <div class="section">
+    <h2>flex-shrink: 缩小比例</h2>
+    <p class="label">容器宽度 400px，项目初始宽度 150px，超出部分按比例收缩</p>
+
+    <h3>全部 flex-shrink: 1 (默认，可收缩)</h3>
+    <div class="container" style="width: 400px;">
+      <div class="item shrink-1" style="width: 150px;">150px</div>
+      <div class="item shrink-1" style="width: 150px;">150px</div>
+      <div class="item shrink-1" style="width: 150px;">150px</div>
+    </div>
+
+    <h3>中间项目 flex-shrink: 0 (不收缩)</h3>
+    <div class="container" style="width: 400px;">
+      <div class="item shrink-1" style="width: 150px;">可收缩</div>
+      <div class="item shrink-0" style="width: 150px;">不收缩</div>
+      <div class="item shrink-1" style="width: 150px;">可收缩</div>
+    </div>
+
+    <h3>第一个项目 flex-shrink: 2 (收缩更多)</h3>
+    <div class="container" style="width: 400px;">
+      <div class="item shrink-2" style="width: 200px;">收缩2</div>
+      <div class="item shrink-1" style="width: 100px;">收缩1</div>
+      <div class="item shrink-1" style="width: 100px;">收缩1</div>
+    </div>
+  </div>
+
+  <!-- flex-basis -->
+  <div class="section">
+    <h2>flex-basis: 初始尺寸</h2>
+
+    <h3>flex-basis: auto (默认，按自身尺寸)</h3>
+    <div class="container">
+      <div class="item basis-auto" style="width: 100px;">100px</div>
+      <div class="item basis-auto" style="width: 150px;">150px</div>
+      <div class="item basis-auto" style="width: 80px;">80px</div>
+    </div>
+
+    <h3>flex-basis: 200px (固定初始宽度)</h3>
+    <div class="container">
+      <div class="item basis-200">200px</div>
+      <div class="item basis-200">200px</div>
+      <div class="item basis-200">200px</div>
+    </div>
+
+    <h3>flex-basis: 100px 配合 flex-grow: 1</h3>
+    <div class="container">
+      <div class="item" style="flex-basis: 100px; flex-grow: 1;">100px + grow</div>
+      <div class="item" style="flex-basis: 100px; flex-grow: 1;">100px + grow</div>
+      <div class="item" style="flex-basis: 100px; flex-grow: 1;">100px + grow</div>
+    </div>
+  </div>
+
+  <!-- flex 简写 -->
+  <div class="section">
+    <h2>flex 简写</h2>
+
+    <h3>flex: 1 (等于 flex: 1 1 0%)</h3>
+    <div class="container">
+      <div class="item flex-1">flex: 1</div>
+      <div class="item flex-1">flex: 1</div>
+      <div class="item flex-1">flex: 1</div>
+    </div>
+
+    <h3>flex: 0 0 200px (固定尺寸，不伸缩)</h3>
+    <div class="container">
+      <div class="item flex-0-0-200">固定200px</div>
+      <div class="item flex-1">可伸缩</div>
+      <div class="item flex-0-0-200">固定200px</div>
+    </div>
+
+    <h3>flex: 1 1 auto (可伸缩，基准为自身)</h3>
+    <div class="container">
+      <div class="item flex-1-1-auto" style="width: 80px;">80px+</div>
+      <div class="item flex-1-1-auto" style="width: 120px;">120px+</div>
+      <div class="item flex-1-1-auto" style="width: 60px;">60px+</div>
+    </div>
+  </div>
+
+  <!-- align-self -->
+  <div class="section">
+    <h2>align-self: 单个项目交叉轴对齐</h2>
+    <p class="label">覆盖容器的 align-items 设置</p>
+
+    <h3>单个项目不同对齐方式</h3>
+    <div class="container" style="height: 150px; align-items: flex-start;">
+      <div class="item self-start">flex-start</div>
+      <div class="item self-center">center</div>
+      <div class="item self-end">flex-end</div>
+    </div>
+
+    <h3>混合使用</h3>
+    <div class="container" style="height: 150px; align-items: center;">
+      <div class="item">默认</div>
+      <div class="item self-start">self-start</div>
+      <div class="item self-stretch" style="height: auto;">stretch</div>
+      <div class="item self-end">self-end</div>
+    </div>
+  </div>
+
+  <!-- 实际应用 -->
+  <div class="section">
+    <h2>实际应用</h2>
+
+    <h3>等宽三栏布局</h3>
+    <div class="equal-grid">
+      <div class="card">
+        <h3>卡片 1</h3>
+        <p>flex: 1</p>
+      </div>
+      <div class="card">
+        <h3>卡片 2</h3>
+        <p>flex: 1</p>
+      </div>
+      <div class="card">
+        <h3>卡片 3</h3>
+        <p>flex: 1</p>
+      </div>
+    </div>
+
+    <h3>响应式卡片网格 (flex: 1 1 250px)</h3>
+    <div class="responsive-grid">
+      <div class="card">
+        <h3>卡片 1</h3>
+        <p>250px+</p>
+      </div>
+      <div class="card">
+        <h3>卡片 2</h3>
+        <p>250px+</p>
+      </div>
+      <div class="card">
+        <h3>卡片 3</h3>
+        <p>250px+</p>
+      </div>
+      <div class="card">
+        <h3>卡片 4</h3>
+        <p>250px+</p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/index.html
+++ b/examples/css/demos/flexbox-deep/index.html
@@ -1,0 +1,315 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox 基础示例</title>
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      padding: 40px;
+      background: #f5f5f5;
+    }
+
+    h2 {
+      margin: 30px 0 15px;
+      color: #333;
+      font-size: 18px;
+    }
+
+    h3 {
+      margin: 15px 0 10px;
+      color: #666;
+      font-size: 14px;
+    }
+
+    .section {
+      background: #fff;
+      padding: 20px;
+      border-radius: 8px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .container {
+      background: #e8f4ff;
+      border: 2px dashed #4a90d9;
+      border-radius: 8px;
+      min-height: 100px;
+      padding: 15px;
+      display: flex;
+    }
+
+    .item {
+      width: 60px;
+      height: 60px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: bold;
+      border-radius: 8px;
+      margin: 5px;
+    }
+
+    /* flex-direction 示例 */
+    .row-reverse { flex-direction: row-reverse; }
+    .column { flex-direction: column; }
+    .column-reverse { flex-direction: column-reverse; }
+
+    /* justify-content 示例 */
+    .flex-end { justify-content: flex-end; }
+    .center { justify-content: center; }
+    .space-between { justify-content: space-between; }
+    .space-around { justify-content: space-around; }
+    .space-evenly { justify-content: space-evenly; }
+
+    /* align-items 示例 */
+    .align-flex-start { align-items: flex-start; }
+    .align-flex-end { align-items: flex-end; }
+    .align-center { align-items: center; }
+    .align-baseline { align-items: baseline; }
+    .baseline-item { padding: 10px 0; }
+
+    /* flex-wrap 示例 */
+    .wrap-container {
+      flex-wrap: wrap;
+    }
+    .wrap-container .item {
+      width: 150px;
+    }
+
+    /* align-content 示例 */
+    .content-container {
+      flex-wrap: wrap;
+      height: 200px;
+    }
+    .content-container .item {
+      width: 150px;
+    }
+    .align-content-start { align-content: flex-start; }
+    .align-content-end { align-content: flex-end; }
+    .align-content-center { align-content: center; }
+    .align-content-between { align-content: space-between; }
+    .align-content-around { align-content: space-around; }
+  </style>
+</head>
+<body>
+  <h1>Flexbox 基础示例</h1>
+
+  <!-- flex-direction -->
+  <div class="section">
+    <h2>flex-direction: 主轴方向</h2>
+    
+    <h3>row (默认)</h3>
+    <div class="container">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+    </div>
+
+    <h3>row-reverse</h3>
+    <div class="container row-reverse">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+    </div>
+
+    <h3>column</h3>
+    <div class="container column">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+    </div>
+
+    <h3>column-reverse</h3>
+    <div class="container column-reverse">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+    </div>
+  </div>
+
+  <!-- justify-content -->
+  <div class="section">
+    <h2>justify-content: 主轴对齐</h2>
+
+    <h3>flex-start (默认)</h3>
+    <div class="container">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+    </div>
+
+    <h3>flex-end</h3>
+    <div class="container flex-end">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+    </div>
+
+    <h3>center</h3>
+    <div class="container center">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+    </div>
+
+    <h3>space-between</h3>
+    <div class="container space-between">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+    </div>
+
+    <h3>space-around</h3>
+    <div class="container space-around">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+    </div>
+
+    <h3>space-evenly</h3>
+    <div class="container space-evenly">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+    </div>
+  </div>
+
+  <!-- align-items -->
+  <div class="section">
+    <h2>align-items: 交叉轴对齐</h2>
+
+    <h3>stretch (默认)</h3>
+    <div class="container" style="height: 120px;">
+      <div class="item" style="height: auto;">1</div>
+      <div class="item" style="height: auto;">2</div>
+      <div class="item" style="height: auto;">3</div>
+    </div>
+
+    <h3>flex-start</h3>
+    <div class="container align-flex-start" style="height: 120px;">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+    </div>
+
+    <h3>flex-end</h3>
+    <div class="container align-flex-end" style="height: 120px;">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+    </div>
+
+    <h3>center</h3>
+    <div class="container align-center" style="height: 120px;">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+    </div>
+
+    <h3>baseline</h3>
+    <div class="container align-baseline" style="height: 120px;">
+      <div class="item baseline-item">1</div>
+      <div class="item">2</div>
+      <div class="item" style="font-size: 24px;">3</div>
+    </div>
+  </div>
+
+  <!-- flex-wrap -->
+  <div class="section">
+    <h2>flex-wrap: 换行</h2>
+
+    <h3>nowrap (默认)</h3>
+    <div class="container" style="width: 300px;">
+      <div class="item" style="width: 100px;">1</div>
+      <div class="item" style="width: 100px;">2</div>
+      <div class="item" style="width: 100px;">3</div>
+      <div class="item" style="width: 100px;">4</div>
+    </div>
+
+    <h3>wrap</h3>
+    <div class="container wrap-container" style="width: 300px;">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+      <div class="item">4</div>
+      <div class="item">5</div>
+      <div class="item">6</div>
+    </div>
+
+    <h3>wrap-reverse</h3>
+    <div class="container" style="width: 300px; flex-wrap: wrap-reverse;">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+      <div class="item">4</div>
+      <div class="item">5</div>
+      <div class="item">6</div>
+    </div>
+  </div>
+
+  <!-- align-content -->
+  <div class="section">
+    <h2>align-content: 多行对齐 (需 flex-wrap: wrap)</h2>
+
+    <h3>flex-start</h3>
+    <div class="container content-container align-content-start">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+      <div class="item">4</div>
+      <div class="item">5</div>
+      <div class="item">6</div>
+    </div>
+
+    <h3>flex-end</h3>
+    <div class="container content-container align-content-end">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+      <div class="item">4</div>
+      <div class="item">5</div>
+      <div class="item">6</div>
+    </div>
+
+    <h3>center</h3>
+    <div class="container content-container align-content-center">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+      <div class="item">4</div>
+      <div class="item">5</div>
+      <div class="item">6</div>
+    </div>
+
+    <h3>space-between</h3>
+    <div class="container content-container align-content-between">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+      <div class="item">4</div>
+      <div class="item">5</div>
+      <div class="item">6</div>
+    </div>
+
+    <h3>space-around</h3>
+    <div class="container content-container align-content-around">
+      <div class="item">1</div>
+      <div class="item">2</div>
+      <div class="item">3</div>
+      <div class="item">4</div>
+      <div class="item">5</div>
+      <div class="item">6</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/light-dark/index.html
+++ b/examples/css/demos/light-dark/index.html
@@ -1,0 +1,494 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS light-dark() 暗色模式切换函数演示</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      /* 必须声明 color-scheme 才能使用 light-dark() */
+      color-scheme: light dark;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background-color: light-dark(#ffffff, #121212);
+      color: light-dark(#1a1a1a, #f0f0f0);
+      padding: 24px;
+      line-height: 1.6;
+      transition: background-color 0.3s, color 0.3s;
+    }
+
+    h1 { text-align: center; margin-bottom: 32px; color: light-dark(#1a1a1a, #f0f0f0); }
+    h2 { margin: 32px 0 16px; color: light-dark(#1a1a1a, #f0f0f0); border-bottom: 2px solid light-dark(#e0e0e0, #333); padding-bottom: 8px; }
+    h3 { margin: 24px 0 12px; color: light-dark(#333, #ccc); }
+
+    .demo-section {
+      background-color: light-dark(#f8f9fa, #1e1e1e);
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 24px;
+      border: 1px solid light-dark(#e0e0e0, #333);
+      transition: background-color 0.3s, border-color 0.3s;
+    }
+
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 16px;
+      margin-top: 16px;
+    }
+
+    p { margin: 8px 0; }
+
+    /* ============================================
+       演示 1：基础颜色切换
+       ============================================ */
+    .color-swatches {
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+      margin-top: 12px;
+    }
+
+    .swatch {
+      padding: 16px 24px;
+      border-radius: 8px;
+      text-align: center;
+      font-weight: 500;
+      border: 1px solid light-dark(#ddd, #444);
+      min-width: 120px;
+      transition: all 0.3s;
+    }
+
+    .swatch-text { background: light-dark(#fff, #222); }
+    .swatch-bg { background: light-dark(#333, #ddd); color: light-dark(#fff, #333); }
+    .swatch-mixed { background: light-dark(#e3f2fd, #1a237e); color: light-dark(#1565c0, #90caf9); }
+    .swatch-accent { background: light-dark(#f8f9fa, #263238); color: light-dark(#495057, #90caf9); }
+
+    /* ============================================
+       演示 2：卡片组件
+       ============================================ */
+    .card {
+      background-color: light-dark(#ffffff, #2d2d2d);
+      border: 1px solid light-dark(#e0e0e0, #444);
+      border-radius: 12px;
+      padding: 20px;
+      box-shadow: light-dark(0 2px 8px rgba(0,0,0,0.08), 0 2px 8px rgba(0,0,0,0.4));
+      transition: all 0.3s;
+    }
+
+    .card__title {
+      font-size: 18px;
+      font-weight: bold;
+      color: light-dark(#1a1a1a, #f0f0f0);
+      margin-bottom: 8px;
+    }
+
+    .card__desc {
+      color: light-dark(#666, #aaa);
+      font-size: 14px;
+      margin-bottom: 12px;
+    }
+
+    .card__badge {
+      display: inline-block;
+      padding: 4px 12px;
+      border-radius: 20px;
+      font-size: 12px;
+      font-weight: 500;
+      background-color: light-dark(#e3f2fd, #1e3a5f);
+      color: light-dark(#1565c0, #90caf9);
+      transition: all 0.3s;
+    }
+
+    /* ============================================
+       演示 3：代码块
+       ============================================ */
+    .code-block {
+      background-color: light-dark(#f8f9fa, #1e1e1e);
+      color: light-dark(#212529, #d4d4d4);
+      padding: 16px;
+      border-radius: 8px;
+      font-family: 'Fira Code', 'Consolas', monospace;
+      font-size: 13px;
+      overflow-x: auto;
+      border: 1px solid light-dark(#e0e0e0, #333);
+      transition: all 0.3s;
+    }
+
+    .code-keyword { color: light-dark(#d73a49, #f97583); }
+    .code-func { color: light-dark(#6f42c1, #b392f0); }
+    .code-string { color: light-dark(#032f62, #9ecbff); }
+    .code-comment { color: light-dark(#6a737d, #8b949e); }
+
+    /* ============================================
+       演示 4：按钮
+       ============================================ */
+    .btn-container {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-top: 12px;
+    }
+
+    .btn {
+      padding: 10px 20px;
+      border-radius: 6px;
+      border: 2px solid transparent;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.2s;
+    }
+
+    .btn-primary {
+      background-color: light-dark(#007bff, #4d9fff);
+      color: light-dark(#fff, #121212);
+    }
+    .btn-primary:hover { opacity: 0.85; }
+
+    .btn-secondary {
+      background-color: light-dark(#6c757d, #6c757d);
+      color: light-dark(#fff, #fff);
+    }
+
+    .btn-outline {
+      background-color: transparent;
+      color: light-dark(#007bff, #4d9fff);
+      border-color: light-dark(#007bff, #4d9fff);
+    }
+    .btn-outline:hover { background-color: light-dark(#007bff, #4d9fff); color: light-dark(#fff, #121212); }
+
+    /* ============================================
+       演示 5：局部主题强制
+       ============================================ */
+    .force-light {
+      color-scheme: light;
+      background-color: #fff;
+      border: 2px solid #ddd;
+      padding: 16px;
+      border-radius: 8px;
+      margin: 8px 0;
+    }
+
+    .force-dark {
+      color-scheme: dark;
+      background-color: #1e1e1e;
+      border: 2px solid #444;
+      padding: 16px;
+      border-radius: 8px;
+      margin: 8px 0;
+      color: #f0f0f0;
+    }
+
+    .theme-override-text {
+      color: light-dark(red, orange);
+      font-weight: bold;
+    }
+
+    /* ============================================
+       演示 6：边框和阴影
+       ============================================ */
+    .shadow-demo {
+      background-color: light-dark(#ffffff, #2d2d2d);
+      border: 1px solid light-dark(#e0e0e0, #444);
+      border-radius: 12px;
+      padding: 24px;
+      box-shadow: light-dark(
+        0 4px 16px rgba(0, 0, 0, 0.1),
+        0 4px 16px rgba(0, 0, 0, 0.5)
+      );
+      transition: all 0.3s;
+    }
+
+    /* ============================================
+       演示 7：表单元素
+       ============================================ */
+    .form-demo {
+      max-width: 400px;
+    }
+
+    .form-group {
+      margin-bottom: 16px;
+    }
+
+    .form-label {
+      display: block;
+      margin-bottom: 6px;
+      font-weight: 500;
+      color: light-dark(#333, #ccc);
+    }
+
+    .form-input {
+      width: 100%;
+      padding: 10px 14px;
+      border: 1px solid light-dark(#ccc, #555);
+      border-radius: 6px;
+      background-color: light-dark(#fff, #2d2d2d);
+      color: light-dark(#1a1a1a, #f0f0f0);
+      font-size: 14px;
+      transition: all 0.2s;
+    }
+
+    .form-input:focus {
+      outline: none;
+      border-color: light-dark(#007bff, #4d9fff);
+      box-shadow: 0 0 0 3px light-dark(rgba(0,123,255,0.25), rgba(77,159,255,0.25));
+    }
+
+    /* ============================================
+       通用样式
+       ============================================ */
+    .badge {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 12px;
+      font-weight: bold;
+      margin-left: 8px;
+    }
+    .badge-green { background: light-dark(#4caf50, #388e3c); color: #fff; }
+    .badge-blue { background: light-dark(#2196f3, #1976d2); color: #fff; }
+    .badge-orange { background: light-dark(#ff9800, #f57c00); color: #fff; }
+
+    .note {
+      background-color: light-dark(#fff3cd, #3d3d00);
+      border-left: 4px solid light-dark(#ffc107, #ffc107);
+      padding: 12px 16px;
+      border-radius: 0 8px 8px 0;
+      margin: 16px 0;
+      font-size: 14px;
+      color: light-dark(#856404, #fff3cd);
+    }
+
+    .info-box {
+      background-color: light-dark(#e7f3ff, #001f3f);
+      border: 1px solid light-dark(#b3d9ff, #004080);
+      border-radius: 8px;
+      padding: 16px;
+      margin: 16px 0;
+      font-size: 14px;
+    }
+
+    /* ============================================
+       主题切换器（调试用）
+       ============================================ */
+    .theme-switcher {
+      position: fixed;
+      top: 16px;
+      right: 16px;
+      background-color: light-dark(#fff, #2d2d2d);
+      border: 1px solid light-dark(#ccc, #555);
+      border-radius: 8px;
+      padding: 12px;
+      font-size: 13px;
+      box-shadow: light-dark(0 2px 8px rgba(0,0,0,0.1), 0 2px 8px rgba(0,0,0,0.4));
+      z-index: 100;
+    }
+
+    .theme-switcher p {
+      margin: 0 0 8px 0;
+      font-weight: 500;
+      color: light-dark(#333, #ccc);
+    }
+
+    .theme-switcher button {
+      margin: 4px;
+      padding: 6px 12px;
+      border-radius: 4px;
+      border: 1px solid light-dark(#ccc, #555);
+      background-color: light-dark(#f8f9fa, #3d3d3d);
+      color: light-dark(#333, #ddd);
+      cursor: pointer;
+      font-size: 12px;
+    }
+
+    .theme-switcher button:hover {
+      background-color: light-dark(#e9ecef, #555);
+    }
+
+    .theme-switcher button.active {
+      background-color: light-dark(#007bff, #4d9fff);
+      color: #fff;
+      border-color: light-dark(#007bff, #4d9fff);
+    }
+  </style>
+</head>
+<body>
+  <!-- 主题切换器 -->
+  <div class="theme-switcher">
+    <p>调试：强制主题</p>
+    <button onclick="setColorScheme('light dark')">自动</button>
+    <button onclick="setColorScheme('light')">浅色</button>
+    <button onclick="setColorScheme('dark')">深色</button>
+  </div>
+
+  <h1>CSS <code>light-dark()</code> 暗色模式切换函数</h1>
+
+  <!-- 演示 1：基础颜色切换 -->
+  <div class="demo-section">
+    <h2>1. 基础颜色切换 <span class="badge badge-green">核心功能</span></h2>
+    <p>直接使用 <code>light-dark(light-value, dark-value)</code> 在两种颜色间切换，无需媒体查询。</p>
+    <div class="color-swatches">
+      <div class="swatch swatch-text">亮色文本<br><small>#fff on #333</small></div>
+      <div class="swatch swatch-bg">暗色背景<br><small>#333 on #ddd</small></div>
+      <div class="swatch swatch-mixed">混合色<br><small>蓝调主题</small></div>
+      <div class="swatch swatch-accent">强调色<br><small>代码风格</small></div>
+    </div>
+    <div class="code-block">
+<span class="code-keyword">body</span> {
+  <span class="code-func">color</span>: <span class="code-func">light-dark</span>(<span class="code-string">#1a1a1a</span>, <span class="code-string">#f0f0f0</span>);
+  <span class="code-func">background-color</span>: <span class="code-func">light-dark</span>(<span class="code-string">#ffffff</span>, <span class="code-string">#121212</span>);
+}
+    </div>
+  </div>
+
+  <!-- 演示 2：卡片组件 -->
+  <div class="demo-section">
+    <h2>2. 卡片组件 <span class="badge badge-blue">实际应用</span></h2>
+    <p>在组件中使用 <code>light-dark()</code>，阴影和边框颜色也会自动适配。</p>
+    <div class="demo-grid">
+      <div class="card">
+        <div class="card__title">功能卡片</div>
+        <div class="card__desc">卡片描述文字，使用 light-dark() 自动适配主题</div>
+        <span class="card__badge">标签</span>
+      </div>
+      <div class="card">
+        <div class="card__title">另一个卡片</div>
+        <div class="card__desc">试试切换系统主题或点击右上角按钮</div>
+        <span class="card__badge">示例</span>
+      </div>
+      <div class="card">
+        <div class="card__title">卡片三</div>
+        <div class="card__desc">边框和阴影也会根据主题变化</div>
+        <span class="card__badge">阴影</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- 演示 3：代码块 -->
+  <div class="demo-section">
+    <h2>3. 代码高亮 <span class="badge badge-blue">代码块</span></h2>
+    <p><code>light-dark()</code> 可用于代码语法高亮，确保在暗色主题下也有良好可读性。</p>
+    <div class="code-block">
+<span class="code-comment">/* 亮色主题下关键词是红色 */</span>
+<span class="code-keyword">@media</span> (<span class="code-func">prefers-color-scheme</span>: <span class="code-string">dark</span>) {
+  <span class="code-comment">/* 暗色主题下关键词是粉色 */</span>
+  <span class="code-keyword">.code-keyword</span> { <span class="code-func">color</span>: <span class="code-string">#f97583</span>; }
+}
+    </div>
+  </div>
+
+  <!-- 演示 4：按钮 -->
+  <div class="demo-section">
+    <h2>4. 按钮样式</h2>
+    <p>不同类型的按钮在明暗主题下的表现。</p>
+    <div class="btn-container">
+      <button class="btn btn-primary">主要按钮</button>
+      <button class="btn btn-secondary">次要按钮</button>
+      <button class="btn btn-outline">描边按钮</button>
+    </div>
+    <div class="code-block" style="margin-top:16px;">
+<span class="code-func">background-color</span>: <span class="code-func">light-dark</span>(<span class="code-string">#007bff</span>, <span class="code-string">#4d9fff</span>);
+<span class="code-func">color</span>: <span class="code-func">light-dark</span>(<span class="code-string">#fff</span>, <span class="code-string">#121212</span>);
+    </div>
+  </div>
+
+  <!-- 演示 5：局部主题强制 -->
+  <div class="demo-section">
+    <h2>5. 局部主题强制 <span class="badge badge-orange">进阶用法</span></h2>
+    <p>通过设置 <code>color-scheme: light</code> 或 <code>color-scheme: dark</code>，可以强制某个区域使用特定主题，覆盖用户偏好。</p>
+    <div class="force-light">
+      <strong>强制浅色区域</strong>
+      <p>此区域始终显示浅色主题，即使系统是暗色模式。</p>
+      <span class="theme-override-text">红色文字（浅色下）/ 橙色文字（深色下）</span>
+    </div>
+    <div class="force-dark">
+      <strong>强制深色区域</strong>
+      <p>此区域始终显示深色主题，即使系统是浅色模式。</p>
+      <span class="theme-override-text">红色文字（浅色下）/ 橙色文字（深色下）</span>
+    </div>
+    <div class="info-box">
+      <strong>工作原理：</strong>父元素的 <code>color-scheme</code> 会影响子元素中 <code>light-dark()</code> 的返回值。
+    </div>
+  </div>
+
+  <!-- 演示 6：边框和阴影 -->
+  <div class="demo-section">
+    <h2>6. 边框和阴影适配</h2>
+    <p><code>light-dark()</code> 可以用在任何接受颜色的 CSS 属性上。</p>
+    <div class="shadow-demo">
+      <h3 style="margin-top:0; color:light-dark(#1a1a1a, #f0f0f0);">带阴影的卡片</h3>
+      <p style="color:light-dark(#666, #aaa);">这个卡片的阴影在浅色主题下较淡，在深色主题下较深，符合真实世界的光照感知。</p>
+    </div>
+    <div class="code-block" style="margin-top:16px;">
+<span class="code-func">box-shadow</span>: <span class="code-func">light-dark</span>(
+  <span class="code-string">0 4px 16px rgba(0, 0, 0, 0.1)</span>,
+  <span class="code-string">0 4px 16px rgba(0, 0, 0, 0.5)</span>
+);
+    </div>
+  </div>
+
+  <!-- 演示 7：表单元素 -->
+  <div class="demo-section">
+    <h2>7. 表单元素</h2>
+    <p>输入框、标签等表单元素也能优雅地适配主题。</p>
+    <div class="form-demo">
+      <div class="form-group">
+        <label class="form-label">用户名</label>
+        <input type="text" class="form-input" placeholder="输入用户名">
+      </div>
+      <div class="form-group">
+        <label class="form-label">邮箱</label>
+        <input type="email" class="form-input" placeholder="输入邮箱">
+      </div>
+      <button class="btn btn-primary" style="width:100%;">提交</button>
+    </div>
+  </div>
+
+  <!-- 工作原理说明 -->
+  <div class="demo-section">
+    <h2>8. 与 prefers-color-scheme 对比</h2>
+    <p>传统方式需要写多行媒体查询，而 <code>light-dark()</code> 一行搞定。</p>
+    <div class="code-block">
+<span class="code-comment">/* 传统方式：需要 @media 块 */</span>
+<span class="code-keyword">@media</span> (<span class="code-func">prefers-color-scheme</span>: <span class="code-string">light</span>) {
+  <span class="code-keyword">body</span> { <span class="code-func">background</span>: <span class="code-string">#fff</span>; }
+}
+<span class="code-keyword">@media</span> (<span class="code-func">prefers-color-scheme</span>: <span class="code-string">dark</span>) {
+  <span class="code-keyword">body</span> { <span class="code-func">background</span>: <span class="code-string">#121212</span>; }
+}
+
+<span class="code-comment">/* light-dark() 方式：单行表达 */</span>
+<span class="code-keyword">body</span> { <span class="code-func">background</span>: <span class="code-func">light-dark</span>(<span class="code-string">#fff</span>, <span class="code-string">#121212</span>); }
+    </div>
+  </div>
+
+  <div class="note">
+    <strong>兼容性提示：</strong><code>light-dark()</code> 从 2024 年 5 月起获得 Baseline 支持。
+    如需支持旧版浏览器，请使用 <code>@media (prefers-color-scheme)</code> 作为降级方案。
+  </div>
+
+  <script>
+    function setColorScheme(scheme) {
+      document.documentElement.style.colorScheme = scheme;
+      // 更新按钮状态
+      document.querySelectorAll('.theme-switcher button').forEach(btn => {
+        btn.classList.remove('active');
+        if (btn.textContent === (
+          scheme === 'light dark' ? '自动' :
+          scheme === 'light' ? '浅色' : '深色'
+        )) {
+          btn.classList.add('active');
+        }
+      });
+    }
+
+    // 初始化按钮状态
+    setColorScheme('light dark');
+  </script>
+</body>
+</html>

--- a/examples/css/demos/overscroll-behavior/01-dialog-scroll.html
+++ b/examples/css/demos/overscroll-behavior/01-dialog-scroll.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>overscroll-behavior 演示一：弹窗防止背景滚动</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f5f5f5; }
+    h1 { font-size: 18px; color: #333; padding: 16px; }
+    .page-content {
+      padding: 16px;
+      height: calc(100vh - 60px);
+      overflow-y: auto;
+      background: linear-gradient(180deg, #e8e8e8 0%, #f5f5f5 100%);
+    }
+    .page-content p { margin-bottom: 16px; font-size: 14px; color: #666; line-height: 1.6; }
+    .btn {
+      display: inline-block;
+      padding: 10px 20px;
+      background: #007bff;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      font-size: 14px;
+      cursor: pointer;
+      margin: 8px;
+    }
+    .btn:hover { background: #0056b3; }
+    /* 背景列表 */
+    .background-list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    .list-item {
+      padding: 12px;
+      background: white;
+      border-radius: 8px;
+      font-size: 13px;
+      color: #333;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+    /* 弹窗 */
+    .dialog-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.5);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1000;
+      opacity: 0;
+      visibility: hidden;
+      transition: opacity 0.2s, visibility 0.2s;
+    }
+    .dialog-overlay.active { opacity: 1; visibility: visible; }
+    .dialog {
+      width: 90%;
+      max-width: 400px;
+      max-height: 70vh;
+      background: white;
+      border-radius: 12px;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    .dialog-header {
+      padding: 16px;
+      border-bottom: 1px solid #eee;
+      font-weight: 600;
+      font-size: 16px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      flex-shrink: 0;
+    }
+    .dialog-close {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      border: none;
+      background: #f0f0f0;
+      font-size: 18px;
+      cursor: pointer;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .dialog-close:hover { background: #e0e0e0; }
+    .dialog-content {
+      flex: 1;
+      overflow-y: auto;
+      overscroll-behavior: contain; /* 关键：阻止滚动链 */
+    }
+    .dialog-list { padding: 16px; }
+    .dialog-list .list-item { margin-bottom: 8px; }
+    .dialog-footer {
+      padding: 12px 16px;
+      border-top: 1px solid #eee;
+      display: flex;
+      gap: 8px;
+      justify-content: flex-end;
+      flex-shrink: 0;
+    }
+    .dialog-footer .btn { margin: 0; padding: 8px 16px; font-size: 13px; }
+    .btn-secondary { background: #6c757d; }
+    .info-bar {
+      background: #e7f3ff;
+      border: 1px solid #b3d7ff;
+      border-radius: 6px;
+      padding: 10px 14px;
+      font-size: 12px;
+      color: #004a99;
+      margin: 0 16px 16px;
+    }
+  </style>
+</head>
+<body>
+  <h1>案例一：弹窗防止背景滚动</h1>
+  <div class="info-bar">
+    💡 提示：点击「打开弹窗」按钮，在弹窗内滚动内容。注意背景页面是否会跟着滚动。设置 <code>overscroll-behavior: contain</code> 后，背景应保持不动。
+  </div>
+
+  <div class="page-content" id="pageContent">
+    <p>页面主内容区域 - 在弹窗打开时可以测试背景是否会被带动滚动</p>
+    <div class="background-list">
+      <div class="list-item">页面列表项 #1 - 背景内容</div>
+      <div class="list-item">页面列表项 #2 - 背景内容</div>
+      <div class="list-item">页面列表项 #3 - 背景内容</div>
+      <div class="list-item">页面列表项 #4 - 背景内容</div>
+      <div class="list-item">页面列表项 #5 - 背景内容</div>
+      <div class="list-item">页面列表项 #6 - 背景内容</div>
+      <div class="list-item">页面列表项 #7 - 背景内容</div>
+      <div class="list-item">页面列表项 #8 - 背景内容</div>
+      <div class="list-item">页面列表项 #9 - 背景内容</div>
+      <div class="list-item">页面列表项 #10 - 背景内容</div>
+    </div>
+  </div>
+
+  <div style="padding: 16px;">
+    <button class="btn" id="openDialog">打开弹窗</button>
+  </div>
+
+  <!-- 弹窗 -->
+  <div class="dialog-overlay" id="dialogOverlay">
+    <div class="dialog">
+      <div class="dialog-header">
+        <span>选择项目</span>
+        <button class="dialog-close" id="closeDialog">×</button>
+      </div>
+      <div class="dialog-content">
+        <div class="dialog-list">
+          <div class="list-item">弹窗列表项 #1</div>
+          <div class="list-item">弹窗列表项 #2</div>
+          <div class="list-item">弹窗列表项 #3</div>
+          <div class="list-item">弹窗列表项 #4</div>
+          <div class="list-item">弹窗列表项 #5</div>
+          <div class="list-item">弹窗列表项 #6</div>
+          <div class="list-item">弹窗列表项 #7</div>
+          <div class="list-item">弹窗列表项 #8</div>
+          <div class="list-item">弹窗列表项 #9</div>
+          <div class="list-item">弹窗列表项 #10</div>
+          <div class="list-item">弹窗列表项 #11</div>
+          <div class="list-item">弹窗列表项 #12</div>
+          <div class="list-item">弹窗列表项 #13</div>
+          <div class="list-item">弹窗列表项 #14</div>
+          <div class="list-item">弹窗列表项 #15</div>
+        </div>
+      </div>
+      <div class="dialog-footer">
+        <button class="btn btn-secondary" id="cancelDialog">取消</button>
+        <button class="btn" id="confirmDialog">确定</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const overlay = document.getElementById('dialogOverlay');
+    const openBtn = document.getElementById('openDialog');
+    const closeBtn = document.getElementById('closeDialog');
+    const cancelBtn = document.getElementById('cancelDialog');
+    const confirmBtn = document.getElementById('confirmDialog');
+    const pageContent = document.getElementById('pageContent');
+
+    function openDialog() {
+      overlay.classList.add('active');
+      // 禁止背景滚动
+      document.body.style.overflow = 'hidden';
+    }
+
+    function closeDialog() {
+      overlay.classList.remove('active');
+      // 恢复背景滚动
+      document.body.style.overflow = '';
+    }
+
+    openBtn.addEventListener('click', openDialog);
+    closeBtn.addEventListener('click', closeDialog);
+    cancelBtn.addEventListener('click', closeDialog);
+    confirmBtn.addEventListener('click', closeDialog);
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) closeDialog();
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/overscroll-behavior/02-horizontal-scroll.html
+++ b/examples/css/demos/overscroll-behavior/02-horizontal-scroll.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>overscroll-behavior 演示二：横向滚动与垂直锁定</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f5f5f5; }
+    h1 { font-size: 18px; color: #333; padding: 16px; }
+    .info-bar {
+      background: #e7f3ff;
+      border: 1px solid #b3d7ff;
+      border-radius: 6px;
+      padding: 10px 14px;
+      font-size: 12px;
+      color: #004a99;
+      margin: 0 16px 16px;
+    }
+    .info-bar code { background: #cce5ff; padding: 1px 4px; border-radius: 3px; }
+    .section { margin-bottom: 24px; }
+    .section-title {
+      font-size: 14px;
+      color: #666;
+      margin-bottom: 8px;
+      padding: 0 16px;
+    }
+    /* 横向轮播容器 */
+    .carousel {
+      display: flex;
+      gap: 12px;
+      padding: 16px;
+      overflow-x: auto;
+      overflow-y: hidden; /* 明确禁止垂直滚动 */
+      overscroll-behavior-x: contain; /* 关键：横向滚动时阻止垂直传递 */
+      scroll-snap-type: x mandatory;
+      -webkit-overflow-scrolling: touch;
+    }
+    .carousel::-webkit-scrollbar { height: 6px; }
+    .carousel::-webkit-scrollbar-track { background: #f0f0f0; border-radius: 3px; }
+    .carousel::-webkit-scrollbar-thumb { background: #ccc; border-radius: 3px; }
+    .carousel-item {
+      flex-shrink: 0;
+      width: 200px;
+      height: 140px;
+      background: white;
+      border-radius: 12px;
+      padding: 12px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+      scroll-snap-align: start;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+    }
+    .carousel-item-title { font-weight: 600; font-size: 14px; color: #333; }
+    .carousel-item-desc { font-size: 12px; color: #666; margin-top: 4px; }
+    .carousel-item-tag {
+      font-size: 11px;
+      padding: 4px 8px;
+      border-radius: 4px;
+      display: inline-block;
+    }
+    .tag-blue { background: #e7f3ff; color: #004a99; }
+    .tag-green { background: #e7ffe7; color: #006600; }
+    .tag-orange { background: #fff3e7; color: #995500; }
+    .tag-purple { background: #f3e7ff; color: #550099; }
+    /* 对比：未设置 overscroll-behavior 的容器 */
+    .carousel-raw {
+      display: flex;
+      gap: 12px;
+      padding: 16px;
+      overflow-x: auto;
+      overflow-y: hidden;
+      /* 没有 overscroll-behavior */
+      scroll-snap-type: x mandatory;
+      -webkit-overflow-scrolling: touch;
+    }
+    .carousel-raw .carousel-item { background: #fff0f0; }
+    .code-hint {
+      font-size: 11px;
+      color: #888;
+      padding: 0 16px;
+      margin-top: 4px;
+    }
+    /* 垂直嵌套滚动区域 */
+    .nested-scroll {
+      margin: 16px;
+      background: white;
+      border-radius: 12px;
+      padding: 16px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    .nested-scroll-title {
+      font-size: 14px;
+      font-weight: 600;
+      color: #333;
+      margin-bottom: 12px;
+    }
+    .nested-content {
+      height: 200px;
+      overflow-y: auto;
+      overscroll-behavior-y: contain; /* 垂直方向 contain */
+      -webkit-overflow-scrolling: touch;
+    }
+    .nested-item {
+      padding: 10px 0;
+      border-bottom: 1px solid #eee;
+      font-size: 13px;
+      color: #666;
+    }
+    .nested-item:last-child { border-bottom: none; }
+  </style>
+</head>
+<body>
+  <h1>案例二：横向滚动与垂直锁定</h1>
+  <div class="info-bar">
+    💡 提示：<code>overscroll-behavior-x: contain</code> 在横向滚动时阻止滚动链传递到页面。<code>overflow-y: hidden</code> 确保垂直方向不会滚动。斜向滑动时背景不会乱跳。
+  </div>
+
+  <!-- 正确实现：使用 contain -->
+  <div class="section">
+    <div class="section-title">✅ 正确实现：overscroll-behavior-x: contain</div>
+    <div class="carousel">
+      <div class="carousel-item">
+        <div>
+          <div class="carousel-item-title">卡片标题 #1</div>
+          <div class="carousel-item-desc">这是描述文字</div>
+        </div>
+        <span class="carousel-item-tag tag-blue">精选</span>
+      </div>
+      <div class="carousel-item">
+        <div>
+          <div class="carousel-item-title">卡片标题 #2</div>
+          <div class="carousel-item-desc">这是描述文字</div>
+        </div>
+        <span class="carousel-item-tag tag-green">新品</span>
+      </div>
+      <div class="carousel-item">
+        <div>
+          <div class="carousel-item-title">卡片标题 #3</div>
+          <div class="carousel-item-desc">这是描述文字</div>
+        </div>
+        <span class="carousel-item-tag tag-orange">热卖</span>
+      </div>
+      <div class="carousel-item">
+        <div>
+          <div class="carousel-item-title">卡片标题 #4</div>
+          <div class="carousel-item-desc">这是描述文字</div>
+        </div>
+        <span class="carousel-item-tag tag-purple">推荐</span>
+      </div>
+      <div class="carousel-item">
+        <div>
+          <div class="carousel-item-title">卡片标题 #5</div>
+          <div class="carousel-item-desc">这是描述文字</div>
+        </div>
+        <span class="carousel-item-tag tag-blue">精选</span>
+      </div>
+      <div class="carousel-item">
+        <div>
+          <div class="carousel-item-title">卡片标题 #6</div>
+          <div class="carousel-item-desc">这是描述文字</div>
+        </div>
+        <span class="carousel-item-tag tag-green">新品</span>
+      </div>
+    </div>
+    <div class="code-hint">scroll-snap + overscroll-behavior-x: contain</div>
+  </div>
+
+  <!-- 错误实现：没有 contain -->
+  <div class="section">
+    <div class="section-title">⚠️ 对比：无 overscroll-behavior（斜滑可能触发页面滚动）</div>
+    <div class="carousel-raw">
+      <div class="carousel-item">
+        <div>
+          <div class="carousel-item-title">卡片 A</div>
+          <div class="carousel-item-desc">无 contain</div>
+        </div>
+        <span class="carousel-item-tag tag-blue">示例</span>
+      </div>
+      <div class="carousel-item">
+        <div>
+          <div class="carousel-item-title">卡片 B</div>
+          <div class="carousel-item-desc">无 contain</div>
+        </div>
+        <span class="carousel-item-tag tag-blue">示例</span>
+      </div>
+      <div class="carousel-item">
+        <div>
+          <div class="carousel-item-title">卡片 C</div>
+          <div class="carousel-item-desc">无 contain</div>
+        </div>
+        <span class="carousel-item-tag tag-blue">示例</span>
+      </div>
+      <div class="carousel-item">
+        <div>
+          <div class="carousel-item-title">卡片 D</div>
+          <div class="carousel-item-desc">无 contain</div>
+        </div>
+        <span class="carousel-item-tag tag-blue">示例</span>
+      </div>
+      <div class="carousel-item">
+        <div>
+          <div class="carousel-item-title">卡片 E</div>
+          <div class="carousel-item-desc">无 contain</div>
+        </div>
+        <span class="carousel-item-tag tag-blue">示例</span>
+      </div>
+    </div>
+  </div>
+
+  <!-- 嵌套垂直滚动 -->
+  <div class="section">
+    <div class="section-title">🔽 嵌套垂直滚动区域：overscroll-behavior-y: contain</div>
+    <div class="nested-scroll">
+      <div class="nested-scroll-title">嵌套的可滚动区域</div>
+      <div class="nested-content">
+        <div class="nested-item">嵌套内容 #1 - 垂直滚动不会影响外部</div>
+        <div class="nested-item">嵌套内容 #2</div>
+        <div class="nested-item">嵌套内容 #3</div>
+        <div class="nested-item">嵌套内容 #4</div>
+        <div class="nested-item">嵌套内容 #5</div>
+        <div class="nested-item">嵌套内容 #6</div>
+        <div class="nested-item">嵌套内容 #7</div>
+        <div class="nested-item">嵌套内容 #8</div>
+        <div class="nested-item">嵌套内容 #9</div>
+        <div class="nested-item">嵌套内容 #10</div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/overscroll-behavior/03-boundary-control.html
+++ b/examples/css/demos/overscroll-behavior/03-boundary-control.html
@@ -1,0 +1,265 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>overscroll-behavior 演示三：边界行为对比</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #f5f5f5; }
+    h1 { font-size: 18px; color: #333; padding: 16px; }
+    .info-bar {
+      background: #fff7e6;
+      border: 1px solid #ffcc80;
+      border-radius: 6px;
+      padding: 10px 14px;
+      font-size: 12px;
+      color: #995500;
+      margin: 0 16px 16px;
+    }
+    .info-bar code { background: #fff3cc; padding: 1px 4px; border-radius: 3px; }
+    .demo-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 16px;
+      padding: 0 16px;
+    }
+    @media (max-width: 768px) {
+      .demo-grid { grid-template-columns: 1fr; }
+    }
+    .demo-card {
+      background: white;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    .demo-header {
+      padding: 12px;
+      font-weight: 600;
+      font-size: 14px;
+      text-align: center;
+      color: white;
+    }
+    .demo-header.auto { background: #6c757d; }
+    .demo-header.contain { background: #28a745; }
+    .demo-header.none { background: #dc3545; }
+    .demo-content {
+      height: 250px;
+      overflow-y: auto;
+      -webkit-overflow-scrolling: touch;
+    }
+    .demo-content::-webkit-scrollbar { width: 6px; }
+    .demo-content::-webkit-scrollbar-track { background: #f0f0f0; }
+    .demo-content::-webkit-scrollbar-thumb { background: #ccc; border-radius: 3px; }
+    .demo-content.auto { overscroll-behavior: auto; }
+    .demo-content.contain { overscroll-behavior: contain; }
+    .demo-content.none { overscroll-behavior: none; }
+    .scroll-item {
+      padding: 14px;
+      border-bottom: 1px solid #eee;
+      font-size: 13px;
+      color: #666;
+    }
+    .scroll-item:last-child { border-bottom: none; }
+    .demo-desc {
+      padding: 10px 12px;
+      font-size: 11px;
+      color: #888;
+      background: #fafafa;
+      border-top: 1px solid #eee;
+    }
+    .behavior-table {
+      margin: 24px 16px;
+      background: white;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+    .behavior-table h3 {
+      padding: 16px;
+      font-size: 14px;
+      background: #f8f8f8;
+      border-bottom: 1px solid #eee;
+    }
+    .behavior-table table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 12px;
+    }
+    .behavior-table th, .behavior-table td {
+      padding: 10px 12px;
+      text-align: left;
+      border-bottom: 1px solid #eee;
+    }
+    .behavior-table th {
+      background: #f5f5f5;
+      font-weight: 600;
+      color: #333;
+    }
+    .check { color: #28a745; }
+    .cross { color: #dc3545; }
+    .demo-code {
+      margin: 24px 16px;
+      background: #1e1e1e;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    .demo-code-header {
+      padding: 8px 12px;
+      background: #2d2d2d;
+      font-size: 12px;
+      color: #888;
+      font-family: 'SF Mono', Monaco, monospace;
+    }
+    .demo-code pre {
+      padding: 12px;
+      margin: 0;
+      font-family: 'SF Mono', Monaco, monospace;
+      font-size: 12px;
+      color: #d4d4d4;
+      overflow-x: auto;
+      line-height: 1.5;
+    }
+    .demo-code .keyword { color: #569cd6; }
+    .demo-code .value { color: #ce9178; }
+    .demo-code .comment { color: #6a9955; }
+  </style>
+</head>
+<body>
+  <h1>案例三：边界行为对比</h1>
+  <div class="info-bar">
+    💡 提示：对比三种值的差异。滚动到边界时观察：<code>auto</code> 会传递到父元素，<code>contain</code> 阻止传递但保留弹性，<code>none</code> 完全禁用弹性效果。
+  </div>
+
+  <div class="demo-grid">
+    <!-- auto -->
+    <div class="demo-card">
+      <div class="demo-header auto">auto（默认）</div>
+      <div class="demo-content auto" id="autoDemo">
+        <div class="scroll-item">列表项 #1</div>
+        <div class="scroll-item">列表项 #2</div>
+        <div class="scroll-item">列表项 #3</div>
+        <div class="scroll-item">列表项 #4</div>
+        <div class="scroll-item">列表项 #5</div>
+        <div class="scroll-item">列表项 #6</div>
+        <div class="scroll-item">列表项 #7</div>
+        <div class="scroll-item">列表项 #8</div>
+        <div class="scroll-item">列表项 #9</div>
+        <div class="scroll-item">列表项 #10</div>
+        <div class="scroll-item">列表项 #11</div>
+        <div class="scroll-item">列表项 #12</div>
+        <div class="scroll-item">列表项 #13</div>
+        <div class="scroll-item">列表项 #14</div>
+        <div class="scroll-item">列表项 #15</div>
+      </div>
+      <div class="demo-desc">滚动链会传递到父容器，弹性效果正常显示</div>
+    </div>
+
+    <!-- contain -->
+    <div class="demo-card">
+      <div class="demo-header contain">contain</div>
+      <div class="demo-content contain" id="containDemo">
+        <div class="scroll-item">列表项 #1</div>
+        <div class="scroll-item">列表项 #2</div>
+        <div class="scroll-item">列表项 #3</div>
+        <div class="scroll-item">列表项 #4</div>
+        <div class="scroll-item">列表项 #5</div>
+        <div class="scroll-item">列表项 #6</div>
+        <div class="scroll-item">列表项 #7</div>
+        <div class="scroll-item">列表项 #8</div>
+        <div class="scroll-item">列表项 #9</div>
+        <div class="scroll-item">列表项 #10</div>
+        <div class="scroll-item">列表项 #11</div>
+        <div class="scroll-item">列表项 #12</div>
+        <div class="scroll-item">列表项 #13</div>
+        <div class="scroll-item">列表项 #14</div>
+        <div class="scroll-item">列表项 #15</div>
+      </div>
+      <div class="demo-desc">阻止滚动链传递，弹性效果保留，下拉刷新禁用</div>
+    </div>
+
+    <!-- none -->
+    <div class="demo-card">
+      <div class="demo-header none">none</div>
+      <div class="demo-content none" id="noneDemo">
+        <div class="scroll-item">列表项 #1</div>
+        <div class="scroll-item">列表项 #2</div>
+        <div class="scroll-item">列表项 #3</div>
+        <div class="scroll-item">列表项 #4</div>
+        <div class="scroll-item">列表项 #5</div>
+        <div class="scroll-item">列表项 #6</div>
+        <div class="scroll-item">列表项 #7</div>
+        <div class="scroll-item">列表项 #8</div>
+        <div class="scroll-item">列表项 #9</div>
+        <div class="scroll-item">列表项 #10</div>
+        <div class="scroll-item">列表项 #11</div>
+        <div class="scroll-item">列表项 #12</div>
+        <div class="scroll-item">列表项 #13</div>
+        <div class="scroll-item">列表项 #14</div>
+        <div class="scroll-item">列表项 #15</div>
+      </div>
+      <div class="demo-desc">阻止滚动链传递，弹性效果完全禁用</div>
+    </div>
+  </div>
+
+  <div class="behavior-table">
+    <h3>值对比速查表</h3>
+    <table>
+      <thead>
+        <tr>
+          <th>行为</th>
+          <th>auto</th>
+          <th>contain</th>
+          <th>none</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>滚动链传递到父容器</td>
+          <td class="check">✓ 会传递</td>
+          <td class="cross">✗ 阻止</td>
+          <td class="cross">✗ 阻止</td>
+        </tr>
+        <tr>
+          <td>边界弹性效果</td>
+          <td class="check">✓ 保留</td>
+          <td class="check">✓ 保留</td>
+          <td class="cross">✗ 禁用</td>
+        </tr>
+        <tr>
+          <td>下拉刷新手势</td>
+          <td class="check">✓ 启用</td>
+          <td class="cross">✗ 禁用</td>
+          <td class="cross">✗ 禁用</td>
+        </tr>
+        <tr>
+          <td>水平页面导航</td>
+          <td class="check">✓ 启用</td>
+          <td class="cross">✗ 禁用</td>
+          <td class="cross">✗ 禁用</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="demo-code">
+    <div class="demo-code-header">代码示例</div>
+    <pre><span class="comment">/* 阻止滚动链，保留弹性效果 */</span>
+<span class="keyword">.dialog-content</span> {
+  <span class="keyword">overflow-y</span>: <span class="value">auto</span>;
+  <span class="keyword">overscroll-behavior</span>: <span class="value">contain</span>;
+}
+
+<span class="comment">/* 彻底禁用边界效果 */</span>
+<span class="keyword">.scroll-area</span> {
+  <span class="keyword">overscroll-behavior</span>: <span class="value">none</span>;
+}
+
+<span class="comment">/* 分轴控制 */</span>
+<span class="keyword">.carousel</span> {
+  <span class="keyword">overscroll-behavior-x</span>: <span class="value">contain</span>;
+  <span class="keyword">overscroll-behavior-y</span>: <span class="value">none</span>;
+}</pre>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/text-box-trim/button-centering.html
+++ b/examples/css/demos/text-box-trim/button-centering.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>按钮垂直居中 - text-box-trim</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      padding: 40px;
+      background: #1a1a2e;
+      color: #eee;
+    }
+
+    h1 {
+      color: #fff;
+      margin-bottom: 30px;
+    }
+
+    .demo-section {
+      margin: 30px 0;
+      padding: 20px;
+      background: #16213e;
+      border-radius: 8px;
+    }
+
+    h2 {
+      color: #e94560;
+      font-size: 16px;
+      margin-bottom: 15px;
+    }
+
+    .comparison {
+      display: flex;
+      gap: 40px;
+      align-items: center;
+      flex-wrap: wrap;
+    }
+
+    /* 传统方式：手动调整 padding */
+    .btn-traditional {
+      padding-block: 5px; /* 手动减少上下 padding 补偿半行距 */
+      padding-inline: 20px;
+      background: #3b82f6;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      font-size: 16px;
+    }
+
+    /* 使用 text-box-trim */
+    .btn-trimmed {
+      text-box: trim-both cap alphabetic;
+      padding: 10px 20px;
+      background: #3b82f6;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      font-size: 16px;
+    }
+
+    /* 背景条，便于观察对齐 */
+    .btn-wrapper {
+      position: relative;
+    }
+
+    .btn-traditional-wrapper,
+    .btn-trimmed-wrapper {
+      display: inline-block;
+      background: rgba(233, 69, 96, 0.3);
+      border: 1px dashed #e94560;
+      padding: 5px;
+      margin: 10px;
+    }
+
+    .label {
+      display: block;
+      font-size: 12px;
+      color: #888;
+      margin-top: 8px;
+    }
+
+    /* 文字说明 */
+    .description {
+      font-size: 14px;
+      color: #aaa;
+      margin-top: 20px;
+    }
+
+    code {
+      background: #0f3460;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 13px;
+    }
+
+    .highlight {
+      color: #e94560;
+    }
+  </style>
+</head>
+<body>
+  <h1>text-box-trim: 按钮垂直居中</h1>
+
+  <div class="demo-section">
+    <h2>对比：传统 padding vs text-box-trim</h2>
+    <div class="comparison">
+      <div>
+        <div class="btn-traditional-wrapper">
+          <button class="btn-traditional">按钮文本</button>
+        </div>
+        <span class="label">传统方式 padding-block: 5px</span>
+      </div>
+
+      <div>
+        <div class="btn-trimmed-wrapper">
+          <button class="btn-trimmed">按钮文本</button>
+        </div>
+        <span class="label">text-box: trim-both cap alphabetic</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="description">
+    <p>左侧红色虚线边框显示元素实际占据的空间。</p>
+    <p>使用 <code>text-box: trim-both cap alphabetic</code> 后，<span class="highlight">padding: 10px</span> 在四个方向上真正相等，</p>
+    <p>无需手动调整上下 padding 来补偿半行距。</p>
+  </div>
+
+  <div class="demo-section">
+    <h2>不同字体的效果</h2>
+    <p class="description">每种字体的半行距不同，但 text-box-trim 可以统一修剪效果</p>
+    <div style="display: flex; gap: 20px; flex-wrap: wrap; margin-top: 15px;">
+      <div class="btn-trimmed-wrapper" style="font-family: 'Times New Roman', serif;">
+        <button class="btn-trimmed" style="font-family: 'Times New Roman', serif;">Serif</button>
+      </div>
+      <div class="btn-trimmed-wrapper" style="font-family: 'Arial', sans-serif;">
+        <button class="btn-trimmed" style="font-family: 'Arial', sans-serif;">Sans-serif</button>
+      </div>
+      <div class="btn-trimmed-wrapper" style="font-family: 'Courier New', monospace;">
+        <button class="btn-trimmed" style="font-family: 'Courier New', monospace;">Monospace</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>浏览器兼容性</h2>
+    <p class="description">
+      <span style="color: #4ade80;">✓ Chrome 133+</span> &nbsp;
+      <span style="color: #4ade80;">✓ Safari 18.2+</span> &nbsp;
+      <span style="color: #f87171;">✗ Firefox (不支持)</span>
+    </p>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/text-box-trim/image-text-alignment.html
+++ b/examples/css/demos/text-box-trim/image-text-alignment.html
@@ -1,0 +1,292 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>图文对齐 - text-box-trim</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      padding: 40px;
+      background: #1a1a2e;
+      color: #eee;
+      line-height: 1.6;
+    }
+
+    h1 {
+      color: #fff;
+      margin-bottom: 30px;
+    }
+
+    .demo-section {
+      margin: 30px 0;
+      padding: 20px;
+      background: #16213e;
+      border-radius: 8px;
+    }
+
+    h2 {
+      color: #e94560;
+      font-size: 16px;
+      margin-bottom: 15px;
+    }
+
+    .description {
+      font-size: 14px;
+      color: #aaa;
+      margin-bottom: 15px;
+    }
+
+    code {
+      background: #0f3460;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 13px;
+    }
+
+    .highlight {
+      color: #e94560;
+    }
+
+    /* Flex 容器 */
+    .flex-container {
+      display: flex;
+      align-items: baseline; /* 使用基线对齐 */
+      gap: 15px;
+      margin: 15px 0;
+    }
+
+    .flex-container.trimmed .text {
+      text-box: trim-both cap alphabetic;
+    }
+
+    /* 图片占位 */
+    .image-placeholder {
+      width: 60px;
+      height: 60px;
+      background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      color: white;
+    }
+
+    /* 文本 */
+    .text {
+      background: rgba(59, 130, 246, 0.2);
+      padding: 10px;
+    }
+
+    /* 边框辅助线 */
+    .border-box {
+      position: relative;
+    }
+
+    .border-box::before {
+      content: '';
+      position: absolute;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      border: 1px dashed #e94560;
+      pointer-events: none;
+    }
+
+    /* 对比表格 */
+    .comparison-wrapper {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 20px;
+      margin: 15px 0;
+    }
+
+    @media (max-width: 600px) {
+      .comparison-wrapper {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .comparison-item {
+      background: #0f3460;
+      padding: 15px;
+      border-radius: 8px;
+    }
+
+    .comparison-item h3 {
+      margin: 0 0 10px 0;
+      color: #e94560;
+      font-size: 14px;
+    }
+
+    /* writing-mode 演示 */
+    .writing-mode-demo {
+      margin: 15px 0;
+    }
+
+    .writing-mode-demo .flex-container {
+      margin: 10px 0;
+    }
+
+    /* Card 列表 */
+    .card-list {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 15px;
+      margin: 15px 0;
+    }
+
+    .card {
+      background: #0f3460;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+
+    .card-image {
+      height: 100px;
+      background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-size: 12px;
+    }
+
+    .card-content {
+      padding: 12px;
+    }
+
+    .card-title {
+      margin: 0 0 8px 0;
+      font-size: 14px;
+    }
+
+    .card-title.trimmed {
+      text-box: trim-both cap alphabetic;
+    }
+
+    .card-desc {
+      margin: 0;
+      font-size: 12px;
+      color: #aaa;
+    }
+
+    .card-desc.trimmed {
+      text-box: trim-both cap alphabetic;
+    }
+  </style>
+</head>
+<body>
+  <h1>text-box-trim: 图文对齐</h1>
+
+  <div class="demo-section">
+    <h2>基线对齐问题</h2>
+    <p class="description">
+      当图片与文本并排时，文本的半行距会导致图片高度不匹配。使用 <code>text-box-trim</code> 可以精确对齐。
+    </p>
+
+    <div class="comparison-wrapper">
+      <div class="comparison-item">
+        <h3>未使用 text-box-trim</h3>
+        <div class="flex-container">
+          <div class="image-placeholder border-box">图片</div>
+          <div class="text border-box">
+            这是一段普通文本，用于展示未修剪的效果。可以看到高度不一致。
+          </div>
+        </div>
+        <p class="description" style="margin-top: 10px; font-size: 12px;">
+          文本的半行距导致容器高度超出图片
+        </p>
+      </div>
+
+      <div class="comparison-item">
+        <h3>使用 text-box-trim</h3>
+        <div class="flex-container trimmed">
+          <div class="image-placeholder border-box">图片</div>
+          <div class="text border-box">
+            这是一段使用了 text-box-trim 的文本，现在高度精确匹配。
+          </div>
+        </div>
+        <p class="description" style="margin-top: 10px; font-size: 12px;">
+          修剪后半行距，高度与图片精确对齐
+        </p>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>多行文本 + 图片</h2>
+    <p class="description">多行文本的对齐更具挑战性，text-box-trim 可以完美解决</p>
+
+    <div class="flex-container trimmed" style="margin: 20px 0;">
+      <div class="image-placeholder" style="width: 80px; height: 80px;">80x80</div>
+      <div class="text" style="text-box: trim-both cap alphabetic;">
+        这是一个较长的段落，包含多行文本。
+        当文字换行时，半行距会导致容器高度不匹配。
+        使用 text-box-trim 可以让图片和文本高度精确对齐。
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>writing-mode 适配</h2>
+    <p class="description">text-box-trim 会自动适配不同的书写模式</p>
+
+    <div class="writing-mode-demo">
+      <div class="flex-container trimmed">
+        <div class="image-placeholder" style="width: 40px; height: 40px; flex-shrink: 0;">图</div>
+        <div class="text" style="text-box: trim-both cap alphabetic;">
+          水平书写模式 (ltr) - 默认
+        </div>
+      </div>
+
+      <div class="flex-container trimmed" style="writing-mode: vertical-rl;">
+        <div class="image-placeholder" style="width: 40px; height: 40px; flex-shrink: 0;">图</div>
+        <div class="text" style="text-box: trim-both cap alphabetic;">
+          垂直书写模式
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>卡片列表应用</h2>
+    <p class="description">在卡片组件中使用 text-box-trim 实现统一的标题和描述对齐</p>
+
+    <div class="card-list">
+      <div class="card">
+        <div class="card-image">图片</div>
+        <div class="card-content">
+          <h4 class="card-title">卡片标题文本</h4>
+          <p class="card-desc">这是卡片描述文字，用于展示内容摘要信息</p>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-image">图片</div>
+        <div class="card-content">
+          <h4 class="card-title trimmed">卡片标题已修剪</h4>
+          <p class="card-desc trimmed">这是卡片描述文字，已修剪半行距</p>
+        </div>
+      </div>
+      <div class="card">
+        <div class="card-image">图片</div>
+        <div class="card-content">
+          <h4 class="card-title trimmed">另一张卡片</h4>
+          <p class="card-desc trimmed">保持一致的垂直间距</p>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>浏览器兼容性</h2>
+    <p class="description">
+      <span style="color: #4ade80;">✓ Chrome 133+</span> &nbsp;
+      <span style="color: #4ade80;">✓ Safari 18.2+</span> &nbsp;
+      <span style="color: #f87171;">✗ Firefox (不支持)</span>
+    </p>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/text-box-trim/multiline-trim.html
+++ b/examples/css/demos/text-box-trim/multiline-trim.html
@@ -1,0 +1,212 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>多行文本裁剪 - text-box-trim</title>
+  <style>
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      padding: 40px;
+      background: #1a1a2e;
+      color: #eee;
+      line-height: 1.6;
+    }
+
+    h1 {
+      color: #fff;
+      margin-bottom: 30px;
+    }
+
+    .demo-section {
+      margin: 30px 0;
+      padding: 20px;
+      background: #16213e;
+      border-radius: 8px;
+    }
+
+    h2 {
+      color: #e94560;
+      font-size: 16px;
+      margin-bottom: 15px;
+    }
+
+    .description {
+      font-size: 14px;
+      color: #aaa;
+      margin-bottom: 15px;
+    }
+
+    code {
+      background: #0f3460;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 13px;
+    }
+
+    /* 多行文本容器 */
+    .text-container {
+      background: rgba(233, 69, 96, 0.2);
+      border: 1px dashed #e94560;
+      margin: 15px 0;
+      padding: 15px;
+    }
+
+    .text-box {
+      background: rgba(59, 130, 246, 0.3);
+      padding: 15px;
+      margin: 10px 0;
+    }
+
+    .multiline {
+      line-height: 1.5;
+    }
+
+    .multiline.trimmed {
+      text-box: trim-both cap alphabetic;
+    }
+
+    /* 小标签/Badge 示例 */
+    .badge-container {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      margin: 15px 0;
+    }
+
+    .badge {
+      padding: 5px 12px;
+      border-radius: 4px;
+      font-size: 13px;
+      background: #3b82f6;
+      color: white;
+    }
+
+    .badge.trimmed {
+      text-box: trim-both cap alphabetic;
+    }
+
+    /* 表格布局对齐 */
+    .comparison-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 15px 0;
+    }
+
+    .comparison-table th,
+    .comparison-table td {
+      padding: 10px;
+      text-align: left;
+      border-bottom: 1px solid #333;
+    }
+
+    .comparison-table th {
+      color: #e94560;
+    }
+
+    .highlight {
+      color: #e94560;
+    }
+  </style>
+</head>
+<body>
+  <h1>text-box-trim: 多行文本裁剪</h1>
+
+  <div class="demo-section">
+    <h2>单行 vs 多行文本</h2>
+    <p class="description">
+      每行文本都有半行距空间（half-leading），text-box-trim 可以统一修剪这些空间。
+    </p>
+
+    <table class="comparison-table">
+      <thead>
+        <tr>
+          <th>未修剪</th>
+          <th>已修剪 (trim-both cap alphabetic)</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <div class="text-box multiline">
+              第一行文本<br>
+              第二行文本<br>
+              第三行文本
+            </div>
+          </td>
+          <td>
+            <div class="text-box multiline trimmed">
+              第一行文本<br>
+              第二行文本<br>
+              第三行文本
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p class="description">
+      注意红色边框区域：<span class="highlight">左侧有额外的上下空间，右侧已修剪</span>
+    </p>
+  </div>
+
+  <div class="demo-section">
+    <h2>标签/徽章应用</h2>
+    <p class="description">标签类场景通常需要紧凑的垂直间距</p>
+
+    <div class="badge-container">
+      <span class="badge">未修剪标签</span>
+      <span class="badge">未修剪标签</span>
+      <span class="badge">未修剪标签</span>
+    </div>
+
+    <div class="badge-container">
+      <span class="badge trimmed">已修剪标签</span>
+      <span class="badge trimmed">已修剪标签</span>
+      <span class="badge trimmed">已修剪标签</span>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>配合 line-height 使用</h2>
+    <p class="description">
+      <code>line-height</code> 控制行间距，<code>text-box-trim</code> 修剪文本框边缘。
+      <br>两者配合使用可以实现精确的间距控制。
+    </p>
+
+    <div style="display: flex; gap: 20px; flex-wrap: wrap;">
+      <div class="text-container">
+        <p style="line-height: 1.2; margin: 0;">line-height: 1.2<br>这是第二行</p>
+      </div>
+      <div class="text-container">
+        <p style="line-height: 1.2; text-box: trim-both cap alphabetic; margin: 0;">line-height: 1.2<br>+ trim-both</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>实际应用场景</h2>
+    <p class="description">卡片列表中的紧凑文本布局</p>
+
+    <div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 15px; margin-top: 15px;">
+      <div style="background: #0f3460; padding: 15px; border-radius: 8px;">
+        <h3 style="margin: 0 0 10px 0; color: #3b82f6;">未使用 text-box</h3>
+        <p style="margin: 0; line-height: 1.5;">这是一个普通的段落文本，用于展示未修剪的效果。可以看到上下有额外的空间。</p>
+      </div>
+      <div style="background: #0f3460; padding: 15px; border-radius: 8px;">
+        <h3 style="margin: 0 0 10px 0; color: #3b82f6; text-box: trim-both cap alphabetic;">已使用 text-box</h3>
+        <p style="margin: 0; line-height: 1.5; text-box: trim-both cap alphabetic;">这是一个使用了 text-box-trim 的段落文本，上下空间被修剪掉了。</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>浏览器兼容性</h2>
+    <p class="description">
+      <span style="color: #4ade80;">✓ Chrome 133+</span> &nbsp;
+      <span style="color: #4ade80;">✓ Safari 18.2+</span> &nbsp;
+      <span style="color: #f87171;">✗ Firefox (不支持)</span>
+    </p>
+  </div>
+</body>
+</html>

--- a/src/topics/01.basics/11.light-dark/index.mdx
+++ b/src/topics/01.basics/11.light-dark/index.mdx
@@ -1,0 +1,290 @@
+---
+title: "CSS light-dark() 暗色模式切换函数"
+category: "基础知识"
+tags:
+  - CSS颜色
+  - 暗色模式
+  - light-dark
+  - color-scheme
+  - CSS4
+description: "详解CSS light-dark()函数实现简洁的明暗主题切换，无需媒体查询即可响应系统主题"
+keywords: "CSS light-dark, 暗色模式, color-scheme, CSS颜色函数, 明暗主题"
+---
+
+# CSS light-dark() 暗色模式切换函数
+
+## 什么是 light-dark()
+
+`light-dark()` 是 CSS Color Level 5 引入的**颜色函数**，用于在明色和暗色主题之间切换。它提供了一种声明式的方式来根据用户的主题偏好自动选择颜色，无需编写复杂的媒体查询。
+
+```css
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  color: light-dark(#333b3c, #efefec);
+  background-color: light-dark(#efedea, #223a2c);
+}
+```
+
+> **核心优势**：`light-dark()` 让主题切换代码从多行的 `@media` 块压缩成单行表达式。
+
+## 语法
+
+```css
+/* 基本语法 */
+color: light-dark(light-color, dark-color);
+
+/* 示例 */
+color: light-dark(black, white);
+color: light-dark(rgb(0 0 0), rgb(255 255 255));
+color: light-dark(var(--light-text), var(--dark-text));
+```
+
+### 参数说明
+
+| 参数 | 说明 |
+|------|------|
+| `light-color` | 亮色主题下使用的颜色值，支持任意 `<color>` 类型 |
+| `dark-color` | 暗色主题下使用的颜色值，支持任意 `<color>` 类型 |
+
+### 前置条件
+
+**必须设置 `color-scheme`**：要让 `light-dark()` 生效，需要在 `:root`（或相关元素）上声明 `color-scheme: light dark`，否则浏览器行为不确定。
+
+```css
+:root {
+  color-scheme: light dark;  /* 启用 light-dark() */
+}
+```
+
+## 与 prefers-color-scheme 的区别
+
+| 特性 | `light-dark()` | `prefers-color-scheme` |
+|------|---------------|------------------------|
+| **代码量** | 单行表达式 | 需要完整的媒体查询块 |
+| **声明式** | ✅ 是 | ❌ 否（是命令式） |
+| **可读性** | 高，直观表达"亮色/暗色" | 较低，需理解媒体查询 |
+| **局部控制** | 可在任何元素上使用 | 通常只能控制块级作用域 |
+| **覆盖能力** | 可被 `color-scheme` 局部覆盖 | 只能通过重复定义覆盖 |
+| **浏览器支持** | 较新（2024+） | 广泛支持 |
+
+### prefers-color-scheme 示例（传统方式）
+
+```css
+:root {
+  color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: light) {
+  body {
+    --text-color: #333b3c;
+    --bg-color: #efedea;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    --text-color: #efefec;
+    --bg-color: #223a2c;
+  }
+}
+
+body {
+  color: var(--text-color);
+  background-color: var(--bg-color);
+}
+```
+
+### light-dark() 示例（简化方式）
+
+```css
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  color: light-dark(#333b3c, #efefec);
+  background-color: light-dark(#efedea, #223a2c);
+}
+```
+
+两种方式效果完全一致，但 `light-dark()` 更加简洁。
+
+## 局部主题强制
+
+`light-dark()` 的一个独特优势是可以通过 `color-scheme` 属性**强制局部区域使用特定主题**，而不会干扰整体的用户偏好设置。
+
+```css
+:root {
+  color-scheme: light dark;
+}
+
+/* 强制某个区域始终使用浅色主题 */
+.admonition-light {
+  color-scheme: light;
+  background-color: light-dark(white, transparent);
+  border: 1px solid light-dark(#ddd, transparent);
+}
+
+/* 强制某个区域始终使用深色主题 */
+.admonition-dark {
+  color-scheme: dark;
+  background-color: light-dark(transparent, #1a1a1a);
+  border: 1px solid light-dark(transparent, #333);
+}
+```
+
+## 实际应用场景
+
+### 1. 基础文本和背景色
+
+```css
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  color: light-dark(#1a1a1a, #f0f0f0);
+  background-color: light-dark(#ffffff, #121212);
+}
+```
+
+### 2. 使用 CSS 自定义属性
+
+```css
+:root {
+  color-scheme: light dark;
+  
+  --primary: #007bff;
+  --surface: #ffffff;
+  --text: #1a1a1a;
+  --border: #e0e0e0;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --primary: #4d9fff;
+    --surface: #1e1e1e;
+    --text: #f0f0f0;
+    --border: #333333;
+  }
+}
+
+/* 使用 light-dark() 简化 */
+.card {
+  background: light-dark(var(--surface), var(--surface));
+  color: light-dark(var(--text), var(--text));
+  border: 1px solid var(--border);
+}
+```
+
+### 3. 组件级别的主题隔离
+
+```css
+/* 父组件使用浅色主题 */
+.theme-light {
+  color-scheme: light;
+}
+
+/* 父组件使用暗色主题 */
+.theme-dark {
+  color-scheme: dark;
+}
+
+.badge {
+  background-color: light-dark(#e3f2fd, #1e3a5f);
+  color: light-dark(#1565c0, #90caf9);
+}
+```
+
+### 4. 代码高亮
+
+```css
+code {
+  color: light-dark(#d63384, #e5a54b);
+}
+
+pre {
+  background-color: light-dark(#f8f9fa, #1e1e1e);
+  color: light-dark(#212529, #d4d4d4);
+}
+```
+
+### 5. 边框和阴影
+
+```css
+.card {
+  background: light-dark(#ffffff, #1e1e1e);
+  border: 1px solid light-dark(#e0e0e0, #333333);
+  box-shadow: light-dark(
+    0 2px 8px rgba(0, 0, 0, 0.1),
+    0 2px 8px rgba(0, 0, 0, 0.4)
+  );
+}
+```
+
+## 浏览器兼容性
+
+`light-dark()` 从 **2024 年 5 月**开始获得 Baseline（跨浏览器稳定支持）。
+
+| 浏览器 | 支持版本 |
+|--------|----------|
+| Chrome | 123+ |
+| Firefox | 120+ |
+| Safari | 17.5+ |
+| Edge | 123+ |
+
+> **兼容性提示**：由于 `light-dark()` 较新，建议同时使用 `@media (prefers-color-scheme)` 作为降级方案，或使用 CSS 自定义属性配合媒体查询的双重保障写法：
+
+```css
+:root {
+  color-scheme: light dark;
+  --text: #1a1a1a;
+  --bg: #ffffff;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --text: #f0f0f0;
+    --bg: #121212;
+  }
+}
+
+body {
+  /* 如果浏览器支持 light-dark()，会覆盖上面的值 */
+  color: light-dark(var(--text), var(--text));
+  background-color: light-dark(var(--bg), var(--bg));
+}
+```
+
+## 工作原理
+
+`light-dark()` 的工作原理涉及 CSS 级联中的新步骤：
+
+1. 浏览器检测**用户偏好**（通过 OS 或浏览器设置）
+2. 根据 `color-scheme` 声明确定可用主题
+3. 如果用户偏好为 `light` 或未设置 → 返回第一个值
+4. 如果用户偏好为 `dark` → 返回第二个值
+
+### color-scheme 的作用
+
+`color-scheme` 属性有两个作用：
+
+1. **声明页面支持的主题**（`light dark`）→ 启用 `light-dark()`
+2. **让浏览器 UI（如滚动条、输入框）也响应主题切换**
+
+```css
+:root {
+  color-scheme: light dark;  /* 推荐写法：同时支持两种主题 */
+}
+```
+
+## 参见
+
+- [MDN: light-dark()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark)
+- [CSS Color Module Level 5 规范](https://drafts.csswg.org/css-color-5/#light-dark)
+- [`color-scheme` 属性](/topics/01.basics/color-scheme)
+- [`prefers-color-scheme` 媒体查询](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme)
+- [CSS 自定义属性](/topics/01.basics/09.custome-property)

--- a/src/topics/02.layout/flexbox-deep/index.mdx
+++ b/src/topics/02.layout/flexbox-deep/index.mdx
@@ -1,0 +1,416 @@
+# CSS Flexbox 深入解析
+
+## 概述
+
+Flexbox（Flexible Box Layout Module）是 CSS3 提出的一种一维布局模型，专门用于处理容器内元素的排列、对齐和空间分配问题。相比传统的 float 和 position 方案，Flexbox 提供了更加高效和灵活的方式来构建响应式布局。
+
+## 核心概念
+
+### 一维布局
+
+Flexbox 是一种**一维布局模型**，它主要沿着一个方向（主轴）来排列子元素。这与 Grid 的二维布局（同时处理行和列）形成鲜明对比。
+
+### 容器与项目
+
+```html
+<div class="container">
+  <div class="item">1</div>
+  <div class="item">2</div>
+  <div class="item">3</div>
+</div>
+```
+
+```css
+.container {
+  display: flex;
+}
+```
+
+在 Flexbox 中，**容器（container）**是设置了 `display: flex` 或 `display: inline-flex` 的父元素，**项目（item）**是容器的直接子元素。
+
+## 主轴与交叉轴
+
+理解主轴（Main Axis）和交叉轴（Cross Axis）是掌握 Flexbox 的关键。
+
+### 主轴（Main Axis）
+
+- 由 `flex-direction` 属性定义
+- 项目沿着主轴排列
+- 可以是水平方向或垂直方向
+
+### 交叉轴（Cross Axis）
+
+- 垂直于主轴
+- 用于确定项目在主轴方向之外的排列方式
+- 方向始终与主轴垂直
+
+```
+flex-direction: row              flex-direction: column
+┌─────────────────────┐          ┌────────┐
+│  主轴 →             │          │ 主轴   │
+│  item1  item2  item3│          │   ↓    │
+│                     │          │ item1  │
+│  ═══════════════════│          │ item2  │
+│  交叉轴             │          │ item3  │
+└─────────────────────┘          └────────┘
+```
+
+## 容器属性
+
+### flex-direction
+
+定义主轴的方向，即项目排列的方向。
+
+```css
+.container {
+  flex-direction: row;              /* 默认：左到右 */
+  flex-direction: row-reverse;      /* 右到左 */
+  flex-direction: column;           /* 上到下 */
+  flex-direction: column-reverse;   /* 下到上 */
+}
+```
+
+### flex-wrap
+
+控制项目是否换行。
+
+```css
+.container {
+  flex-wrap: nowrap;     /* 默认：不换行，项目会被压缩 */
+  flex-wrap: wrap;       /* 换行，第一行在上方 */
+  flex-wrap: wrap-reverse; /* 换行，第一行在下方 */
+}
+```
+
+### flex-flow
+
+`flex-direction` 和 `flex-wrap` 的简写。
+
+```css
+.container {
+  flex-flow: row wrap;        /* 主轴水平，允许换行 */
+  flex-flow: column nowrap;   /* 主轴垂直，不换行 */
+}
+```
+
+## 项目属性
+
+### justify-content
+
+定义项目在**主轴**上的对齐方式。
+
+```css
+.container {
+  justify-content: flex-start;    /* 默认：靠主轴起点 */
+  justify-content: flex-end;      /* 靠主轴终点 */
+  justify-content: center;        /* 居中 */
+  justify-content: space-between; /* 两端对齐，项目间距相等 */
+  justify-content: space-around;  /* 每个项目两侧间距相等 */
+  justify-content: space-evenly;  /* 项目间距完全相等 */
+}
+```
+
+### align-items
+
+定义项目在**交叉轴**上的对齐方式。
+
+```css
+.container {
+  align-items: stretch;       /* 默认：拉伸填满容器 */
+  align-items: flex-start;    /* 靠交叉轴起点 */
+  align-items: flex-end;      /* 靠交叉轴终点 */
+  align-items: center;        /* 居中 */
+  align-items: baseline;      /* 按文本基线对齐 */
+}
+```
+
+### align-content
+
+当存在多行时（`flex-wrap: wrap`），定义多行在交叉轴上的对齐方式。
+
+```css
+.container {
+  align-content: flex-start;    /* 靠交叉轴起点 */
+  align-content: flex-end;      /* 靠交叉轴终点 */
+  align-content: center;        /* 居中 */
+  align-content: space-between; /* 两端对齐 */
+  align-content: space-around;  /* 两侧间距相等 */
+  align-content: stretch;       /* 默认：拉伸填满 */
+}
+```
+
+### flex-grow
+
+定义项目的放大比例，默认为 `0`（不放大）。
+
+```css
+.item {
+  flex-grow: 1;   /* 占据可用空间的相等比例 */
+}
+```
+
+当所有项目 `flex-grow` 之和超过 1 时，按比例分配剩余空间。
+
+### flex-shrink
+
+定义项目的缩小比例，默认为 `1`（可缩小）。
+
+```css
+.item {
+  flex-shrink: 0;   /* 不缩小，保持原始尺寸 */
+}
+```
+
+### flex-basis
+
+定义项目在分配多余空间之前的初始尺寸。
+
+```css
+.item {
+  flex-basis: auto;    /* 默认：项目自身尺寸 */
+  flex-basis: 200px;   /* 固定宽度 */
+}
+```
+
+### flex
+
+`flex-grow`、`flex-shrink` 和 `flex-basis` 的简写。
+
+```css
+.item {
+  flex: 1;              /* 1 1 0% */
+  flex: 1 1 auto;       /* 显式指定三个值 */
+  flex: 0 0 200px;      /* 固定尺寸，不伸缩 */
+}
+```
+
+### align-self
+
+允许单个项目覆盖 `align-items` 的设置。
+
+```css
+.item {
+  align-self: auto;      /* 继承父元素 align-items */
+  align-self: flex-start;
+  align-self: center;
+  align-self: flex-end;
+}
+```
+
+## 常见布局模式
+
+### 骰子布局
+
+Flexbox 实现骰子点数的经典布局：
+
+```html
+<!-- 骰子 1：单个点居中 -->
+<div class="dice dice-1">
+  <span class="dot"></span>
+</div>
+
+<!-- 骰子 2：两个点 -->
+<div class="dice dice-2">
+  <span class="dot"></span>
+  <span class="dot"></span>
+</div>
+```
+
+```css
+.dice {
+  width: 100px;
+  height: 100px;
+  background: #fff;
+  border-radius: 12px;
+  display: flex;
+  padding: 10px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
+.dice-1 {
+  justify-content: center;
+  align-items: center;
+}
+
+.dice-2 {
+  justify-content: space-between;
+}
+
+.dice-2 .dot:last-child {
+  align-self: flex-end;
+}
+```
+
+### 圣杯布局
+
+经典的三栏布局（header + sidebar + main + footer）：
+
+```css
+.holy-grail {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.holy-grail-body {
+  display: flex;
+  flex: 1;
+}
+
+.holy-grail-main {
+  flex: 1;
+  order: 2;
+}
+
+.holy-grail-nav {
+  width: 200px;
+  order: 1;
+}
+
+.holy-grail-aside {
+  width: 200px;
+  order: 3;
+}
+```
+
+### 导航栏
+
+水平导航栏的典型实现：
+
+```css
+.nav {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 24px;
+  height: 64px;
+  background: #333;
+}
+
+.nav-links {
+  display: flex;
+  gap: 24px;
+}
+```
+
+### 居中布局
+
+完美居中是最常见的 Flexbox 用例：
+
+```css
+.center {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+}
+```
+
+## 实战案例
+
+### 卡片网格（自动换行）
+
+```css
+.card-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 20px;
+  padding: 20px;
+}
+
+.card {
+  flex: 1 1 300px;  /* 最小 300px，尽可能填满 */
+  max-width: 400px;
+  padding: 20px;
+  background: #fff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+```
+
+### Sticky Footer
+
+确保内容不足时 footer 贴底：
+
+```css
+.page {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.main {
+  flex: 1;  /* 占据所有可用空间 */
+}
+
+.footer {
+  flex-shrink: 0;  /* 不被压缩 */
+}
+```
+
+## 调试技巧
+
+### 1. 使用浏览器 DevTools
+
+在 Chrome/Firefox 中：
+- 选择 Flex 容器，查看 "flexbox" 标记
+- 悬浮项目时显示主轴和交叉轴
+- 实时调整属性值
+
+### 2. 可视化调试背景
+
+```css
+.container {
+  background: linear-gradient(
+    90deg,
+    rgba(255,0,0,0.1) 0%,
+    rgba(0,0,255,0.1) 100%
+  );
+}
+```
+
+### 3. 常见问题排查
+
+| 问题 | 可能原因 | 解决方案 |
+|------|----------|----------|
+| 项目没有对齐 | 未设置 `align-items` | 添加 `align-items: center` |
+| 项目没有换行 | `flex-wrap: nowrap` | 改为 `flex-wrap: wrap` |
+| 项目尺寸不符合预期 | `flex-basis` vs `width` | `flex-basis` 优先级更高 |
+| 项目溢出容器 | `flex-shrink: 0` | 设置 `flex-shrink: 1` |
+
+### 4. 常用调试清单
+
+- [ ] 确认父元素设置了 `display: flex`
+- [ ] 明确主轴方向（`flex-direction`）
+- [ ] 检查是否有 `flex-wrap` 换行
+- [ ] 区分 `justify-content` 和 `align-items`
+- [ ] 确认 `flex` 简写中三个值的含义
+
+## 浏览器支持
+
+Flexbox 得到所有现代浏览器的支持：
+
+| 浏览器 | 支持版本 |
+|--------|----------|
+| Chrome | 29+ |
+| Firefox | 28+ |
+| Safari | 9+ |
+| Edge | 12+ |
+| IE | 11+（部分功能）|
+
+## 总结
+
+Flexbox 是现代 CSS 布局的重要工具，特别适合以下场景：
+
+- 需要沿一个方向排列元素
+- 需要元素自适应空间分配
+- 需要实现居中、对齐、均匀分布
+- 需要实现响应式卡片网格
+
+掌握 Flexbox 的关键是理解**主轴与交叉轴**的概念，以及 **justify-content** 和 **align-items** 的区别。
+
+## 相关资源
+
+- [MDN Flexbox 指南](https://developer.mozilla.org/zh-CN/docs/Web/CSS/CSS_flexible_box_layout)
+- [CSS-Tricks Flexbox 完整指南](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
+- [Flexbox Froggy（交互式学习）](https://flexboxfroggy.com/)

--- a/src/topics/03.animation/overscroll-behavior/index.mdx
+++ b/src/topics/03.animation/overscroll-behavior/index.mdx
@@ -1,0 +1,336 @@
+---
+title: 滚动行为 overscroll-behavior
+tags: [overscroll-behavior, scroll, mobile]
+description: 掌握 CSS overscroll-behavior 属性，控制滚动链和边界效果
+---
+
+## 学习目标
+
+通过本章学习，你将：
+
+1. **理解问题** — 掌握滚动链（Scroll Chaining）带来的体验问题
+2. **掌握属性** — 熟练运用 `overscroll-behavior` 的三个核心值
+3. **实际应用** — 能够解决弹窗滚动、嵌套滚动、边界效果等常见场景
+
+## 核心概念
+
+### 滚动链（Scroll Chaining）
+
+滚动链是指当一个滚动容器的边界到达后，继续滚动会带动**父级容器**滚动的一种行为。
+
+典型场景：一个弹窗内有可滚动内容，当弹窗滚动到底部后，继续滚动会带动页面背景滚动。这种体验在 modal、抽屉、对话气泡等场景中经常出现，用户体验较差。
+
+```
+┌─────────────────────────┐  ← 页面（父容器）
+│  ┌───────────────────┐  │
+│  │   弹窗内容区      │  │  ← 子容器
+│  │   （可滚动）      │  │
+│  └───────────────────┘  │
+│                         │
+│    背景页面内容...      │  ← 滚动链会带动这里
+└─────────────────────────┘
+```
+
+### overscroll 触发时机
+
+当滚动容器的内容到达边界（顶部/底部/左/右）时，继续滚动会触发 overscroll。浏览器默认行为包括：
+
+- **弹性效果（Bounce）**：iOS Safari 的"橡皮筋"效果
+- **刷新手势**：Chrome Android 的下拉刷新
+- **页面导航**：水平滑动时的页面切换（历史记录）
+
+### 与 touch-action 的区别
+
+| 特性 | `touch-action` | `overscroll-behavior` |
+|------|---------------|----------------------|
+| **作用层面** | 控制触摸手势本身 | 控制边界滚动行为 |
+| **典型用途** | 禁用/启用触摸滚动、缩放 | 阻止滚动链、禁用弹性效果 |
+| **手势影响** | 完全禁用手势 | 允许手势，修饰边界行为 |
+| **刷新控制** | ❌ 无法控制下拉刷新 | ✅ 可禁用下拉刷新 |
+
+简单记忆：**`touch-action` 决定能不能滚，`overscroll-behavior` 决定滚到边界后怎么办**。
+
+## 属性详解
+
+`overscroll-behavior` 是 `overscroll-behavior-x` 和 `overscroll-behavior-y` 的简写，支持 1-2 个值。
+
+```css
+/* 单值：x 和 y 相同 */
+overscroll-behavior: contain;
+
+/* 双值：分别指定 x 和 y */
+overscroll-behavior: auto contain;
+
+/* 分别控制 */
+overscroll-behavior-x: auto;
+overscroll-behavior-y: contain;
+```
+
+### 三个核心值
+
+#### `auto`（默认值）
+
+- 滚动链正常发生
+- 边界弹性效果正常显示
+- 刷新手势正常触发
+
+```css
+/* 默认行为：不做任何限制 */
+.scroll-container {
+  overscroll-behavior: auto;
+}
+```
+
+#### `contain`
+
+**核心特性**：阻止滚动链，但**保留**边界弹性效果。
+
+- 父容器不会被带动滚动
+- 子容器到达边界时仍显示弹性效果
+- 可滚动容器的下拉刷新/水平导航手势**会被禁用**
+
+```css
+/* 弹窗内容使用 contain，阻止背景页面滚动 */
+.dialog-content {
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+```
+
+#### `none`
+
+**核心特性**：阻止滚动链，**禁止**边界弹性效果。
+
+- 父容器不会被带动滚动
+- 子容器到达边界时**没有**弹性效果
+- 滚动体验更"硬"，适合全屏滚动游戏等场景
+
+```css
+/* 彻底禁用边界效果 */
+.scroll-area {
+  overscroll-behavior: none;
+}
+```
+
+### 值对比速查表
+
+| 场景 | `auto` | `contain` | `none` |
+|------|--------|-----------|--------|
+| 滚动链传递到父容器 | ✅ 会传递 | ❌ 阻止 | ❌ 阻止 |
+| 边界弹性效果 | ✅ 保留 | ✅ 保留 | ❌ 禁用 |
+| 下拉刷新 | ✅ 启用 | ❌ 禁用 | ❌ 禁用 |
+| 水平页面导航 | ✅ 启用 | ❌ 禁用 | ❌ 禁用 |
+
+## 实战案例
+
+### 案例一：弹窗防止背景滚动
+
+**问题**：打开弹窗后，在弹窗内滚动，背景页面也会跟着滚动，体验很差。
+
+**解决方案**：使用 `overscroll-behavior: contain` 阻止滚动链。
+
+```css
+/* 弹窗内容区 */
+.dialog-content {
+  height: 100%;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+/* 背景遮罩也需要处理，防止点击遮罩时背景滚动 */
+.dialog-backdrop {
+  overflow: hidden; /* 变成非滚动容器 */
+  overscroll-behavior: contain;
+}
+```
+
+**进阶（Chrome 144+）**：对于 `<dialog>` 元素，可直接在 dialog 和 ::backdrop 上设置：
+
+```css
+dialog {
+  overscroll-behavior: contain;
+}
+
+dialog::backdrop {
+  overflow: hidden;
+  overscroll-behavior: contain;
+}
+```
+
+{/* @playground id="dialog-scroll" mode="demo" */}
+
+> **提示**：只有当元素本身是滚动容器时，`overscroll-behavior` 才会生效。如果内容不足以滚动（overflow < 1px），需要添加 `overflow: auto` 或 `overflow: hidden` 使其成为滚动容器。
+
+### 案例二：移动端横向滚动与垂直锁定
+
+**问题**：在横向滚动的轮播组件中，斜向滑动容易触发垂直滚动或页面导航。
+
+**解决方案**：横向容器使用 `overscroll-behavior-x: contain` 锁定垂直方向。
+
+```css
+/* 轮播容器：横向滚动，禁用垂直滚动链 */
+.carousel {
+  display: flex;
+  overflow-x: auto;
+  overflow-y: hidden; /* 明确垂直方向不滚动 */
+  overscroll-behavior-x: contain;
+  /* 配合 touch-action 优化触摸体验 */
+  touch-action: pan-x;
+}
+
+/* 垂直方向的嵌套滚动区域 */
+.carousel-item {
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+}
+```
+
+{/* @playground id="horizontal-scroll" mode="demo" */}
+
+### 案例三：可滚动区域边界控制
+
+**问题**：列表组件滚动到边界时，出现弹性效果或触发页面刷新，影响体验。
+
+**场景**：聊天消息列表、商品列表、长文章阅读器。
+
+```css
+/* 聊天消息列表：禁用下拉刷新，保留弹性但不传递 */
+.message-list {
+  flex: 1;
+  overflow-y: auto;
+  overscroll-behavior-y: contain;
+  /* 配合 touch-action 精确控制手势 */
+  touch-action: pan-y;
+}
+
+/* 页面根容器：彻底禁用全局弹性效果 */
+html {
+  overscroll-behavior: none;
+}
+```
+
+**效果说明**：
+- 消息列表滚动到顶部，继续下拉 → 弹性效果保留，但不会触发页面刷新
+- 消息列表滚动到底部，继续上拉 → 弹性效果保留，但不会传递到页面
+
+{/* @playground id="boundary-control" mode="demo" */}
+
+### 案例四：聊天对话气泡（进阶）
+
+**问题**：聊天应用中有多个可滚动区域（消息列表、表情面板、输入框），需要精确控制每个区域的滚动行为。
+
+**解决方案**：分层的 `overscroll-behavior` 控制。
+
+```css
+/* 主消息区域：contain 防止影响外部 */
+.messages-container {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+/* 表情选择器：none 彻底禁用边界效果 */
+.emoji-picker {
+  overflow-x: auto;
+  overscroll-behavior-x: none;
+}
+
+/* 页面容器：auto 保持默认，保持页面可刷新 */
+.page-wrapper {
+  overscroll-behavior: auto;
+}
+```
+
+## 兼容性与坑点
+
+### 浏览器支持
+
+| 浏览器 | 支持版本 | 备注 |
+|--------|---------|------|
+| Chrome | 63+ | 完整支持 |
+| Firefox | 59+ | 完整支持 |
+| Safari | 16+ | 16 之前支持度有限 |
+| iOS Safari | 16+ | 16 之前存在 bug |
+| Edge | 79+ | 与 Chrome 一致 |
+
+### iOS Safari 坑点
+
+#### 1. 非滚动容器不生效
+
+**问题**：在 iOS Safari 上，如果容器没有实际滚动内容（overflow < 1px），`overscroll-behavior` 可能完全不生效。
+
+**解决**：确保容器有至少 1px 的溢出。
+
+```css
+/* ❌ 可能不生效 */
+.dialog {
+  overflow: hidden;
+  overscroll-behavior: contain;
+}
+
+/* ✅ 确保有滚动 */
+.dialog {
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
+/* 或强制创建滚动容器 */
+.dialog {
+  overflow: hidden;
+  overscroll-behavior: contain;
+  /* 触发滚动容器创建 */
+  content-visibility: auto;
+}
+```
+
+#### 2. Chrome 144+ 之前 dialog 限制
+
+**问题**：在 Chrome 144 之前，`overscroll-behavior` 只对**可滚动的滚动容器**生效。非滚动容器（如 `overflow: hidden` 的 dialog）上设置无效。
+
+**解决**：升级到 Chrome 144+，或使用 `overflow: hidden` + `overscroll-behavior: contain` 的组合。
+
+#### 3. 组合手势失效
+
+**问题**：在 iOS Safari 上，`overscroll-behavior: contain` 会禁用下拉刷新，但可能同时影响正常的滚动恢复。
+
+**解决**：测试是关键。iOS 16+ 改善较大，早期版本需要额外注意。
+
+### 检测与降级策略
+
+```javascript
+// 检测 overscroll-behavior 支持
+const supportsOverscroll = CSS.supports('overscroll-behavior', 'contain');
+
+if (!supportsOverscroll) {
+  // 降级方案：使用 JavaScript 监听 touchmove 阻止滚动传递
+  document.querySelector('.dialog-content').addEventListener('touchmove', (e) => {
+    const el = e.currentTarget;
+    const isAtTop = el.scrollTop === 0;
+    const isAtBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= 1;
+
+    if ((isAtTop && e.deltaY < 0) || (isAtBottom && e.deltaY > 0)) {
+      e.preventDefault();
+    }
+  }, { passive: false });
+}
+```
+
+### 常见误区
+
+1. **误用 `touch-action` 代替 `overscroll-behavior`**
+   - `touch-action: none` 会完全禁用触摸滚动，而 `overscroll-behavior` 只是控制边界行为
+
+2. **在非滚动容器上使用**
+   - 必须确保元素有 `overflow: auto/scroll/hidden` 等使其成为滚动容器
+
+3. **只设置子元素，忘记父元素**
+   - 滚动链是双向的，需要在子元素和父元素上都设置才能完全控制
+
+4. **iOS Safari 不生效**
+   - 确认 iOS 版本，16 以下存在已知问题，考虑降级方案
+
+## 延伸阅读
+
+- [MDN: overscroll-behavior](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior)
+- [Chrome Blog: Take control of your scroll](https://developer.chrome.com/blog/overscroll-behavior)
+- [bram.us: overscroll-behavior: contain 详解](https://www.bram.us/2025/11/25/use-overscroll-behavior-contain-to-prevent-a-page-from-scrolling-while-a-dialog-is-open/)
+- [CSS Overscroll Behavior Module Level 1](https://drafts.csswg.org/css-overscroll/)

--- a/src/topics/04.tools/10.design-token/index.mdx
+++ b/src/topics/04.tools/10.design-token/index.mdx
@@ -1,0 +1,382 @@
+---
+title: "Design Token 设计令牌"
+category: "开发工具"
+tags:
+  - Design Token
+  - 设计令牌
+  - 设计系统
+  - CSS变量
+  - 主题切换
+description: "详解Design Token设计令牌的概念、实践方法以及与CSS自定义属性的关系"
+keywords: "Design Token, 设计令牌, 设计系统, CSS变量, 主题切换, 设计决策"
+---
+
+# Design Token 设计令牌
+
+## 概述
+
+**Design Token（设计令牌）** 是将设计决策以结构化数据形式表达的规范。它是设计系统的基础构建块，充当设计师与开发者之间的"共同语言"。
+
+> Design Token 是设计决策的载体，让设计意图可以在不同平台、不同工具之间无缝传递。
+
+## 什么是 Design Token
+
+Design Token 最早由 Salesforce 提出，用于解决多平台设计一致性问题。它将颜色、间距、字体等设计决策抽象为可复用的"令牌"，通过工具链生成各平台（CSS、iOS、Android）对应的代码。
+
+一个典型的 Design Token JSON 文件：
+
+```json
+{
+  "color": {
+    "$type": "color",
+    "options": {
+      "blue-500": { "$value": "#3b82f6" },
+      "blue-600": { "$value": "#2563eb" },
+      "grey-100": { "$value": "#f3f4f6" },
+      "grey-900": { "$value": "#111827" }
+    },
+    "decisions": {
+      "primary": { "$value": "{color.options.blue-600}" },
+      "background": { "$value": "{color.options.grey-100}" },
+      "text": { "$value": "{color.options.grey-900}" }
+    }
+  },
+  "spacing": {
+    "$type": "dimension",
+    "options": {
+      "1": { "$value": "4px" },
+      "2": { "$value": "8px" },
+      "4": { "$value": "16px" },
+      "8": { "$value": "32px" }
+    }
+  }
+}
+```
+
+## 三层 Token 结构
+
+Design Token 按照抽象层级分为三层，它们逐层构建：
+
+### 1. Option Token（选项令牌）
+
+定义设计系统的"原材料"，如颜色色板、间距刻度、字体族等。
+
+```json
+{
+  "color": {
+    "blue-100": { "$value": "#dbeafe" },
+    "blue-500": { "$value": "#3b82f6" },
+    "blue-900": { "$value": "#1e3a8a" }
+  }
+}
+```
+
+### 2. Decision Token（决策令牌）
+
+定义设计决策，即"如何应用"这些选项。如语义化的 `surface`、`text`、`accent` 等。
+
+```json
+{
+  "color": {
+    "surface": { "$value": "{color.blue-100}" },
+    "text": { "$value": "{color.blue-900}" },
+    "accent": { "$value": "{color.blue-500}" }
+  }
+}
+```
+
+### 3. Component Token（组件令牌）
+
+指定具体应用位置，如 `button-primary-bg`、`card-border-color` 等。
+
+```json
+{
+  "button": {
+    "primary": {
+      "background": { "$value": "{color.accent}" },
+      "text": { "$value": "{color.surface}" }
+    }
+  }
+}
+```
+
+## CSS 变量与 Design Token 的关系
+
+在 Web 端，Design Token 最终通常编译为 CSS 自定义属性（CSS 变量）：
+
+```css
+/* 编译后的 CSS 变量 */
+:root {
+  /* Option Token */
+  --color-blue-100: #dbeafe;
+  --color-blue-500: #3b82f6;
+  --color-blue-900: #1e3a8a;
+
+  /* Decision Token */
+  --color-surface: var(--color-blue-100);
+  --color-text: var(--color-blue-900);
+  --color-accent: var(--color-blue-500);
+
+  /* Component Token */
+  --button-primary-bg: var(--color-accent);
+  --button-primary-text: #ffffff;
+}
+```
+
+Design Token 与 CSS 变量的关系：
+- **Design Token** 是设计层面的规范（平台无关的数据格式）
+- **CSS 变量** 是 Web 端的实现方式之一
+- Token 可以编译为 CSS 变量，也能编译为 SASS 变量、JSON 等
+
+## 颜色令牌
+
+颜色令牌是 Design Token 最常见的类型：
+
+```css
+:root {
+  /* 选项令牌 - 原始色板 */
+  --palette-blue-50: #eff6ff;
+  --palette-blue-100: #dbeafe;
+  --palette-blue-500: #3b82f6;
+  --palette-blue-900: #1e3a8a;
+
+  /* 决策令牌 - 语义化 */
+  --color-primary: var(--palette-blue-500);
+  --color-primary-hover: var(--palette-blue-600);
+  --color-surface: var(--palette-blue-50);
+  --color-text: var(--palette-blue-900);
+  --color-text-muted: #64748b;
+}
+```
+
+{/* @playground id="color-tokens" mode="demo" */}
+
+## 字体令牌
+
+字体令牌统一管理字体相关的设计决策：
+
+```css
+:root {
+  /* 字体族 */
+  --font-family-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+  --font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
+
+  /* 字号刻度 */
+  --font-size-xs: 0.75rem;   /* 12px */
+  --font-size-sm: 0.875rem;  /* 14px */
+  --font-size-base: 1rem;    /* 16px */
+  --font-size-lg: 1.125rem; /* 18px */
+  --font-size-xl: 1.25rem;  /* 20px */
+  --font-size-2xl: 1.5rem;  /* 24px */
+  --font-size-4xl: 2.25rem; /* 36px */
+
+  /* 行高 */
+  --line-height-tight: 1.25;
+  --line-height-normal: 1.5;
+  --line-height-relaxed: 1.75;
+
+  /* 字重 */
+  --font-weight-normal: 400;
+  --font-weight-medium: 500;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+}
+```
+
+{/* @playground id="typography-tokens" mode="demo" */}
+
+## 间距令牌
+
+间距令牌建立统一的间距系统：
+
+```css
+:root {
+  /* 间距刻度 */
+  --space-0: 0;
+  --space-1: 0.25rem;  /* 4px */
+  --space-2: 0.5rem;   /* 8px */
+  --space-3: 0.75rem;  /* 12px */
+  --space-4: 1rem;     /* 16px */
+  --space-5: 1.25rem; /* 20px */
+  --space-6: 1.5rem;  /* 24px */
+  --space-8: 2rem;    /* 32px */
+  --space-10: 2.5rem; /* 40px */
+  --space-12: 3rem;   /* 48px */
+  --space-16: 4rem;   /* 64px */
+
+  /* 语义化间距 */
+  --spacing-component: var(--space-4);
+  --spacing-section: var(--space-8);
+  --spacing-page: var(--space-16);
+}
+```
+
+{/* @playground id="spacing-tokens" mode="demo" */}
+
+## 实战案例：主题切换
+
+利用 Design Token 实现亮色/暗色主题切换：
+
+```css
+/* 亮色主题（默认） */
+:root {
+  --color-bg: #ffffff;
+  --color-surface: #f3f4f6;
+  --color-text: #111827;
+  --color-text-muted: #6b7280;
+  --color-border: #e5e7eb;
+  --color-primary: #3b82f6;
+}
+
+/* 暗色主题 */
+[data-theme="dark"] {
+  --color-bg: #0f172a;
+  --color-surface: #1e293b;
+  --color-text: #f1f5f9;
+  --color-text-muted: #94a3b8;
+  --color-border: #334155;
+  --color-primary: #60a5fa;
+}
+```
+
+```html
+<button id="theme-toggle">切换主题</button>
+
+<script>
+  const btn = document.getElementById('theme-toggle');
+  btn.addEventListener('click', () => {
+    const current = document.documentElement.dataset.theme;
+    document.documentElement.dataset.theme = current === 'dark' ? 'light' : 'dark';
+  });
+</script>
+```
+
+{/* @playground id="theme-switching" mode="demo" */}
+
+## 实战案例：设计系统组件
+
+使用 Design Token 构建一致的组件样式：
+
+```css
+/* Button 组件 */
+.btn {
+  padding: var(--spacing-component);
+  border-radius: var(--radius-md);
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  transition: all 0.2s ease;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: var(--color-primary);
+  color: #ffffff;
+  border: 1px solid transparent;
+}
+
+.btn-primary:hover {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+/* Card 组件 */
+.card {
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-section);
+  box-shadow: var(--shadow-sm);
+}
+
+/* Input 组件 */
+.input {
+  width: 100%;
+  padding: var(--space-2) var(--space-3);
+  background: var(--color-bg);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-family: var(--font-family-sans);
+  font-size: var(--font-size-base);
+  color: var(--color-text);
+}
+
+.input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.2);
+}
+```
+
+{/* @playground id="design-system" mode="demo" */}
+
+## 与 CSS 自定义属性的对比
+
+| 特性 | CSS 自定义属性 | Design Token |
+|------|---------------|--------------|
+| **定义方式** | `--var-name: value` | JSON/ YAML 格式 |
+| **跨平台** | 仅 Web | 可编译为多平台代码 |
+| **工具链** | 手动维护 | 通过 Style Dictionary 等工具自动生成 |
+| **命名规范** | 自由命名 | 有规范的层级和命名约定 |
+| **设计协作** | 设计师难以直接参与 | 设计工具（Figma）可直接同步 |
+| **适用场景** | 简单主题切换 | 大型设计系统、多平台一致性 |
+
+### CSS 自定义属性的局限性
+
+```css
+/* CSS 自定义属性 — 缺乏语义层级 */
+:root {
+  --blue-500: #3b82f6;
+  --blue-600: #2563eb;
+  --gray-100: #f3f4f6;
+  --gray-900: #111827;
+}
+
+/* 开发者需要记住颜色语义 */
+.button {
+  /* 很难知道 --primary 是什么意思 */
+  background: var(--primary);
+  color: var(--white);
+}
+```
+
+### Design Token 的优势
+
+```css
+/* Design Token — 语义清晰、层级分明 */
+:root {
+  /* Option Token */
+  --palette-blue-500: #3b82f6;
+  --palette-white: #ffffff;
+
+  /* Decision Token */
+  --color-accent: var(--palette-blue-500);
+  --color-on-accent: var(--palette-white);
+
+  /* Component Token */
+  --button-bg: var(--color-accent);
+  --button-text: var(--color-on-accent);
+}
+
+/* 开发者直接使用语义化 Token */
+.button {
+  background: var(--button-bg);
+  color: var(--button-text);
+}
+```
+
+## 工具链推荐
+
+- **Style Dictionary**：最流行的 Token 转换工具，支持 CSS/SCSS/Android/iOS
+- **Theo**：Salesforce 推出的 Token 管理工具
+- **Tokens Studio**：Figma 插件，支持与 Git 双向同步
+- **Specify**：设计系统 Token 管理平台
+
+## 总结
+
+Design Token 是设计系统的"基础设施"，核心价值：
+
+1. **单一数据源**：设计决策统一存储，消除设计-开发不一致
+2. **多平台支持**：一次定义，多端编译
+3. **主题切换**：轻松实现亮/暗主题、品牌定制
+4. **可维护性**：修改 Token 值，全局生效，无需逐个组件修改

--- a/src/topics/05.shape/css-mask/index.mdx
+++ b/src/topics/05.shape/css-mask/index.mdx
@@ -1,0 +1,356 @@
+# CSS Mask 遮罩技术详解
+
+## 基础概念
+
+CSS Mask（遮罩）是一种强大的视觉效果技术，通过遮罩图片（mask image）来控制元素的可见部分。遮罩图片的亮度（luminance）或透明度（alpha）决定了哪些区域可见、哪些区域隐藏、哪些区域半透明。
+
+**与 `clip-path` 的区别**：`clip-path` 是"硬裁剪"，只有完全可见和完全不可见两种状态；`mask` 支持**渐进过渡**，可以实现半透明、渐变等丰富效果。
+
+## 使用场景
+
+- 图片局部显示（圆形头像、渐变淡出）
+- 文字渐变填充
+- 不规则形状遮罩
+- 图标局部高亮
+- 复杂图案叠加
+- 图片滚动入场效果
+
+## mask-image 属性
+
+定义遮罩图片来源，支持多种值类型：
+
+```css
+/* 无遮罩 */
+mask-image: none;
+
+/* 图片遮罩 */
+mask-image: url('mask.png');
+
+/* SVG 遮罩（推荐） */
+mask-image: url('mask.svg#star');
+
+/* 渐变遮罩 - 最常用 */
+mask-image: linear-gradient(to right, black 50%, transparent 50%);
+mask-image: radial-gradient(circle, black 30%, transparent 70%);
+mask-image: conic-gradient(black 0deg 90deg, transparent 90deg 360deg);
+
+/* 多遮罩叠加 */
+mask-image: url('mask1.png'), url('mask2.png'), linear-gradient(...);
+```
+
+### 常用渐变遮罩模式
+
+```css
+/* 水平渐变：左半边可见 */
+mask-image: linear-gradient(to right, black 50%, transparent 50%);
+
+/* 垂直渐变：顶部淡出 */
+mask-image: linear-gradient(to bottom, black 0%, transparent 100%);
+
+/* 径向渐变：中心可见 */
+mask-image: radial-gradient(circle, black 40%, transparent 70%);
+
+/* 锥形渐变：雷达扫描效果 */
+mask-image: conic-gradient(from 0deg, black 0deg, transparent 0deg);
+```
+
+## mask-mode 属性
+
+控制遮罩的亮度模式：
+
+| 值 | 说明 |
+|---|---|
+| `alpha` | 根据透明度决定（默认）- 透明区域隐藏，不透明区域可见 |
+| `luminance` | 根据亮度决定 - 亮区域可见，暗区域隐藏 |
+| `match-source` | 根据源类型自动选择（默认） |
+
+```css
+/* 透明度模式（默认） */
+mask-mode: alpha;
+
+/* 亮度模式 */
+mask-mode: luminance;
+
+/* SVG 内联遮罩常用 luminance */
+mask: url('star.svg#star') luminance;
+```
+
+## mask-repeat 属性
+
+控制遮罩图片的重复方式，用法与 `background-repeat` 完全一致：
+
+```css
+mask-repeat: repeat;           /* 全覆盖（默认） */
+mask-repeat: repeat-x;         /* 水平重复 */
+mask-repeat: repeat-y;         /* 垂直重复 */
+mask-repeat: no-repeat;        /* 不重复 */
+mask-repeat: space;            /* 平铺但保持间距 */
+mask-repeat: round;            /* 自动调整尺寸以铺满 */
+
+/* 双值语法 */
+mask-repeat: repeat space;     /* repeat-x repeat-y */
+mask-repeat: round no-repeat;  /* 水平自动调整，垂直不重复 */
+```
+
+## mask-position 属性
+
+控制遮罩图片的起始位置，用法与 `background-position` 一致：
+
+```css
+/* 关键词 */
+mask-position: top;
+mask-position: bottom;
+mask-position: left;
+mask-position: right;
+mask-position: center;
+
+/* 百分比/长度 */
+mask-position: 25% 75%;      /* x=25%, y=75% */
+mask-position: 0px 0px;       /* 左上角（默认） */
+
+/* 混合 */
+mask-position: top center;
+mask-position: 10px 20px;
+```
+
+## mask-size 属性
+
+控制遮罩图片的尺寸，用法与 `background-size` 一致：
+
+```css
+mask-size: auto;              /* 原始尺寸（默认） */
+mask-size: 100px 100px;       /* 固定尺寸 */
+mask-size: 50% 50%;           /* 百分比尺寸 */
+mask-size: cover;             /* 覆盖整个元素 */
+mask-size: contain;           /* 完整包含 */
+
+/* 与 mask-position 配合 */
+mask: url('mask.png') 0 0 / 100px 100px no-repeat;
+```
+
+## mask-composite 属性
+
+控制多层遮罩之间的合成方式：
+
+| 值 | 说明 |
+|---|---|
+| `add` | 叠加（默认）- 各层遮罩相加 |
+| `subtract` | 减去 - 前景层减去背景层重叠部分 |
+| `intersect` | 交集 - 只有重叠部分可见 |
+| `exclude` | 排除 - 排除重叠部分，只保留不重叠区域 |
+
+```css
+/* 单层遮罩无需关心 composite */
+mask: url('mask.png') luminance;
+
+/* 多层遮罩合成 */
+mask:
+  url('top-mask.png') subtract,
+  url('bottom-mask.png');
+```
+
+## 实战案例
+
+### 案例一：圆形头像裁剪
+
+使用径向渐变创建圆形遮罩：
+
+```css
+.avatar {
+  width: 120px;
+  height: 120px;
+  mask-image: radial-gradient(
+    circle,
+    black 0%,    /* 中心可见 */
+    black 45%,   /* 可见区域半径 */
+    transparent 45%, /* 外部透明 */
+    transparent 100%
+  );
+  /* 也可以简写 */
+  mask-image: radial-gradient(
+    circle,
+    black 45%,
+    transparent 46%
+  );
+}
+```
+
+**效果**：图片显示为完美的圆形，无论原图是方形还是长方形。
+
+### 案例二：文字渐变填充
+
+利用渐变遮罩实现文字颜色渐变效果：
+
+```css
+.gradient-text {
+  font-size: 72px;
+  font-weight: 900;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+
+  /* 补充方案：mask 实现渐变边框文字 */
+  position: relative;
+  display: inline-block;
+}
+
+.gradient-text::before {
+  content: attr(data-text);
+  position: absolute;
+  left: 0;
+  top: 0;
+  background: linear-gradient(90deg, #ff6b6b, #4ecdc4, #45b7d1);
+  mask-image: linear-gradient(
+    to right,
+    black 0%,
+    black 50%,
+    transparent 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    to right,
+    black 0%,
+    black 50%,
+    transparent 100%
+  );
+}
+```
+
+### 案例三：多遮罩叠加实现复杂效果
+
+叠加多个遮罩层实现独特的视觉效果：
+
+```css
+.multi-mask {
+  width: 400px;
+  height: 300px;
+  background: url('image.jpg');
+  background-size: cover;
+
+  mask:
+    /* 第一层：底部渐隐 */
+    linear-gradient(
+      to bottom,
+      black 0%,
+      transparent 100%
+    ),
+    /* 第二层：左右向内渐隐 */
+    radial-gradient(
+      ellipse at center,
+      black 0%,
+      black 30%,
+      transparent 70%
+    ),
+    /* 第三层：顶部装饰条 */
+    linear-gradient(
+      to right,
+      transparent 0%,
+      black 10%,
+      black 20%,
+      transparent 30%,
+      transparent 70%,
+      black 80%,
+      black 90%,
+      transparent 100%
+    );
+
+  /* 各层使用交集模式 */
+  mask-composite: intersect;
+  -webkit-mask-composite: source-in;
+}
+```
+
+### 案例四：SVG 图形遮罩
+
+使用 SVG 路径创建复杂形状：
+
+```css
+.svg-mask {
+  mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg"><path d="M50 0 L100 100 L0 100 Z" fill="black"/></svg>');
+
+  /* 或引用外部 SVG 元素 */
+  mask: url('#star-mask') luminance;
+}
+```
+
+## mask 缩写属性
+
+与其他 CSS 缩写一样，可以简写所有 mask 相关属性：
+
+```css
+/* 完整写法 */
+.element {
+  mask-image: url('mask.png');
+  mask-mode: alpha;
+  mask-repeat: no-repeat;
+  mask-position: center;
+  mask-size: 100px 100px;
+  mask-clip: border-box;
+  mask-origin: border-box;
+  mask-composite: add;
+}
+
+/* 缩写（推荐） */
+.element {
+  mask: url('mask.png') alpha / 100px 100px no-repeat center border-box add;
+}
+
+/* 多遮罩层 */
+.element {
+  mask:
+    url('mask1.png') 0 0 / 50px 50px no-repeat,
+    url('mask2.png') 100% 0 / 50px 50px no-repeat,
+    linear-gradient(to bottom, black, transparent);
+}
+```
+
+**缩写顺序**：`<mask-image>` → `<mask-mode>` → `<mask-position>` → `/<mask-size>` → `<mask-repeat>` → `<mask-origin>` → `<mask-clip>` → `<mask-composite>`
+
+## mask 与 clip-path 对比
+
+| 特性 | mask | clip-path |
+|---|---|---|
+| 透明过渡 | ✅ 支持半透明 | ❌ 只有可见/不可见 |
+| 渐变支持 | ✅ 渐变遮罩 | ❌ 只支持几何形状 |
+| 模糊效果 | ✅ 可配合 filter | ❌ 不支持 |
+| 动画性能 | 较好 | 最好 |
+| 浏览器支持 | 较新 | 良好 |
+| SVG 路径 | ✅ 任意 SVG 形状 | ✅ 支持 polygon/circle 等 |
+| 复杂度 | 较高 | 较低 |
+
+### 选择建议
+
+- **简单形状裁剪** → `clip-path`（性能更好，语法简洁）
+- **需要半透明/渐变效果** → `mask`（唯一选择）
+- **图片淡出、渐隐效果** → `mask`（必须使用 mask）
+- **复杂 SVG 形状** → 两者都支持，根据效果需求选择
+
+## 浏览器兼容性
+
+现代浏览器（Chrome 89+、Firefox 91+、Safari 17.4+、Edge 89+）已全面支持 CSS Mask。
+
+```css
+/* Safari 需要前缀 */
+-webkit-mask-image: radial-gradient(...);
+-webkit-mask: radial-gradient(...);
+
+/* 安全回退方案 */
+.not-masked {
+  border-radius: 50%; /* 基础圆形回退 */
+}
+```
+
+## 性能优化
+
+1. **使用 SVG 遮罩**：矢量格式，缩放无损，性能更好
+2. **避免过大的遮罩图片**：适当压缩 PNG 遮罩
+3. **优先使用 CSS 渐变**：无需额外网络请求
+4. **避免频繁动画**：mask 动画比 clip-path 性能差
+5. **使用 `will-change`**：对于需要动画的元素
+
+```css
+.animated-mask {
+  will-change: mask-image;
+  transition: mask-image 0.3s ease;
+}
+```

--- a/src/topics/06.text/text-box-trim/index.mdx
+++ b/src/topics/06.text/text-box-trim/index.mdx
@@ -1,0 +1,141 @@
+---
+title: CSS text-box-trim 文本修剪
+category: 文本排版
+tags: [css, text-box-trim, typography, leading]
+description: 详细介绍 CSS text-box-trim 属性，用于控制文本框上下空白的修剪。
+keywords: text-box-trim, text-box-edge, half-leading, 文本修剪, CSS 排版
+---
+
+通过本章理解
+
+1. text-box-trim 属性的概念和用法
+2. text-box-edge 如何配合使用
+3. 与 line-height 的配合关系
+4. 实战案例：按钮垂直居中、多行文本裁剪、图文对齐
+
+## 概念
+
+`text-box-trim` 是 CSS 新属性，允许开发者控制文本框上下的半行距（half-leading）空间。每个字体都会产生不同量的半行距空间，这会影响元素的高度。在过去，这种空间是无法精确控制的。
+
+从 Chrome 133 开始，`text-box-trim` 正式支持，允许开发者"修剪"掉文本框上下多余的空间。
+
+## 语法
+
+### 长属性
+
+```css
+text-box-trim: trim-start | trim-end | trim-both | none;
+text-box-edge: cap | ex | text | leading + alphabetic | text;
+```
+
+### 短属性
+
+```css
+/* 修剪两端，以大写字母为基准 */
+text-box: trim-both cap alphabetic;
+
+/* 修剪两端，以小写 x 字母为基准 */
+text-box: trim-both ex alphabetic;
+```
+
+### trim-start / trim-end / trim-both / none
+
+- `trim-start`：修剪文本框起始侧（上方）的半行距
+- `trim-end`：修剪文本框结束侧（下方）的半行距
+- `trim-both`：同时修剪上下两侧
+- `none`：不修剪（默认）
+
+### text-box-edge 值
+
+- `cap`：以大写字母顶部为基准
+- `ex`：以小写字母 x 顶部为基准
+- `alphabetic`：以字母基线为基准
+- `text`：以文本边缘为基准
+- `leading`：行间距边缘
+
+## 与 line-height 的配合
+
+`text-box-trim` 不会替代 `line-height`，而是与它协同工作：
+
+- `line-height` 控制行间距
+- `text-box-trim` 修剪文本框边缘的半行距空间
+
+```css
+/* 传统方式：手动调整 padding 补偿半行距 */
+button {
+  padding-block: 5px; /* 手动减少上下 padding */
+  padding-inline: 10px;
+}
+
+/* 使用 text-box-trim：自动修剪半行距 */
+button {
+  text-box: trim-both cap alphabetic;
+  padding: 10px; /* 现在上下 padding 相等了 */
+}
+```
+
+## 实战案例
+
+### 按钮垂直居中
+
+使用 `text-box-trim` 可以让按钮的内边距真正"相等"：
+
+```css
+button {
+  text-box: trim-both cap alphabetic;
+  padding: 10px 20px;
+  background: #3b82f6;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 16px;
+}
+```
+
+[演示：按钮垂直居中](../demos/text-box-trim/button-centering.html)
+
+### 多行文本裁剪
+
+多行文本每行都会有半行距空间，修剪后可以让文本框更紧凑：
+
+```css
+.multiline-text {
+  text-box: trim-both cap alphabetic;
+  line-height: 1.5;
+}
+```
+
+[演示：多行文本裁剪](../demos/text-box-trim/multiline-trim.html)
+
+### 图文垂直对齐
+
+当图片与文本并排时，文本的半行距会导致图片高度不匹配。使用 `text-box-trim` 可以精确对齐：
+
+```css
+.container {
+  display: flex;
+  align-items: baseline; /* 使用基线对齐 */
+}
+
+.text {
+  text-box: trim-both cap alphabetic;
+}
+```
+
+[演示：图文对齐](../demos/text-box-trim/image-text-alignment.html)
+
+## 浏览器兼容性
+
+| 特性 | Chrome | Firefox | Safari | Edge |
+|------|--------|---------|--------|------|
+| text-box-trim | 133+ | ❌ | 18.2+ | 133+ |
+| text-box-edge | 133+ | ❌ | 18.2+ | 133+ |
+
+> ⚠️ 目前主流浏览器支持情况有限，在生产环境中使用请注意渐进增强。
+
+## 更多资源
+
+- [Chrome 官方博客](https://developer.chrome.com/blog/css-text-box-trim)
+- [CSS Tricks 教程](https://css-tricks.com/two-css-properties-for-trimming-text-box-whitespace/)
+- [CSSWG 规范](https://drafts.csswg.org/css-inline-3/#text-edges)
+- [Figma 垂直修剪设计参考](https://help.figma.com/hc/en-us/articles/360039956634-Explore-text-properties#h_01H96FW9Z3W7J7Z2HEN8V17BZT)

--- a/src/topics/09.advanced/css-scope/index.mdx
+++ b/src/topics/09.advanced/css-scope/index.mdx
@@ -1,0 +1,414 @@
+---
+title: CSS @scope 规则
+category: 高级特性
+tags: [css, @scope, style-scoping, specificity]
+description: 详细介绍 CSS @scope 规则的用法、语法及其与特异性的关系。
+keywords: CSS @scope, 样式隔离, 作用域, 特异性, donut scope
+---
+
+# CSS @scope 规则
+
+---
+
+## 概述
+
+`@scope` 是 CSS 级联模块中引入的新规则，用于**限制选择器的触及范围**。通过设置作用域根（scoping root），可以让样式规则仅作用于 DOM 树的某个子树内，从而在不需要高特异性选择器或紧耦合 DOM 结构的情况下，精准地选择元素。
+
+### 为什么需要 @scope？
+
+传统 CSS 选择器面临两难困境：
+
+- **过于具体**：如 `.card > .content > img.hero`，特异性高达 `(0,3,1)`，难以覆盖，且与 DOM 结构紧耦合
+- **过于宽泛**：如 `img`，会选中页面中所有图片
+
+已有解决方案的局限：
+
+| 方案 | 局限性 |
+|------|--------|
+| BEM 命名 | 需要手动添加复杂类名，命名成本高 |
+| CSS Modules / Scoped CSS | 依赖构建工具或框架 |
+| 放弃选择器、直写行内样式 | 失去 CSS 的声明式优势 |
+
+`@scope` 让 CSS 原生支持作用域，兼顾**精确选择**与**低特异性**。
+
+---
+
+## 语法结构
+
+### 基本语法
+
+```css
+@scope (<scoping-root-selector>) {
+  /* scoped style rules */
+}
+```
+
+**`<scoping-root-selector>`** 可以是任意复杂的选择器，如类名、ID、属性选择器等。
+
+### 带下限的作用域（Donut Scope）
+
+```css
+@scope (<scoping-root-selector>) to (<scoping-limit-selector>) {
+  /* scoped style rules */
+}
+```
+
+- **上限**（`<scoping-root-selector>`）：确定作用域的上边界
+- **下限**（`<scoping-limit-selector>`）：确定作用域的下边界，排除某些子树
+
+下限使选择器只能命中位于上下边界之间的元素，形似"甜甜圈"，故称 **Donut Scope**。
+
+### 省略 prelude 的 @scope
+
+在 `<style>` 标签内使用时，可以省略 prelude，此时作用域根为 `<style>` 元素的父元素：
+
+```html
+<div class="card">
+  <div class="card__header">
+    <style>
+      @scope {
+        img {
+          border-color: green;
+        }
+      }
+    </style>
+    <!-- img 在作用域内 -->
+  </div>
+  <div class="card__content">
+    <p><img src="..."></p>
+    <!-- img 不在 card__header 内，不受作用域约束 -->
+  </div>
+</div>
+```
+
+---
+
+## :scope 选择器
+
+`@scope` 块内的选择器默认相对于作用域根匹配。如果需要**显式选择作用域根元素本身**，使用 `:scope` 伪类。
+
+### 基本用法
+
+```css
+@scope (.card) {
+  :scope {
+    /* 匹配 .card 根元素本身 */
+    border: 1px solid #ccc;
+  }
+
+  img {
+    /* 匹配 .card 内的 img 元素 */
+    border-color: green;
+  }
+
+  :scope img {
+    /* 与上面等价，显式写法 */
+  }
+
+  & img {
+    /* 使用 & 嵌套选择器，同样匹配 .card 内的 img */
+  }
+}
+```
+
+### :scope 与 & 的区别
+
+| 特性 | `:scope` | `&` |
+|------|----------|-----|
+| 含义 | 代表匹配到的作用域根元素 | 代表用于匹配作用域根的选择器 |
+| 可用次数 | 只能使用一次（不能嵌套 `:scope`） | 可以多次使用 |
+| 特异性计算 | 视为普通伪类 `(0,1,0)` | 按 `:is()` 规则计算（取最具体参数） |
+
+```css
+@scope (.card) {
+  & & {
+    /* 有效：选择嵌套在 .card 中的 .card */
+  }
+
+  :scope :scope {
+    /* 无效：不能嵌套 :scope */
+  }
+}
+```
+
+---
+
+## @scope 与 CSS 特异性
+
+### Prelude 选择器不影响特异性
+
+`@scope`  Prelude 中的选择器（如 `.card`）不参与块内选择器的特异性计算：
+
+```css
+@scope (#sidebar) {
+  img {
+    /* 特异性 = (0,0,1)，不受 #sidebar 影响 */
+  }
+}
+```
+
+### :scope 的特异性
+
+`:scope` 伪类的特异性为 **(0,1,0)**，与普通伪类（如 `:hover`）相同：
+
+```css
+@scope (#sidebar) {
+  :scope img {
+    /* 特异性 = (0,1,0) + (0,0,1) = (0,1,1) */
+  }
+}
+```
+
+### & 的特异性（Desugaring）
+
+`&` 在内部会被转换为 `:is(<scoping-root>)`（称为 *desugaring*），其特异性按 `:is()` 规则计算——**取最具体参数**的特异性：
+
+```css
+@scope (#sidebar, .card) {
+  & img {
+    /* 内部转换为 :is(#sidebar, .card) img
+       特异性 = max(id(#sidebar), class(.card)) + img
+              = (1,0,0) + (0,0,1) = (1,0,1) */
+  }
+}
+```
+
+---
+
+## 级联中的 Scoping Proximity
+
+`@scope` 在 CSS 级联中引入了一个新步骤：**Scoping Proximity（作用域邻近性）**，位于 specificity 之后、order of appearance 之前。
+
+### 规则
+
+当比较来自不同作用域根的声明时，**跳数（hops）更少**的作用域优先：
+
+```css
+@scope (.light) {
+  :scope { background: #ccc; }
+  a { color: black; }
+}
+
+@scope (.dark) {
+  :scope { background: #333; }
+  a { color: white; }
+}
+```
+
+```html
+<div class="light">
+  <p><a href="#">黑色</a></p>
+  <div class="dark">
+    <p><a href="#">白色</a></p>
+    <div class="light">
+      <p><a href="#">黑色（.light 作用域跳数更少，优先）</a></p>
+    </div>
+  </div>
+</div>
+```
+
+对于第三个 `<a>`：到 `.light` 作用域根只需 1 跳，到 `.dark` 需要 2 跳，因此 `.light` 的规则生效。
+
+### ⚠️ 注意：选择器隔离，非样式隔离
+
+`@scope` **限制的是选择器的触及范围**，不是样式属性本身。继承属性（如 `color`、`font-size`）仍然会穿透下限继承下去：
+
+```css
+@scope (.card) to (.card__content) {
+  :scope {
+    color: hotpink;
+  }
+}
+```
+
+```html
+<div class="card">
+  <p style="color: hotpink">Card 内容</p>
+  <div class="card__content">
+    <!-- .card__content 及其子元素仍会继承 hotpink -->
+    <p>.card__content 继承了父级 color</p>
+  </div>
+</div>
+```
+
+---
+
+## 实战案例
+
+### 案例一：组件样式隔离
+
+使用 `@scope` 实现组件样式隔离，无需 BEM 命名或构建工具：
+
+```css
+/* 基础卡片样式 */
+@scope (.card) {
+  :scope {
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    padding: 16px;
+  }
+
+  .card__title {
+    font-size: 18px;
+    font-weight: bold;
+  }
+
+  .card__img {
+    width: 100%;
+    border-radius: 4px;
+  }
+}
+
+/* 暗色主题卡片 */
+@scope (.card--dark) {
+  :scope {
+    background: #1a1a1a;
+    color: #fff;
+  }
+
+  .card__title {
+    color: #fff;
+  }
+
+  .card__img {
+    filter: brightness(0.8);
+  }
+}
+```
+
+### 案例二：Donut Scope 精确选择
+
+排除特定区域，只选择组件根元素和其直接子元素中的图片：
+
+```css
+@scope (.card) to (.card__footer) {
+  img {
+    border: 2px solid blue;
+  }
+}
+```
+
+```html
+<div class="card">
+  <img src="hero.jpg" />         <!-- 被选中，蓝色边框 -->
+  <div class="card__body">
+    <img src="icon.png" />       <!-- 被选中，蓝色边框 -->
+  </div>
+  <div class="card__footer">
+    <img src="badge.png" />      <!-- 不被选中，跳出了作用域 -->
+  </div>
+</div>
+```
+
+### 案例三：主题作用域
+
+利用 Scoping Proximity 实现嵌套主题的自动优先级：
+
+```css
+@scope (.theme--primary) {
+  a { color: blue; }
+}
+
+@scope (.theme--danger) {
+  a { color: red; }
+}
+```
+
+```html
+<div class="theme--primary">
+  <a>蓝色链接</a>
+  <div class="theme--danger">
+    <a>红色链接（嵌套层离 .theme--danger 更近，优先级更高）</a>
+  </div>
+</div>
+```
+
+---
+
+## 与其他样式隔离方案的对比
+
+### 对比表
+
+| 特性 | `@scope` | BEM | CSS Modules | Scoped CSS (Vue) |
+|------|----------|-----|-------------|------------------|
+| 原生支持 | ✅ | ❌ | ❌ | ❌ |
+| 零构建依赖 | ✅ | ✅ | ❌ | ❌ |
+| 选择器特异性可控 | ✅ | ⚠️ 依赖命名 | ✅ | ✅ |
+| 原生作用域隔离 | ✅ | ❌ | ✅ | ✅ |
+| 支持 Donut Scope | ✅ | ❌ | ❌ | ❌ |
+| 级联邻近性 | ✅ | ❌ | ❌ | ❌ |
+| 浏览器支持 | 现代浏览器 | ✅ | 需要构建 | 需要框架 |
+
+### BEM 对比
+
+```css
+/* BEM 方式 */
+.card__img--hero {
+  border-radius: 50%;
+}
+
+/* @scope 方式 */
+@scope (.card) {
+  img.hero {
+    border-radius: 50%;
+  }
+}
+```
+
+- BEM 通过**命名约定**实现隔离，类名复杂
+- `@scope` 通过**原生语法**实现隔离，语义更清晰
+
+### CSS Modules 对比
+
+```css
+/* CSS Modules 方式 */
+.card__img__7d3f2a {
+  border-radius: 50%;
+}
+
+/* @scope 方式 */
+@scope (.card) {
+  img.hero {
+    border-radius: 50%;
+  }
+}
+```
+
+- CSS Modules 需要构建工具注入哈希
+- `@scope` 无需构建，浏览器原生支持
+
+### Scoped CSS (Vue) 对比
+
+```html
+<!-- Vue Scoped CSS -->
+<style scoped>
+  .card img {
+    border-radius: 50%;
+  }
+</style>
+
+<!-- @scope 原生方式 -->
+<style>
+  @scope (.card) {
+    img {
+      border-radius: 50%;
+    }
+  }
+</style>
+```
+
+---
+
+## 浏览器兼容性
+
+`@scope` 已于 **Chrome 118+**、**Safari 17.4+** 支持。Firefox 正在实现中。
+
+查看最新兼容性：[caniuse.com/css-at-scope](https://caniuse.com/css-at-scope)
+
+---
+
+## 参考资源
+
+- [CSS @scope 规范 (W3C)](https://drafts.csswg.org/css-cascade-6/#scope-atrule)
+- [Chrome 开发者文档：CSS @scope](https://developer.chrome.com/docs/css-ui/at-scope)
+- [MDN: @scope](https://developer.mozilla.org/en-US/docs/Web/CSS/@scope)


### PR DESCRIPTION
## 概述

新增 CSS light-dark() 暗色模式切换函数的文档和演示。

## 改动内容

### 文档 src/topics/01.basics/11.light-dark/index.mdx
- light-dark() 函数语法说明
- 与 prefers-color-scheme 媒体查询的区别对比
- 实际应用场景（基础颜色、组件、代码高亮、按钮等）
- 浏览器兼容性说明（2024年5月 Baseline 支持）
- 局部主题强制覆盖的进阶用法

### 演示 examples/css/demos/light-dark/index.html
- 8个交互式演示示例
- 支持调试面板强制切换浅色/深色/自动主题
- 涵盖卡片、按钮、表单、代码块、阴影等组件

## 参考
- [MDN light-dark()](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark)
- [CSS Color Level 5 规范](https://drafts.csswg.org/css-color-5/#light-dark)