### PR TITLE
feat: CSS content 属性完整学习

### DIFF
--- a/examples/css/demos/color-contrast/index.html
+++ b/examples/css/demos/color-contrast/index.html
@@ -1,0 +1,418 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS contrast-color() 交互演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 13px; color: #6e7681; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .section h3 { font-size: 14px; color: #8b949e; margin: 16px 0 8px; }
+    .demo-area { display: flex; gap: 16px; min-height: 80px; padding: 16px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; align-items: center; flex-wrap: wrap; }
+    .box { background: #21262d; border: 1px solid #30363d; border-radius: 4px; padding: 12px; color: #c9d1d9; font-size: 14px; }
+    .demo-label { font-size: 13px; color: #6e7681; min-width: 120px; }
+    .info { font-size: 12px; color: #6e7681; margin-top: 12px; }
+    .warning { font-size: 12px; color: #d29922; margin-top: 8px; padding: 8px; background: #d299220d; border-radius: 4px; }
+    .success { font-size: 12px; color: #3fb950; margin-top: 8px; padding: 8px; background: #3fb9501a; border-radius: 4px; }
+    .error { font-size: 12px; color: #f85149; margin-top: 8px; padding: 8px; background: #f851491a; border-radius: 4px; }
+
+    /* 演示卡片样式 */
+    .color-card {
+      display: inline-flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+      padding: 16px;
+      border-radius: 8px;
+      min-width: 120px;
+    }
+    .color-swatch {
+      width: 80px;
+      height: 80px;
+      border-radius: 8px;
+      border: 2px solid #30363d;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      font-weight: bold;
+    }
+    .color-name { font-size: 12px; color: #8b949e; text-align: center; }
+
+    /* 背景选择器 */
+    .bg-selector { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .bg-btn {
+      padding: 8px 16px;
+      border: 2px solid #30363d;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 13px;
+      transition: all 0.15s;
+      color: #c9d1d9;
+    }
+    .bg-btn:hover { border-color: #58a6ff; }
+    .bg-btn.active { border-color: #58a6ff; background: #58a6ff22; }
+
+    /* 结果展示区 */
+    .result-area { display: flex; gap: 16px; flex-wrap: wrap; margin-top: 16px; }
+    .result-item { display: flex; flex-direction: column; align-items: center; gap: 8px; }
+    .result-color { width: 100px; height: 60px; border-radius: 6px; display: flex; align-items: center; justify-content: center; font-weight: bold; border: 2px solid #30363d; }
+    .result-label { font-size: 11px; color: #6e7681; }
+
+    /* 代码块 */
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; margin-top: 12px; }
+
+    /* 对比度指示器 */
+    .contrast-ratio {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 4px 8px;
+      border-radius: 4px;
+      font-size: 12px;
+      font-weight: bold;
+    }
+    .contrast-ratio.high { background: #3fb95022; color: #3fb950; }
+    .contrast-ratio.medium { background: #d2992222; color: #d29922; }
+    .contrast-ratio.low { background: #f8514922; color: #f85149; }
+
+    /* 对比度等级说明 */
+    .wcag-table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+    .wcag-table th, .wcag-table td { padding: 8px 12px; border: 1px solid #30363d; text-align: left; font-size: 13px; }
+    .wcag-table th { background: #21262d; color: #f0f6fc; }
+    .wcag-table td { color: #c9d1d9; }
+
+    /* 按钮样式 */
+    .btn { padding: 6px 12px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS contrast-color() 交互演示</h1>
+    <p class="subtitle">根据背景色自动选择高对比度前景色（需浏览器支持，目前无浏览器实现）</p>
+
+    <!-- 说明区域 -->
+    <div class="section">
+      <h2>⚠️ 浏览器支持状态</h2>
+      <p class="info">contrast-color() 是 CSS Color Level 5 的实验性功能，目前没有任何主流浏览器支持。以下演示使用 JavaScript 模拟函数行为，CSS 代码仅为语法示例。</p>
+      <div class="code-block">/* CSS 语法（目前浏览器不支持） */
+color: contrast-color(blue, white, black);  /* 期望返回 white */</div>
+    </div>
+
+    <!-- 对比度计算原理 -->
+    <div class="section">
+      <h2>对比度计算原理（WCAG 2.1）</h2>
+      <p class="info">对比度比值 = (L1 + 0.05) / (L2 + 0.05)，其中 L1 是较亮颜色的相对亮度，L2 是较暗颜色的相对亮度。</p>
+
+      <table class="wcag-table">
+        <thead>
+          <tr>
+            <th>对比度等级</th>
+            <th>AA 级要求</th>
+            <th>AAA 级要求</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>普通文本</td>
+            <td>≥ 4.5:1</td>
+            <td>≥ 7:1</td>
+          </tr>
+          <tr>
+            <td>大文本 (18px+)</td>
+            <td>≥ 3:1</td>
+            <td>≥ 4.5:1</td>
+          </tr>
+          <tr>
+            <td>UI 组件和图形</td>
+            <td>≥ 3:1</td>
+            <td>≥ 3:1</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- 交互演示 -->
+    <div class="section">
+      <h2>交互演示：自动选择高对比度颜色</h2>
+      <p class="info">点击不同背景色，查看 contrast-color() 会选择哪个前景色（模拟）</p>
+
+      <!-- 背景选择 -->
+      <div class="bg-selector" id="bgSelector">
+        <button class="bg-btn" data-bg="#000000" style="background:#000000;color:#fff;">黑色</button>
+        <button class="bg-btn" data-bg="#ffffff" style="background:#fff;color:#000;">白色</button>
+        <button class="bg-btn" data-bg="#1890ff" style="background:#1890ff;color:#fff;">蓝色</button>
+        <button class="bg-btn" data-bg="#52c41a" style="background:#52c41a;color:#fff;">绿色</button>
+        <button class="bg-btn" data-bg="#ff4d4f" style="background:#ff4d4f;color:#fff;">红色</button>
+        <button class="bg-btn" data-bg="#722ed1" style="background:#722ed1;color:#fff;">紫色</button>
+        <button class="bg-btn" data-bg="#faad14" style="background:#faad14;color:#000;">黄色</button>
+        <button class="bg-btn active" data-bg="#f0f0f0" style="background:#f0f0f0;color:#000;">浅灰</button>
+      </div>
+
+      <!-- 结果展示 -->
+      <div class="result-area" id="resultArea">
+        <div class="result-item">
+          <div class="result-color" id="resultWhite" style="background:#ffffff;">白色</div>
+          <span class="result-label">白色</span>
+          <span class="contrast-ratio" id="ratioWhite"></span>
+        </div>
+        <div class="result-item">
+          <div class="result-color" id="resultBlack" style="background:#ffffff;">黑色</div>
+          <span class="result-label">黑色</span>
+          <span class="contrast-ratio" id="ratioBlack"></span>
+        </div>
+        <div class="result-item">
+          <div class="result-color" id="resultChosen" style="background:#1890ff;">选中</div>
+          <span class="result-label">contrast-color()</span>
+          <span class="contrast-ratio" id="ratioChosen"></span>
+        </div>
+      </div>
+
+      <div class="code-block" id="cssCode">color: contrast-color(#f0f0f0, white, black);</div>
+    </div>
+
+    <!-- 实际应用示例 -->
+    <div class="section">
+      <h2>实际应用场景</h2>
+
+      <h3>1. 按钮文字自动适配</h3>
+      <div class="demo-area">
+        <div class="color-card" style="background:#1890ff;" id="card1">
+          <div class="color-swatch" id="btnText1" style="background:#fff;color:#1890ff;">按钮文字</div>
+          <span class="color-name">#1890ff 背景</span>
+          <span id="chosen1" style="font-size:11px;color:#8b949e;">选中白色文字</span>
+        </div>
+        <div class="color-card" style="background:#1a1a1a;" id="card2">
+          <div class="color-swatch" id="btnText2" style="background:#fff;color:#1a1a1a;">按钮文字</div>
+          <span class="color-name">#1a1a1a 背景</span>
+          <span id="chosen2" style="font-size:11px;color:#8b949e;">选中白色文字</span>
+        </div>
+        <div class="color-card" style="background:#faad14;" id="card3">
+          <div class="color-swatch" id="btnText3" style="background:#000;color:#faad14;">按钮文字</div>
+          <span class="color-name">#faad14 背景</span>
+          <span id="chosen3" style="font-size:11px;color:#8b949e;">选中黑色文字</span>
+        </div>
+      </div>
+      <div class="code-block">.button {
+  background-color: var(--brand-color);
+  color: contrast-color(var(--brand-color), #fff, #000);
+}</div>
+
+      <h3>2. 卡片标题文字</h3>
+      <div class="demo-area">
+        <div style="padding:16px;background:#e8f0ff;border-radius:8px;margin-right:16px;">
+          <p style="color:#1a1a1a;font-size:16px;font-weight:bold;">卡片标题文字</p>
+          <p style="color:#4a5568;font-size:14px;margin-top:8px;">浅蓝色背景配深色文字</p>
+          <span style="font-size:11px;color:#3fb950;">✓ 对比度 12.6:1 (AAA)</span>
+        </div>
+        <div style="padding:16px;background:#1a1a1a;border-radius:8px;">
+          <p style="color:#ffffff;font-size:16px;font-weight:bold;">卡片标题文字</p>
+          <p style="color:#a0aec0;font-size:14px;margin-top:8px;">深色背景配浅色文字</p>
+          <span style="font-size:11px;color:#3fb950;">✓ 对比度 16.1:1 (AAA)</span>
+        </div>
+      </div>
+
+      <h3>3. 用户头像边框</h3>
+      <div class="demo-area">
+        <div style="display:flex;align-items:center;gap:16px;">
+          <div style="width:60px;height:60px;border-radius:50%;background:linear-gradient(135deg,#ff6b6b,#feca57);display:flex;align-items:center;justify-content:center;color:#fff;font-weight:bold;">头像</div>
+          <div style="display:flex;flex-direction:column;gap:4px;">
+            <span style="font-size:14px;color:#fff;">用户名</span>
+            <span style="font-size:12px;color:#a0aec0;">渐变边框上的文字</span>
+            <span style="font-size:11px;color:#3fb950;">✓ 对比度充足</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- 代码示例 -->
+    <div class="section">
+      <h2>CSS 代码示例</h2>
+      <div class="code-block">/* 基本用法 */
+color: contrast-color(blue, white, black);
+
+/* 使用 CSS 变量 */
+:root {
+  --bg: #f5f5f5;
+  --text: contrast-color(var(--bg), #1a1a1a, #ffffff);
+}
+
+body {
+  background-color: var(--bg);
+  color: var(--text);
+}
+
+/* 暗黑模式 */
+[data-theme="dark"] {
+  --bg: #1a1a1a;
+  --text: contrast-color(var(--bg), #ffffff, #000000);
+}
+
+/* 三个颜色选项 */
+.label {
+  color: contrast-color(
+    var(--label-bg),
+    #fff,
+    #000,
+    #f0f0f0  /* 如果白和黑对比度都不够，可选第三个 */
+  );
+}</div>
+    </div>
+
+    <div class="warning">
+      ⚠️ contrast-color() 目前无浏览器支持。以上演示使用 JavaScript 模拟函数行为。当浏览器支持后，请移除 JavaScript 模拟代码。
+    </div>
+  </div>
+
+  <script>
+    // 计算相对亮度 (Relative Luminance)
+    function relativeLuminance(r, g, b) {
+      const [rs, gs, bs] = [r, g, b].map(c => {
+        c = c / 255;
+        return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+      });
+      return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+    }
+
+    // 计算对比度
+    function contrastRatio(color1, color2) {
+      const l1 = relativeLuminance(color1[0], color1[1], color1[2]);
+      const l2 = relativeLuminance(color2[0], color2[1], color2[2]);
+      const lighter = Math.max(l1, l2);
+      const darker = Math.min(l1, l2);
+      return (lighter + 0.05) / (darker + 0.05);
+    }
+
+    // hex 转 rgb
+    function hexToRgb(hex) {
+      const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+      return result ? [
+        parseInt(result[1], 16),
+        parseInt(result[2], 16),
+        parseInt(result[3], 16)
+      ] : [0, 0, 0];
+    }
+
+    // 获取 contrast-color 函数的结果（模拟）
+    function contrastColor(bgHex, ...colors) {
+      const bgRgb = hexToRgb(bgHex);
+      let best = colors[0];
+      let bestRatio = 0;
+      for (const color of colors) {
+        const ratio = contrastRatio(bgRgb, hexToRgb(color));
+        if (ratio > bestRatio) {
+          bestRatio = ratio;
+          best = color;
+        }
+      }
+      return { color: best, ratio: bestRatio };
+    }
+
+    // 获取对比度等级
+    function getContrastLevel(ratio) {
+      if (ratio >= 7) return { label: `${ratio.toFixed(1)}:1 AAA`, class: 'high' };
+      if (ratio >= 4.5) return { label: `${ratio.toFixed(1)}:1 AA`, class: 'medium' };
+      if (ratio >= 3) return { label: `${ratio.toFixed(1)}:1 AA Large`, class: 'medium' };
+      return { label: `${ratio.toFixed(1)}:1 失败`, class: 'low' };
+    }
+
+    // 更新结果展示
+    function updateResults(bgHex) {
+      const white = '#ffffff';
+      const black = '#000000';
+
+      const whiteRatio = contrastRatio(hexToRgb(bgHex), hexToRgb(white));
+      const blackRatio = contrastRatio(hexToRgb(bgHex), hexToRgb(black));
+      const result = contrastColor(bgHex, white, black);
+
+      // 更新结果卡片
+      const resultWhite = document.getElementById('resultWhite');
+      const resultBlack = document.getElementById('resultBlack');
+      const resultChosen = document.getElementById('resultChosen');
+
+      resultWhite.style.backgroundColor = bgHex;
+      resultWhite.style.color = white;
+      resultWhite.textContent = white;
+
+      resultBlack.style.backgroundColor = bgHex;
+      resultBlack.style.color = black;
+      resultBlack.textContent = black;
+
+      resultChosen.style.backgroundColor = bgHex;
+      resultChosen.style.color = result.color;
+      resultChosen.textContent = result.color === white ? '白色 ✓' : '黑色 ✓';
+
+      // 更新对比度指示器
+      updateRatioIndicator('ratioWhite', whiteRatio);
+      updateRatioIndicator('ratioBlack', blackRatio);
+      updateRatioIndicator('ratioChosen', result.ratio);
+
+      // 更新代码示例
+      document.getElementById('cssCode').textContent =
+        `color: contrast-color(${bgHex}, white, black); /* 返回 ${result.color} */`;
+
+      // 更新按钮文字卡片
+      updateButtonCards(bgHex);
+    }
+
+    function updateRatioIndicator(id, ratio) {
+      const el = document.getElementById(id);
+      const level = getContrastLevel(ratio);
+      el.textContent = level.label;
+      el.className = `contrast-ratio ${level.class}`;
+    }
+
+    function updateButtonCards(bgHex) {
+      const result = contrastColor(bgHex, '#ffffff', '#000000');
+
+      // 卡片1
+      const card1 = document.getElementById('card1');
+      const btnText1 = document.getElementById('btnText1');
+      const chosen1 = document.getElementById('chosen1');
+      card1.style.backgroundColor = '#1890ff';
+      btnText1.style.backgroundColor = result.color;
+      btnText1.style.color = '#1890ff';
+      chosen1.textContent = `选中 ${result.color === '#ffffff' ? '白色' : '黑色'} 文字`;
+
+      // 卡片2
+      const card2 = document.getElementById('card2');
+      const btnText2 = document.getElementById('btnText2');
+      const chosen2 = document.getElementById('chosen2');
+      card2.style.backgroundColor = '#1a1a1a';
+      const result2 = contrastColor('#1a1a1a', '#ffffff', '#000000');
+      btnText2.style.backgroundColor = result2.color;
+      btnText2.style.color = '#1a1a1a';
+      chosen2.textContent = `选中 ${result2.color === '#ffffff' ? '白色' : '黑色'} 文字`;
+
+      // 卡片3
+      const card3 = document.getElementById('card3');
+      const btnText3 = document.getElementById('btnText3');
+      const chosen3 = document.getElementById('chosen3');
+      card3.style.backgroundColor = '#faad14';
+      const result3 = contrastColor('#faad14', '#ffffff', '#000000');
+      btnText3.style.backgroundColor = result3.color;
+      btnText3.style.color = '#faad14';
+      chosen3.textContent = `选中 ${result3.color === '#ffffff' ? '白色' : '黑色'} 文字`;
+    }
+
+    // 绑定事件
+    document.querySelectorAll('.bg-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.bg-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        updateResults(btn.dataset.bg);
+      });
+    });
+
+    // 初始化
+    updateResults('#f0f0f0');
+  </script>
+</body>
+</html>

--- a/examples/css/demos/css-content/content-attr.html
+++ b/examples/css/demos/css-content/content-attr.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>content 属性 - attr() 函数</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0d1117; color: #c9d1d9;
+      min-height: 100vh; padding: 24px;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 22px; color: #f0f6fc; margin-bottom: 20px; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 16px; }
+    h2 { font-size: 15px; color: #f0f6fc; margin-bottom: 14px; }
+    .demo-box { padding: 16px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; }
+    .form-row { margin-bottom: 12px; }
+    .form-row label { display: inline-block; min-width: 80px; }
+    .form-row [data-label]::before { content: attr(data-label) ": "; color: #58a6ff; font-weight: bold; }
+    .form-row { padding: 8px; border: 1px solid #21262d; border-radius: 4px; }
+    .file-list { list-style: none; }
+    .file-list li { padding: 8px 0; border-bottom: 1px solid #21262d; }
+    .file-list li:last-child { border-bottom: none; }
+    .file-list a { color: #58a6ff; text-decoration: none; }
+    .file-list a[href$=".pdf"]::after { content: " (PDF, " attr(data-size) ")"; color: #f85149; font-size: 12px; margin-left: 6px; }
+    .file-list a[href$=".zip"]::after { content: " (ZIP, " attr(data-size) ")"; color: #3fb950; font-size: 12px; margin-left: 6px; }
+    .file-list a[href$=".docx"]::after { content: " (Word, " attr(data-size) ")"; color: #58a6ff; font-size: 12px; margin-left: 6px; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; white-space: pre-wrap; }
+    .desc { font-size: 13px; color: #8b949e; margin-top: 10px; }
+    .print-note { background: #21262d; padding: 8px; border-radius: 4px; font-size: 12px; color: #8b949e; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>content 属性 - attr() 函数</h1>
+
+    <div class="section">
+      <h2>数据标签</h2>
+      <div class="demo-box">
+        <div class="form-row">
+          <span data-label="姓名">张三</span>
+        </div>
+        <div class="form-row">
+          <span data-label="邮箱">zhangsan@example.com</span>
+        </div>
+        <div class="form-row">
+          <span data-label="电话">138-0013-8000</span>
+        </div>
+      </div>
+      <div class="code-block">[data-label]::before {
+  content: attr(data-label) ": ";
+  color: #58a6ff;
+  font-weight: bold;
+}</div>
+      <p class="desc">使用 data-* 属性配合 attr() 读取标签文本</p>
+    </div>
+
+    <div class="section">
+      <h2>文件类型和大小</h2>
+      <div class="demo-box">
+        <ul class="file-list">
+          <li><a href="report.pdf" data-size="2.4 MB">年度报告 2025</a></li>
+          <li><a href="assets.zip" data-size="15.8 MB">设计资源包</a></li>
+          <li><a href="brief.docx" data-size="156 KB">项目简报</a></li>
+        </ul>
+      </div>
+      <div class="code-block">a[href$=".pdf"]::after {
+  content: " (PDF, " attr(data-size) ")";
+  color: #f85149;
+}</div>
+      <p class="desc">根据文件类型显示不同颜色标记，并从 data-size 属性读取文件大小</p>
+    </div>
+
+    <div class="section">
+      <h2>打印样式中的 URL 显示</h2>
+      <div class="demo-box">
+        <p>这是一个外部链接：<a href="https://www.example.com/documentation" style="color:#58a6ff;">查看文档</a></p>
+      </div>
+      <div class="code-block">@media print {
+  a[href^="http://"]::after,
+  a[href^="https://"]::after {
+    content: " (" attr(href) ")";
+    font-size: 10px;
+    color: #666;
+  }
+}</div>
+      <p class="desc">打印时在链接后显示完整 URL，方便读者查找原始资料</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-content/content-breadcrumb.html
+++ b/examples/css/demos/css-content/content-breadcrumb.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>content 属性 - 面包屑导航</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0d1117; color: #c9d1d9;
+      min-height: 100vh; padding: 24px;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 22px; color: #f0f6fc; margin-bottom: 20px; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 16px; }
+    h2 { font-size: 15px; color: #f0f6fc; margin-bottom: 14px; }
+    .demo-box { padding: 16px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; }
+    .breadcrumb { display: flex; align-items: center; flex-wrap: wrap; gap: 4px; font-size: 14px; }
+    .breadcrumb a { color: #58a6ff; text-decoration: none; }
+    .breadcrumb a:hover { text-decoration: underline; }
+    .breadcrumb-sep::before { content: " / "; color: #484f58; }
+    .breadcrumb-sep { color: #484f58; }
+    .breadcrumb-icon { display: flex; align-items: center; }
+    .breadcrumb-icon a::before { content: ""; display: inline-block; width: 14px; height: 14px; background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%2358a6ff'%3E%3Cpath d='M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z'/%3E%3C/svg%3E") no-repeat center; background-size: contain; margin-right: 4px; vertical-align: middle; }
+    .breadcrumb-icon-sep::before { content: ""; display: inline-block; width: 10px; height: 10px; background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23484f58'%3E%3Cpath d='M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6z'/%3E%3C/svg%3E") no-repeat center; background-size: contain; margin: 0 4px; vertical-align: middle; }
+    .breadcrumb-number { display: flex; align-items: center; counter-reset: breadcrumb; }
+    .breadcrumb-number li { counter-increment: breadcrumb; }
+    .breadcrumb-number li a::before { content: counter(breadcrumb) ". "; color: #8b949e; font-size: 12px; margin-right: 4px; }
+    .breadcrumb-number li { list-style: none; }
+    .breadcrumb-number { display: flex; gap: 8px; }
+    .breadcrumb-number a { color: #58a6ff; text-decoration: none; }
+    .breadcrumb-number li::after { content: ""; display: inline-block; width: 10px; height: 10px; background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23484f58'%3E%3Cpath d='M8.59 16.59L13.17 12 8.59 7.41 10 6l6 6-6 6z'/%3E%3C/svg%3E") no-repeat center; background-size: contain; margin-left: 8px; vertical-align: middle; }
+    .breadcrumb-number li:last-child::after { content: none; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; white-space: pre-wrap; }
+    .desc { font-size: 13px; color: #8b949e; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>content 属性 - 面包屑导航</h1>
+
+    <div class="section">
+      <h2>简单分隔符</h2>
+      <div class="demo-box">
+        <nav class="breadcrumb">
+          <a href="#">首页</a>
+          <span class="breadcrumb-sep"></span>
+          <a href="#">产品</a>
+          <span class="breadcrumb-sep"></span>
+          <a href="#">电子产品</a>
+          <span class="breadcrumb-sep"></span>
+          <span>智能手机</span>
+        </nav>
+      </div>
+      <div class="code-block">.breadcrumb-sep::before { content: " / "; color: #484f58; }</div>
+      <p class="desc">使用 ::before 伪元素在分隔符 span 前添加 "/" 字符</p>
+    </div>
+
+    <div class="section">
+      <h2>图标分隔符</h2>
+      <div class="demo-box">
+        <nav class="breadcrumb">
+          <span class="breadcrumb-icon"><a href="#">首页</a></span>
+          <span class="breadcrumb-icon-sep"></span>
+          <span class="breadcrumb-icon"><a href="#">产品</a></span>
+          <span class="breadcrumb-icon-sep"></span>
+          <span class="breadcrumb-icon"><a href="#">电子产品</a></span>
+          <span class="breadcrumb-icon-sep"></span>
+          <span>智能手机</span>
+        </nav>
+      </div>
+      <div class="code-block">.breadcrumb-icon-sep::before {
+  content: "";
+  display: inline-block;
+  width: 10px; height: 10px;
+  background: url("chevron-right.svg") no-repeat center;
+  margin: 0 8px;
+}</div>
+      <p class="desc">使用 SVG 图标作为分隔符，替代纯文本</p>
+    </div>
+
+    <div class="section">
+      <h2>带编号的面包屑</h2>
+      <div class="demo-box">
+        <nav>
+          <ol class="breadcrumb-number">
+            <li><a href="#">首页</a></li>
+            <li><a href="#">产品</a></li>
+            <li><a href="#">电子产品</a></li>
+            <li><span>智能手机</span></li>
+          </ol>
+        </nav>
+      </div>
+      <div class="code-block">ol { counter-reset: breadcrumb; }
+li { counter-increment: breadcrumb; }
+li a::before { content: counter(breadcrumb) ". "; color: #8b949e; }
+li::after { content: ""; display: inline-block; width: 10px; height: 10px; background: url("chevron.svg") no-repeat center; margin-left: 8px; }
+li:last-child::after { content: none; }</div>
+      <p class="desc">使用计数器为每个导航项添加序号</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-content/content-clearfix.html
+++ b/examples/css/demos/css-content/content-clearfix.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>content 属性 - 浮动清除</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0d1117; color: #c9d1d9;
+      min-height: 100vh; padding: 24px;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 22px; color: #f0f6fc; margin-bottom: 20px; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 16px; }
+    h2 { font-size: 15px; color: #f0f6fc; margin-bottom: 14px; }
+    .demo-box { padding: 16px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; }
+    .demo-box2 { padding: 16px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; border: 2px dashed #f85149; }
+    .profile-card { border: 1px solid #30363d; border-radius: 6px; padding: 16px; margin-bottom: 16px; }
+    .profile-card .avatar { float: left; width: 60px; height: 60px; background: #58a6ff; border-radius: 50%; margin-right: 12px; display: flex; align-items: center; justify-content: center; font-size: 24px; }
+    .profile-card .info { overflow: hidden; }
+    .profile-card .name { font-size: 16px; font-weight: bold; color: #f0f6fc; }
+    .profile-card .bio { font-size: 13px; color: #8b949e; margin-top: 4px; }
+    .profile-card .clearfix::after { content: ""; display: block; clear: both; }
+    .gallery { border: 1px solid #30363d; border-radius: 6px; overflow: hidden; }
+    .gallery-item { float: left; width: 25%; padding: 8px; }
+    .gallery-item-inner { background: #21262d; border-radius: 4px; height: 60px; display: flex; align-items: center; justify-content: center; color: #8b949e; font-size: 12px; }
+    .gallery .clearfix::after { content: ""; display: block; clear: both; }
+    .gallery-caption { background: #161b22; padding: 10px; font-size: 13px; color: #8b949e; border-top: 1px solid #30363d; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; white-space: pre-wrap; }
+    .desc { font-size: 13px; color: #8b949e; margin-top: 10px; }
+    .warning { background: #f8514922; border: 1px solid #f85149; border-radius: 4px; padding: 10px; font-size: 13px; color: #f85149; margin-top: 12px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>content 属性 - 浮动清除</h1>
+
+    <div class="section">
+      <h2>基本清除浮动</h2>
+      <div class="demo-box">
+        <div class="profile-card">
+          <div class="avatar">👤</div>
+          <div class="info">
+            <div class="name">张小明</div>
+            <div class="bio">全栈工程师，热爱开源，专注前端技术</div>
+          </div>
+        </div>
+        <div style="color:#8b949e; font-size:13px;">下方内容不受浮动影响</div>
+      </div>
+      <div class="code-block">.clearfix::after {
+  content: "";
+  display: block;
+  clear: both;
+}</div>
+      <p class="desc">使用 ::after 伪元素在浮动容器末尾插入一个空块元素，清除所有浮动</p>
+    </div>
+
+    <div class="section">
+      <h2>图片画廊</h2>
+      <div class="demo-box">
+        <div class="gallery">
+          <div class="gallery-item"><div class="gallery-item-inner">图片 1</div></div>
+          <div class="gallery-item"><div class="gallery-item-inner">图片 2</div></div>
+          <div class="gallery-item"><div class="gallery-item-inner">图片 3</div></div>
+          <div class="gallery-item"><div class="gallery-item-inner">图片 4</div></div>
+          <div class="gallery-item"><div class="gallery-item-inner">图片 5</div></div>
+          <div class="gallery-item"><div class="gallery-item-inner">图片 6</div></div>
+          <div class="gallery-item"><div class="gallery-item-inner">图片 7</div></div>
+          <div class="gallery-item"><div class="gallery-item-inner">图片 8</div></div>
+          <div class="clearfix"></div>
+          <div class="gallery-caption">8 张图片 · 2025年摄影作品集</div>
+        </div>
+      </div>
+      <div class="code-block">.gallery-item { float: left; width: 25%; }
+.gallery::after { content: ""; display: block; clear: both; }</div>
+      <p class="desc">在没有 clearfix 类的情况下，下方的 caption 会紧贴着浮动元素</p>
+    </div>
+
+    <div class="section">
+      <h2>没有清除浮动的问题</h2>
+      <div class="demo-box2">
+        <div style="color:#f85149; font-size:13px; margin-bottom:8px;">⚠️ 下方没有使用 clearfix，caption 紧贴着浮动元素</div>
+        <div class="gallery">
+          <div class="gallery-item"><div class="gallery-item-inner">图片 1</div></div>
+          <div class="gallery-item"><div class="gallery-item-inner">图片 2</div></div>
+          <div class="gallery-item"><div class="gallery-item-inner">图片 3</div></div>
+          <div class="gallery-item"><div class="gallery-item-inner">图片 4</div></div>
+          <div class="gallery-caption" style="border-top:none;">⚠️ 我应该在这里，但被挤到旁边了</div>
+        </div>
+      </div>
+      <div class="warning">注意：如果不使用 ::after 清除浮动，后续元素会紧贴浮动元素排列，导致布局错乱</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-content/content-counter-basic.html
+++ b/examples/css/demos/css-content/content-counter-basic.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>content 属性 - 基本计数器</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0d1117; color: #c9d1d9;
+      min-height: 100vh; padding: 24px;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 22px; color: #f0f6fc; margin-bottom: 20px; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 16px; }
+    h2 { font-size: 15px; color: #f0f6fc; margin-bottom: 14px; }
+    .demo-box { padding: 16px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; }
+    ol { list-style: none; }
+    .article-list { counter-reset: chapter; }
+    .article-list li { counter-increment: chapter; padding: 8px 0; border-bottom: 1px solid #21262d; display: flex; align-items: center; gap: 10px; }
+    .article-list li::before { content: "第 " counter(chapter) " 章"; color: #58a6ff; min-width: 80px; font-size: 13px; }
+    .article-list li:last-child { border-bottom: none; }
+    .steps { counter-reset: step; }
+    .steps li { counter-increment: step; padding: 6px 0; }
+    .steps li::before { content: counter(step); background: #238636; color: white; width: 20px; height: 20px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-size: 12px; margin-right: 10px; font-weight: bold; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; white-space: pre-wrap; }
+    .desc { font-size: 13px; color: #8b949e; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>content 属性 - 基本计数器</h1>
+
+    <div class="section">
+      <h2>文章章节编号</h2>
+      <div class="demo-box">
+        <ol class="article-list">
+          <li>CSS 基础入门</li>
+          <li>选择器详解</li>
+          <li>盒模型原理</li>
+          <li>Flexbox 布局</li>
+          <li>CSS Grid 布局</li>
+        </ol>
+      </div>
+      <div class="code-block">ol { counter-reset: chapter; }
+li { counter-increment: chapter; }
+li::before {
+  content: "第 " counter(chapter) " 章";
+  color: #58a6ff;
+}</div>
+      <p class="desc">使用 counter() 输出计数器值，自动编号文章章节</p>
+    </div>
+
+    <div class="section">
+      <h2>步骤指示器</h2>
+      <div class="demo-box">
+        <ol class="steps" style="list-style:none;">
+          <li>注册账号</li>
+          <li>完成实名认证</li>
+          <li>充值金额</li>
+          <li>开始交易</li>
+        </ol>
+      </div>
+      <div class="code-block">ol { counter-reset: step; }
+li { counter-increment: step; }
+li::before {
+  content: counter(step);
+  background: #238636;
+  color: white;
+  width: 20px; height: 20px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}</div>
+      <p class="desc">配合圆形背景制作步骤指示器</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-content/content-counter-nested.html
+++ b/examples/css/demos/css-content/content-counter-nested.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>content 属性 - 嵌套计数器</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0d1117; color: #c9d1d9;
+      min-height: 100vh; padding: 24px;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 22px; color: #f0f6fc; margin-bottom: 20px; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 16px; }
+    h2 { font-size: 15px; color: #f0f6fc; margin-bottom: 14px; }
+    .demo-box { padding: 16px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; }
+    .toc { list-style: none; counter-reset: chapter; padding-left: 0; }
+    .toc li { padding: 4px 0; }
+    .toc > li { counter-increment: chapter; padding: 8px 0; border-bottom: 1px solid #21262d; }
+    .toc > li:last-child { border-bottom: none; }
+    .toc > li::before { content: counter(chapter) " "; color: #58a6ff; font-weight: bold; }
+    .toc ol { list-style: none; counter-reset: section; padding-left: 24px; margin-top: 4px; }
+    .toc ol li { counter-increment: section; }
+    .toc ol li::before { content: counter(chapter) "." counter(section) " "; color: #8b949e; font-size: 13px; }
+    .toc ol ol { counter-reset: subsection; padding-left: 24px; }
+    .toc ol ol li { counter-increment: subsection; font-size: 14px; color: #8b949e; }
+    .toc ol ol li::before { content: counter(chapter) "." counter(section) "." counter(subsection) " "; font-size: 12px; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; white-space: pre-wrap; }
+    .desc { font-size: 13px; color: #8b949e; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>content 属性 - 嵌套计数器</h1>
+
+    <div class="section">
+      <h2>多级目录编号</h2>
+      <div class="demo-box">
+        <ol class="toc">
+          <li>HTML 基础
+            <ol>
+              <li>标签语法</li>
+              <li>常用元素
+                <ol>
+                  <li>div 和 span</li>
+                  <li>表单元素</li>
+                </ol>
+              </li>
+              <li>属性</li>
+            </ol>
+          </li>
+          <li>CSS 基础
+            <ol>
+              <li>选择器</li>
+              <li>盒模型</li>
+            </ol>
+          </li>
+          <li>JavaScript
+            <ol>
+              <li>变量</li>
+              <li>函数</li>
+              <li>DOM 操作</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+      <div class="code-block">/* 使用 counters() 处理嵌套计数器 */
+ol { counter-reset: section; }
+li { counter-increment: section; }
+li::before {
+  content: counters(section, ".") " ";
+}</div>
+      <p class="desc">使用 counters() 函数自动处理多层嵌套的编号，格式为 "1.1"、"1.2.1" 等</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-content/content-file-type.html
+++ b/examples/css/demos/css-content/content-file-type.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>content 属性 - 文件类型标识</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0d1117; color: #c9d1d9;
+      min-height: 100vh; padding: 24px;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 22px; color: #f0f6fc; margin-bottom: 20px; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 16px; }
+    h2 { font-size: 15px; color: #f0f6fc; margin-bottom: 14px; }
+    .demo-box { padding: 16px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; }
+    .file-list { list-style: none; }
+    .file-list li { padding: 10px 0; border-bottom: 1px solid #21262d; }
+    .file-list li:last-child { border-bottom: none; }
+    .file-list a { color: #58a6ff; text-decoration: none; font-size: 15px; }
+    .file-list a:hover { text-decoration: underline; }
+    a[href$=".pdf"]::after { content: ""; display: inline-block; width: 16px; height: 16px; background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23f85149'%3E%3Cpath d='M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm-1 7V3.5L18.5 9H13z'/%3E%3C/svg%3E") no-repeat center; background-size: contain; margin-left: 6px; vertical-align: middle; }
+    a[href$=".docx"]::after, a[href$=".doc"]::after { content: ""; display: inline-block; width: 16px; height: 16px; background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%2358a6ff'%3E%3Cpath d='M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm-1 7V3.5L18.5 9H13z'/%3E%3C/svg%3E") no-repeat center; background-size: contain; margin-left: 6px; vertical-align: middle; }
+    a[href$=".zip"]::after, a[href$=".rar"]::after { content: ""; display: inline-block; width: 16px; height: 16px; background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%233fb950'%3E%3Cpath d='M20 6h-8l-2-2H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-2 6h-2v2h2v2h-2v2h-2v-2h2v-2h-2v-2h2v-2h-2V8h2v2h2v2z'/%3E%3C/svg%3E") no-repeat center; background-size: contain; margin-left: 6px; vertical-align: middle; }
+    a[href$=".mp4"]::after, a[href$=".mov"]::after { content: ""; display: inline-block; width: 16px; height: 16px; background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23a371f7'%3E%3Cpath d='M17 10.5V7c0-.55-.45-1-1-1H4c-.55 0-1 .45-1 1v10c0 .55.45 1 1 1h12c.55 0 1-.45 1-1v-3.5l4 4v-11l-4 4z'/%3E%3C/svg%3E") no-repeat center; background-size: contain; margin-left: 6px; vertical-align: middle; }
+    .download-section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; }
+    .download-header { padding: 12px 16px; border-bottom: 1px solid #30363d; font-size: 14px; color: #f0f6fc; font-weight: bold; }
+    .download-list { list-style: none; }
+    .download-list li { padding: 12px 16px; border-bottom: 1px solid #21262d; display: flex; justify-content: space-between; align-items: center; }
+    .download-list li:last-child { border-bottom: none; }
+    .download-list .file-name { color: #c9d1d9; }
+    .download-list a { color: #58a6ff; text-decoration: none; }
+    .file-meta { font-size: 12px; color: #8b949e; margin-top: 2px; }
+    .file-meta::before { content: attr(data-size) " · "; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; white-space: pre-wrap; }
+    .desc { font-size: 13px; color: #8b949e; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>content 属性 - 文件类型标识</h1>
+
+    <div class="section">
+      <h2>按文件类型显示图标</h2>
+      <div class="demo-box">
+        <ul class="file-list">
+          <li><a href="report.pdf">年度财务报告.pdf</a></li>
+          <li><a href="proposal.docx">项目提案.docx</a></li>
+          <li><a href="assets.zip">设计资源包.zip</a></li>
+          <li><a href="demo.mp4">产品演示视频.mp4</a></li>
+          <li><a href="archive.rar">旧文件备份.rar</a></li>
+        </ul>
+      </div>
+      <div class="code-block">a[href$=".pdf"]::after {
+  content: url("pdf-icon.svg");
+}
+a[href$=".docx"]::after {
+  content: url("doc-icon.svg");
+}
+a[href$=".zip"]::after {
+  content: url("zip-icon.svg");
+}</div>
+      <p class="desc">通过属性选择器 [href$=".pdf"] 匹配特定扩展名，添加对应文件类型的图标</p>
+    </div>
+
+    <div class="section">
+      <h2>资源下载列表</h2>
+      <div class="demo-box">
+        <div class="download-section">
+          <div class="download-header">📦 资源下载</div>
+          <ul class="download-list">
+            <li>
+              <div>
+                <a href="guide.pdf">使用指南.pdf</a>
+                <div class="file-meta" data-size="2.4 MB"></div>
+              </div>
+              <a href="guide.pdf" style="font-size:13px; color:#58a6ff;">下载</a>
+            </li>
+            <li>
+              <div>
+                <a href="template.zip">文档模板.zip</a>
+                <div class="file-meta" data-size="15.8 MB"></div>
+              </div>
+              <a href="template.zip" style="font-size:13px; color:#58a6ff;">下载</a>
+            </li>
+            <li>
+              <div>
+                <a href="video.mp4">功能介绍视频.mp4</a>
+                <div class="file-meta" data-size="128.5 MB"></div>
+              </div>
+              <a href="video.mp4" style="font-size:13px; color:#58a6ff;">下载</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+      <div class="code-block">.file-meta::before {
+  content: attr(data-size) " · ";
+}</div>
+      <p class="desc">结合 attr() 读取 data-size 属性显示文件大小</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-content/content-icon-inject.html
+++ b/examples/css/demos/css-content/content-icon-inject.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>content 属性 - 图标注入</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0d1117; color: #c9d1d9;
+      min-height: 100vh; padding: 24px;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 22px; color: #f0f6fc; margin-bottom: 20px; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 16px; }
+    h2 { font-size: 15px; color: #f0f6fc; margin-bottom: 14px; }
+    .demo-box { padding: 16px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; }
+    .nav-menu { list-style: none; }
+    .nav-menu li { padding: 10px 0; border-bottom: 1px solid #21262d; }
+    .nav-menu li:last-child { border-bottom: none; }
+    .nav-menu a { color: #c9d1d9; text-decoration: none; display: flex; align-items: center; gap: 8px; }
+    .icon-home::before { content: ""; display: inline-block; width: 16px; height: 16px; background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%2358a6ff'%3E%3Cpath d='M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z'/%3E%3C/svg%3E") no-repeat center; background-size: contain; flex-shrink: 0; }
+    .icon-settings::before { content: ""; display: inline-block; width: 16px; height: 16px; background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%238b949e'%3E%3Cpath d='M19.14 12.94c.04-.31.06-.63.06-.94 0-.31-.02-.63-.06-.94l2.03-1.58a.49.49 0 0 0 .12-.61l-1.92-3.32a.49.49 0 0 0-.59-.22l-2.39.96c-.5-.38-1.03-.7-1.62-.94l-.36-2.54a.484.484 0 0 0-.48-.41h-3.84c-.24 0-.43.17-.47.41l-.36 2.54c-.59.24-1.13.57-1.62.94l-2.39-.96a.49.49 0 0 0-.59.22L2.74 8.87c-.12.21-.08.47.12.61l2.03 1.58c-.04.31-.06.63-.06.94 0 .31.02.63.06.94l-2.03 1.58a.49.49 0 0 0-.12.61l1.92 3.32c.12.22.37.29.59.22l2.39-.96c.5.38 1.03.7 1.62.94l.36 2.54c.05.24.24.41.48.41h3.84c.24 0 .44-.17.47-.41l.36-2.54c.59-.24 1.13-.56 1.62-.94l2.39.96c.22.08.47 0 .59-.22l1.92-3.32c.12-.22.07-.47-.12-.61l-2.01-1.58zM12 15.6c-1.98 0-3.6-1.62-3.6-3.6s1.62-3.6 3.6-3.6 3.6 1.62 3.6 3.6-1.62 3.6-3.6 3.6z'/%3E%3C/svg%3E") no-repeat center; background-size: contain; flex-shrink: 0; }
+    .icon-mail::before { content: ""; display: inline-block; width: 16px; height: 16px; background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%238b949e'%3E%3Cpath d='M20 4H4c-1.1 0-1.99.9-1.99 2L2 18c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 4l-8 5-8-5V6l8 5 8-5v2z'/%3E%3C/svg%3E") no-repeat center; background-size: contain; flex-shrink: 0; }
+    .icon-user::before { content: ""; display: inline-block; width: 16px; height: 16px; background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%238b949e'%3E%3Cpath d='M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z'/%E%3C/svg%3E") no-repeat center; background-size: contain; flex-shrink: 0; }
+    .feature-list { list-style: none; }
+    .feature-list li { padding: 8px 0; color: #c9d1d9; }
+    .feature-list li::before { content: "✓"; color: #3fb950; margin-right: 8px; font-weight: bold; }
+    .feature-list.new li::before { content: "✦"; color: #58a6ff; }
+    .feature-list.beta li::before { content: "β"; color: #a371f7; background: #a371f722; padding: 0 4px; border-radius: 3px; font-size: 11px; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; white-space: pre-wrap; }
+    .desc { font-size: 13px; color: #8b949e; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>content 属性 - 图标注入</h1>
+
+    <div class="section">
+      <h2>导航菜单图标</h2>
+      <div class="demo-box">
+        <ul class="nav-menu">
+          <li><a href="#" class="icon-home">首页</a></li>
+          <li><a href="#" class="icon-settings">设置</a></li>
+          <li><a href="#" class="icon-mail">消息</a></li>
+          <li><a href="#" class="icon-user">个人中心</a></li>
+        </ul>
+      </div>
+      <div class="code-block">.icon-home::before {
+  content: url("data:image/svg+xml,%3Csvg ... %3E%3C/svg%3E");
+  display: inline-block;
+  width: 16px; height: 16px;
+  background-size: contain;
+  margin-right: 8px;
+}</div>
+      <p class="desc">使用 SVG Data URI 注入图标，无需任何外部资源</p>
+    </div>
+
+    <div class="section">
+      <h2>功能列表标记</h2>
+      <div class="demo-box">
+        <h3 style="color:#f0f6fc; font-size:14px; margin-bottom:8px;">已上线功能</h3>
+        <ul class="feature-list">
+          <li>用户注册和登录</li>
+          <li>数据可视化图表</li>
+          <li>团队协作功能</li>
+        </ul>
+      </div>
+      <div class="code-block">.feature-list li::before {
+  content: "✓";
+  color: #3fb950;
+  margin-right: 8px;
+}</div>
+      <p class="desc">通过 ::before 伪元素添加列表项图标</p>
+    </div>
+
+    <div class="section">
+      <h2>不同状态的列表标记</h2>
+      <div class="demo-box">
+        <h3 style="color:#f0f6fc; font-size:14px; margin-bottom:8px;">新功能</h3>
+        <ul class="feature-list new">
+          <li>AI 智能推荐</li>
+          <li>多语言支持</li>
+        </ul>
+        <h3 style="color:#f0f6fc; font-size:14px; margin:16px 0 8px;">Beta 功能</h3>
+        <ul class="feature-list beta">
+          <li>实时协作编辑</li>
+          <li>API Webhooks</li>
+        </ul>
+      </div>
+      <div class="code-block">.feature-list.new li::before {
+  content: "✦";
+  color: #58a6ff;
+}
+.feature-list.beta li::before {
+  content: "β";
+  color: #a371f7;
+  background: #a371f722;
+  padding: 0 4px;
+  border-radius: 3px;
+  font-size: 11px;
+}</div>
+      <p class="desc">使用不同图标区分功能状态</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-content/content-image.html
+++ b/examples/css/demos/css-content/content-image.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>content 属性 - 图片内容</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0d1117; color: #c9d1d9;
+      min-height: 100vh; padding: 24px;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 22px; color: #f0f6fc; margin-bottom: 20px; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 16px; }
+    h2 { font-size: 15px; color: #f0f6fc; margin-bottom: 14px; }
+    .demo-box { padding: 16px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; display: flex; flex-direction: column; gap: 16px; }
+    .location { font-size: 16px; padding: 10px 0; }
+    .location-geo::before { content: ""; display: inline-block; width: 16px; height: 16px; background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='%23f85149'%3E%3Cpath d='M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z'/%3E%3C/svg%3E") no-repeat center; background-size: contain; margin-right: 8px; vertical-align: middle; }
+    .star { font-size: 18px; }
+    .star-highlight::before { content: "★"; color: #f0883e; margin-right: 4px; }
+    .star-highlight { color: #f0f6fc; }
+    .img-text { border: 1px dashed #30363d; padding: 12px; border-radius: 4px; }
+    .img-text-geo::before { content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' viewBox='0 0 24 24' fill='%2358a6ff'%3E%3Cpath d='M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7z'/%3E%3C/svg%3E"); margin-right: 8px; vertical-align: middle; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; white-space: pre-wrap; }
+    .desc { font-size: 13px; color: #8b949e; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>content 属性 - 图片内容</h1>
+
+    <div class="section">
+      <h2>使用 SVG Data URI 插入图标</h2>
+      <div class="demo-box">
+        <p class="location location-geo">北京市朝阳区</p>
+        <p class="star star-highlight">精选推荐</p>
+      </div>
+      <div class="code-block">.location-geo::before {
+  content: url("data:image/svg+xml,...");
+  margin-right: 8px;
+}</div>
+      <p class="desc">通过 Data URI 嵌入 SVG 图片，无需外部文件</p>
+    </div>
+
+    <div class="section">
+      <h2>图片与文本组合</h2>
+      <div class="demo-box">
+        <div class="img-text img-text-geo">当前位置：北京市朝阳区</div>
+      </div>
+      <div class="code-block">.img-text-geo::before {
+  content: url("data:image/svg+xml,...") "当前位置：";
+}</div>
+      <p class="desc">可以同时插入图片和文本内容</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-content/content-quotes.html
+++ b/examples/css/demos/css-content/content-quotes.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>content 属性 - 引号处理</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0d1117; color: #c9d1d9;
+      min-height: 100vh; padding: 24px;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 22px; color: #f0f6fc; margin-bottom: 20px; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 16px; }
+    h2 { font-size: 15px; color: #f0f6fc; margin-bottom: 14px; }
+    .demo-box { padding: 16px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; }
+    blockquote { padding: 12px 16px; border-left: 3px solid #30363d; background: #161b22; margin: 8px 0; }
+    blockquote p { margin: 8px 0; }
+    blockquote.auto-quote { quotes: "«" "»" "‹" "›"; }
+    blockquote.auto-quote::before { content: open-quote; color: #58a6ff; }
+    blockquote.auto-quote::after { content: close-quote; color: #58a6ff; }
+    blockquote.auto-quote q { quotes: "‹" "›"; }
+    blockquote.auto-quote q::before { content: open-quote; color: #8b949e; }
+    blockquote.auto-quote q::after { content: close-quote; color: #8b949e; }
+    blockquote.fr { quotes: "«" "»" "‹" "›"; }
+    blockquote.fr::before { content: open-quote; color: #58a6ff; }
+    blockquote.fr::after { content: close-quote; color: #58a6ff; }
+    blockquote.de { quotes: "„" """ "'" "'"; }
+    blockquote.de::before { content: open-quote; color: #58a6ff; }
+    blockquote.de::after { content: close-quote; color: #58a6ff; }
+    blockquote.en { quotes: """ """ "'" "'"; }
+    blockquote.en::before { content: open-quote; color: #58a6ff; }
+    blockquote.en::after { content: close-quote; color: #58a6ff; }
+    .lang-tag { font-size: 11px; background: #21262d; color: #8b949e; padding: 2px 6px; border-radius: 3px; margin-bottom: 8px; display: inline-block; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; white-space: pre-wrap; }
+    .desc { font-size: 13px; color: #8b949e; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>content 属性 - 引号处理</h1>
+
+    <div class="section">
+      <h2>自动引号嵌套</h2>
+      <div class="demo-box">
+        <blockquote class="auto-quote">
+          <p>妈妈总是说，<q>生活就像一盒巧克力，你永远不知道下一颗是什么。</q></p>
+        </blockquote>
+      </div>
+      <div class="code-block">blockquote { quotes: "«" "»" "‹" "›"; }
+blockquote::before { content: open-quote; }
+blockquote::after { content: close-quote; }
+q { quotes: "‹" "›"; }
+q::before { content: open-quote; }
+q::after { content: close-quote; }</div>
+      <p class="desc">通过 open-quote/close-quote 自动在 blockquote 周围添加外层引号，内部 q 元素自动使用内层引号</p>
+    </div>
+
+    <div class="section">
+      <h2>不同语言的引号风格</h2>
+      <div class="demo-box">
+        <span class="lang-tag">法语</span>
+        <blockquote class="fr">
+          <p>Maman disait toujours, <q>la vie, c'est comme une boîte de chocolats.</q></p>
+        </blockquote>
+
+        <span class="lang-tag">德语</span>
+        <blockquote class="de">
+          <p>Mama hat immer gesagt, <q>Das Leben ist wie eine Schachtel Pralinen.</q></p>
+        </blockquote>
+
+        <span class="lang-tag">英语</span>
+        <blockquote class="en">
+          <p>My mama always said, <q>Life was like a box of chocolates.</q></p>
+        </blockquote>
+      </div>
+      <div class="code-block">/* 法语引号 */
+blockquote[lang="fr"] { quotes: "«" "»" "‹" "›"; }
+/* 德语引号 */
+blockquote[lang="de"] { quotes: "„" """ "'" "'"; }
+/* 英语引号 */
+blockquote[lang="en"] { quotes: """ """ "'" "'"; }</div>
+      <p class="desc">不同语言有不同的引号习惯，可以通过 lang 属性或类名区分</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-content/content-required.html
+++ b/examples/css/demos/css-content/content-required.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>content 属性 - 表单必填标记</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0d1117; color: #c9d1d9;
+      min-height: 100vh; padding: 24px;
+    }
+    .container { max-width: 600px; margin: 0 auto; }
+    h1 { font-size: 22px; color: #f0f6fc; margin-bottom: 20px; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 16px; }
+    .form-group { margin-bottom: 16px; }
+    label { display: block; margin-bottom: 6px; font-size: 14px; color: #f0f6fc; }
+    label .required::after { content: " *"; color: #f85149; font-weight: bold; }
+    input[type="text"], input[type="email"], input[type="tel"], textarea, select { width: 100%; padding: 10px 12px; background: #0d1117; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 14px; }
+    input:focus, textarea:focus, select:focus { outline: none; border-color: #58a6ff; }
+    .form-hint { font-size: 12px; color: #8b949e; margin-top: 4px; }
+    .form-hint::before { content: "💡 "; }
+    .submit-btn { width: 100%; padding: 12px; background: #238636; color: white; border: none; border-radius: 4px; font-size: 14px; cursor: pointer; }
+    .submit-btn:hover { background: #2ea043; }
+    .form-group.has-error input { border-color: #f85149; }
+    .form-group.has-error label::after { content: " (必填)"; color: #f85149; font-size: 12px; }
+    .error-msg { font-size: 12px; color: #f85149; margin-top: 4px; }
+    .error-msg::before { content: "⚠️ "; }
+    .counter-hint { display: flex; justify-content: space-between; font-size: 12px; color: #8b949e; margin-top: 4px; }
+    .char-count::after { content: " / 200"; color: #484f58; }
+    .char-count.warn::after { content: " / 200"; color: #f0883e; }
+    .char-count.over::after { content: " / 200"; color: #f85149; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; white-space: pre-wrap; margin-top: 12px; }
+    .desc { font-size: 13px; color: #8b949e; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>content 属性 - 表单必填标记</h1>
+
+    <div class="section">
+      <form>
+        <div class="form-group">
+          <label class="required">用户名</label>
+          <input type="text" placeholder="请输入用户名">
+          <div class="form-hint">3-20个字符，支持字母、数字、下划线</div>
+        </div>
+
+        <div class="form-group">
+          <label class="required">邮箱</label>
+          <input type="email" placeholder="example@domain.com">
+        </div>
+
+        <div class="form-group">
+          <label>个人网站</label>
+          <input type="text" placeholder="https://your-site.com">
+          <div class="form-hint">选填，以 http:// 或 https:// 开头</div>
+        </div>
+
+        <div class="form-group">
+          <label class="required">个人简介</label>
+          <textarea rows="3" placeholder="请介绍一下你自己..."></textarea>
+          <div class="counter-hint">
+            <span>选填</span>
+            <span class="char-count">0</span>
+          </div>
+        </div>
+
+        <button type="submit" class="submit-btn">注册</button>
+      </form>
+    </div>
+
+    <div class="code-block">label.required::after {
+  content: " *";
+  color: #f85149;
+  font-weight: bold;
+}</div>
+    <p class="desc">使用 ::after 伪元素自动为必填字段添加 * 标记，无需在 HTML 中手动添加</p>
+
+    <div class="section">
+      <h2 style="font-size:15px; color:#f0f6fc; margin-bottom:14px;">带错误状态的表单</h2>
+      <form>
+        <div class="form-group has-error">
+          <label>邮箱</label>
+          <input type="email" value="invalid-email" style="border-color:#f85149;">
+          <div class="error-msg">请输入有效的邮箱地址</div>
+        </div>
+        <button type="submit" class="submit-btn">提交</button>
+      </form>
+    </div>
+
+    <div class="code-block">.form-group.has-error label::after {
+  content: " (必填)";
+  color: #f85149;
+  font-size: 12px;
+}
+.error-msg::before {
+  content: "⚠️ ";
+}</div>
+    <p class="desc">结合错误状态类，通过 content 属性添加错误提示图标</p>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-content/content-text.html
+++ b/examples/css/demos/css-content/content-text.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>content 属性 - 文本内容</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: #0d1117; color: #c9d1d9;
+      min-height: 100vh; padding: 24px;
+    }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { font-size: 22px; color: #f0f6fc; margin-bottom: 20px; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 16px; }
+    h2 { font-size: 15px; color: #f0f6fc; margin-bottom: 14px; }
+    .demo-box { padding: 16px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; }
+    .required::after { content: " *"; color: #f85149; }
+    .badge::before { content: "NEW "; background: #238636; color: white; padding: 2px 6px; border-radius: 3px; margin-right: 6px; font-size: 12px; }
+    .badge { display: inline-block; }
+    .arrow-link::after { content: " →"; color: #58a6ff; }
+    .arrow-link { color: #58a6ff; text-decoration: none; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; white-space: pre-wrap; }
+    .desc { font-size: 13px; color: #8b949e; margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>content 属性 - 文本内容</h1>
+
+    <div class="section">
+      <h2>必填标记</h2>
+      <div class="demo-box">
+        <p class="required">用户名</p>
+        <input type="text" placeholder="请输入用户名" style="margin-top:8px; padding:6px; background:#0d1117; border:1px solid #30363d; color:#c9d1d9; border-radius:4px;">
+      </div>
+      <div class="code-block">.required::after { content: " *"; color: red; }</div>
+      <p class="desc">使用 ::after 伪元素在必填字段后添加 * 标记</p>
+    </div>
+
+    <div class="section">
+      <h2>徽章标签</h2>
+      <div class="demo-box">
+        <span class="badge">新功能发布</span>
+      </div>
+      <div class="code-block">.badge::before { content: "NEW "; background: #238636; color: white; padding: 2px 6px; border-radius: 3px; margin-right: 6px; font-size: 12px; }</div>
+      <p class="desc">使用 ::before 伪元素在内容前添加彩色徽章</p>
+    </div>
+
+    <div class="section">
+      <h2>链接箭头</h2>
+      <div class="demo-box">
+        <a href="#" class="arrow-link">查看详情</a>
+      </div>
+      <div class="code-block">.arrow-link::after { content: " →"; color: #58a6ff; }</div>
+      <p class="desc">在链接文字后添加箭头符号</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/align-content.html
+++ b/examples/css/demos/flexbox-deep/align-content.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox align-content 示例</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { background: #21262d; border-radius: 6px; padding: 16px; margin-bottom: 12px; min-height: 200px; display: flex; flex-wrap: wrap; gap: 8px; width: 100%; }
+    .demo-item { width: 80px; height: 60px; background: linear-gradient(135deg, #58a6ff, #1f6feb); border-radius: 6px; display: flex; align-items: center; justify-content: center; font-weight: 600; color: white; font-size: 13px; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .control-btn { padding: 6px 14px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .control-btn:hover { background: #30363d; }
+    .control-btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; line-height: 1.6; }
+    .warning { border-left: 3px solid #d29922; padding-left: 12px; }
+    .comparison { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 16px; }
+    .compare-box { background: #21262d; border-radius: 6px; padding: 12px; }
+    .compare-box h4 { font-size: 13px; color: #f0f6fc; margin-bottom: 8px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>align-content 多行对齐</h1>
+
+    <div class="section">
+      <h2>align-content 六种模式（需多行）</h2>
+      <div class="controls">
+        <button class="control-btn" data-ac="stretch">stretch</button>
+        <button class="control-btn" data-ac="flex-start">flex-start</button>
+        <button class="control-btn active" data-ac="center">center</button>
+        <button class="control-btn" data-ac="flex-end">flex-end</button>
+        <button class="control-btn" data-ac="space-between">space-between</button>
+        <button class="control-btn" data-ac="space-around">space-around</button>
+      </div>
+      <div class="demo-area" id="demo" style="align-content: center;">
+        <div class="demo-item">1</div><div class="demo-item">2</div><div class="demo-item">3</div>
+        <div class="demo-item">4</div><div class="demo-item">5</div><div class="demo-item">6</div>
+        <div class="demo-item">7</div><div class="demo-item">8</div><div class="demo-item">9</div>
+        <div class="demo-item">10</div><div class="demo-item">11</div><div class="demo-item">12</div>
+      </div>
+      <div class="code-block">align-content: center;</div>
+      <div class="info warning">前提条件：必须同时满足：<br>1. flex-wrap: wrap（多行模式）<br>2. items 总宽度超过容器宽度，触发换行</div>
+    </div>
+
+    <div class="section">
+      <h2>align-content vs align-items</h2>
+      <div class="comparison">
+        <div class="compare-box">
+          <h4>align-items: center（单行有效）</h4>
+          <div style="background:#0d1117;border-radius:6px;padding:12px;display:flex;flex-wrap:wrap;align-items:center;width:300px;gap:8px;">
+            <div style="width:80px;height:60px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">1</div>
+            <div style="width:80px;height:60px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">2</div>
+            <div style="width:80px;height:60px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">3</div>
+            <div style="width:80px;height:60px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">4</div>
+            <div style="width:80px;height:60px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">5</div>
+          </div>
+          <div class="info" style="margin-top:8px;font-size:11px;">items 在各自行内居中，但各行之间无间距控制</div>
+        </div>
+        <div class="compare-box">
+          <h4>align-content: center（多行有效）</h4>
+          <div style="background:#0d1117;border-radius:6px;padding:12px;display:flex;flex-wrap:wrap;align-content:center;width:300px;gap:8px;">
+            <div style="width:80px;height:60px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">1</div>
+            <div style="width:80px;height:60px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">2</div>
+            <div style="width:80px;height:60px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">3</div>
+            <div style="width:80px;height:60px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">4</div>
+            <div style="width:80px;height:60px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">5</div>
+            <div style="width:80px;height:60px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">6</div>
+            <div style="width:80px;height:60px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">7</div>
+            <div style="width:80px;height:60px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">8</div>
+          </div>
+          <div class="info" style="margin-top:8px;font-size:11px;">所有行作为一个整体在交叉轴上居中</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.control-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.control-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const ac = btn.dataset.ac;
+        document.getElementById('demo').style.alignContent = ac;
+        document.querySelector('.code-block').textContent = 'align-content: ' + ac + ';';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/align-items.html
+++ b/examples/css/demos/flexbox-deep/align-items.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox align-items 示例</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { background: #21262d; border-radius: 6px; padding: 16px; margin-bottom: 12px; min-height: 160px; display: flex; gap: 8px; width: 100%; }
+    .demo-item { width: 60px; background: linear-gradient(135deg, #58a6ff, #1f6feb); border-radius: 6px; display: flex; align-items: center; justify-content: center; font-weight: 600; color: white; font-size: 13px; }
+    .demo-item.tall { height: 100px; }
+    .demo-item.medium { height: 70px; }
+    .demo-item.short { height: 50px; }
+    .demo-item.baseline { padding: 10px 0; font-size: 24px; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .control-btn { padding: 6px 14px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .control-btn:hover { background: #30363d; }
+    .control-btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; line-height: 1.6; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>align-items 交叉轴对齐（单行）</h1>
+
+    <div class="section">
+      <h2>align-items 五种模式</h2>
+      <div class="controls">
+        <button class="control-btn" data-ai="stretch">stretch</button>
+        <button class="control-btn" data-ai="flex-start">flex-start</button>
+        <button class="control-btn active" data-ai="center">center</button>
+        <button class="control-btn" data-ai="flex-end">flex-end</button>
+        <button class="control-btn" data-ai="baseline">baseline</button>
+      </div>
+      <div class="demo-area" id="demo" style="align-items: center;">
+        <div class="demo-item tall">高</div>
+        <div class="demo-item medium">中</div>
+        <div class="demo-item short">矮</div>
+        <div class="demo-item tall">高</div>
+      </div>
+      <div class="code-block">align-items: center;</div>
+      <div class="info">align-items 控制所有 items 在交叉轴上的对齐方式（单行有效）<br>stretch：拉伸至填满容器（默认）<br>flex-start：靠交叉轴起点对齐<br>center：居中对齐<br>flex-end：靠交叉轴终点对齐<br>baseline：按文字 baseline 对齐</div>
+    </div>
+
+    <div class="section">
+      <h2>baseline 对齐效果</h2>
+      <div class="demo-area" style="align-items: baseline;">
+        <div class="demo-item baseline" style="font-size:14px;">小字</div>
+        <div class="demo-item baseline" style="font-size:20px;">中字</div>
+        <div class="demo-item baseline" style="font-size:28px;">大字</div>
+        <div class="demo-item baseline" style="font-size:36px;">超大</div>
+      </div>
+      <div class="info">baseline 对齐：items 的文字基线在同一条水平线上</div>
+    </div>
+
+    <div class="section">
+      <h2>stretch（默认）效果</h2>
+      <div class="demo-area" style="align-items: stretch; height: 160px;">
+        <div class="demo-item" style="height:auto;">自动高度</div>
+        <div class="demo-item" style="height:auto;">自动高度</div>
+        <div class="demo-item" style="height:auto;">自动高度</div>
+      </div>
+      <div class="info">stretch 是默认值，前提是 items 没有设置明确高度且没有 max-height/min-height 限制</div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.control-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.control-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const ai = btn.dataset.ai;
+        document.getElementById('demo').style.alignItems = ai;
+        document.querySelector('.code-block').textContent = 'align-items: ' + ai + ';';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/display-flex.html
+++ b/examples/css/demos/flexbox-deep/display-flex.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox display:flex vs display:inline-flex</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; line-height: 1.6; }
+    .demo-area { background: #21262d; border-radius: 6px; padding: 16px; margin-bottom: 12px; min-height: 100px; display: flex; gap: 8px; }
+    .demo-item { width: 60px; height: 60px; background: linear-gradient(135deg, #58a6ff, #1f6feb); border-radius: 6px; display: flex; align-items: center; justify-content: center; font-weight: 600; color: white; font-size: 13px; }
+    .inline-demo { background: #21262d; border-radius: 6px; padding: 16px; margin-bottom: 12px; display: inline-flex; gap: 8px; }
+    .comparison { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .compare-box { background: #21262d; border-radius: 6px; padding: 12px; }
+    .compare-box h4 { font-size: 13px; color: #f0f6fc; margin-bottom: 8px; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>display: flex vs inline-flex</h1>
+
+    <div class="section">
+      <h2>display: flex（块级容器）</h2>
+      <div style="background:#21262d;border-radius:6px;padding:16px;margin-bottom:12px;">
+        <div class="demo-area" style="display: flex;">
+          <div class="demo-item">1</div><div class="demo-item">2</div><div class="demo-item">3</div>
+        </div>
+      </div>
+      <div class="info"><strong>display: flex</strong>：容器是块级元素，会独自占据一行</div>
+    </div>
+
+    <div class="section">
+      <h2>display: inline-flex（行内容器）</h2>
+      <div style="background:#21262d;border-radius:6px;padding:16px;margin-bottom:12px;">
+        <span style="color:#8b949e;font-size:12px;margin-right:8px;">前面文字：</span>
+        <div class="inline-demo">
+          <div class="demo-item">1</div><div class="demo-item">2</div><div class="demo-item">3</div>
+        </div>
+        <span style="color:#8b949e;font-size:12px;margin-left:8px;">：后面文字</span>
+      </div>
+      <div class="info"><strong>display: inline-flex</strong>：容器是行内元素，不会独占一行</div>
+    </div>
+
+    <div class="section">
+      <h2>对比</h2>
+      <div class="comparison">
+        <div class="compare-box">
+          <h4>display: flex</h4>
+          <div style="background:#0d1117;padding:12px;border-radius:4px;">
+            <div style="display:flex;gap:8px;margin-bottom:8px;">
+              <div style="width:60px;height:40px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">flex</div>
+              <div style="width:60px;height:40px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">flex</div>
+            </div>
+            <div style="width:60px;height:40px;background:#30363d;border-radius:4px;display:flex;align-items:center;justify-content:center;color:#8b949e;font-size:11px;">block</div>
+          </div>
+          <div class="code-block">display: flex;</div>
+          <div class="info" style="margin-top:8px;font-size:11px;">独占一行，后续元素换行</div>
+        </div>
+        <div class="compare-box">
+          <h4>display: inline-flex</h4>
+          <div style="background:#0d1117;padding:12px;border-radius:4px;display:flex;gap:8px;align-items:flex-start;">
+            <div style="display:inline-flex;gap:8px;">
+              <div style="width:60px;height:40px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">inline</div>
+              <div style="width:60px;height:40px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">inline</div>
+            </div>
+            <div style="width:60px;height:40px;background:#30363d;border-radius:4px;display:flex;align-items:center;justify-content:center;color:#8b949e;font-size:11px;">inline</div>
+          </div>
+          <div class="code-block">display: inline-flex;</div>
+          <div class="info" style="margin-top:8px;font-size:11px;">不独占一行，后续元素并排</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/flex-basis.html
+++ b/examples/css/demos/flexbox-deep/flex-basis.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox flex-basis 示例</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { background: #21262d; border-radius: 6px; padding: 16px; margin-bottom: 12px; min-height: 100px; display: flex; gap: 8px; width: 100%; }
+    .demo-item { background: linear-gradient(135deg, #58a6ff, #1f6feb); border-radius: 6px; display: flex; align-items: center; justify-content: center; font-weight: 600; color: white; font-size: 12px; min-height: 60px; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .control-btn { padding: 6px 14px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .control-btn:hover { background: #30363d; }
+    .control-btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; line-height: 1.6; }
+    .warning { border-left: 3px solid #f78166; padding-left: 12px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>flex-basis 初始尺寸</h1>
+
+    <div class="section">
+      <h2>flex-basis vs width 优先级</h2>
+      <div class="controls">
+        <button class="control-btn active" data-mode="basis">flex-basis 生效</button>
+        <button class="control-btn" data-mode="width">width 生效</button>
+        <button class="control-btn" data-mode="content">内容尺寸</button>
+      </div>
+      <div class="demo-area" style="flex-direction: column;" id="demo">
+        <div class="demo-item" id="item1" style="flex-basis:200px;width:100px;">item</div>
+      </div>
+      <div class="code-block" id="codeBlock">flex-basis: 200px; width: 100px; /* 结果: 200px */</div>
+      <div class="info warning" style="margin-top:8px;">
+        <strong>优先级：</strong>max/min > flex-basis > width/height > 内容尺寸
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>flex-basis: auto vs 0</h2>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:12px;">
+        <div>
+          <h4 style="font-size:13px;color:#f0f6fc;margin-bottom:8px;">flex-basis: auto（默认）</h4>
+          <div style="background:#0d1117;border-radius:6px;padding:12px;display:flex;gap:8px;">
+            <div style="flex:1 1 auto;min-width:60px;height:60px;background:linear-gradient(135deg,#58a6ff,#1f6feb);border-radius:6px;display:flex;align-items:center;justify-content:center;color:white;font-size:11px;font-weight:600;">auto</div>
+            <div style="flex:1 1 auto;min-width:60px;height:60px;background:linear-gradient(135deg,#58a6ff,#1f6feb);border-radius:6px;display:flex;align-items:center;justify-content:center;color:white;font-size:11px;font-weight:600;">自适应内容</div>
+            <div style="flex:1 1 auto;min-width:60px;height:60px;background:linear-gradient(135deg,#58a6ff,#1f6feb);border-radius:6px;display:flex;align-items:center;justify-content:center;color:white;font-size:11px;font-weight:600;">auto</div>
+          </div>
+          <div class="info" style="margin-top:8px;font-size:11px;">使用 width 或内容尺寸作为基础，可正常自适应</div>
+        </div>
+        <div>
+          <h4 style="font-size:13px;color:#f0f6fc;margin-bottom:8px;">flex-basis: 0</h4>
+          <div style="background:#0d1117;border-radius:6px;padding:12px;display:flex;gap:8px;">
+            <div style="flex:1 1 0;min-width:0;height:60px;background:linear-gradient(135deg,#3fb950,#238636);border-radius:6px;display:flex;align-items:center;justify-content:center;color:white;font-size:11px;font-weight:600;">0</div>
+            <div style="flex:1 1 0;min-width:0;height:60px;background:linear-gradient(135deg,#3fb950,#238636);border-radius:6px;display:flex;align-items:center;justify-content:center;color:white;font-size:11px;font-weight:600;">内容</div>
+            <div style="flex:1 1 0;min-width:0;height:60px;background:linear-gradient(135deg,#3fb950,#238636);border-radius:6px;display:flex;align-items:center;justify-content:center;color:white;font-size:11px;font-weight:600;">0</div>
+          </div>
+          <div class="info" style="margin-top:8px;font-size:11px;">初始尺寸为 0，内容被压缩再分配！</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>常见用法</h2>
+      <div class="info">
+        flex: 0 0 200px; -> 固定 200px，不伸缩<br><br>
+        flex: 1 1 auto; -> 可伸缩，使用 width/内容<br><br>
+        flex: 1; -> 可伸缩，初始 0（常被误用！）<br><br>
+        flex: none; -> 完全不伸缩 (0 0 auto)
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const modes = {
+      basis: { css: 'flex-basis: 200px; width: 100px;', desc: 'flex-basis 200px > width 100px' },
+      width: { css: 'flex-basis: 0; width: 150px;', desc: 'flex-basis 0，但 width 生效' },
+      content: { css: 'flex-basis: auto; width: auto;', desc: '完全由内容决定尺寸' }
+    };
+
+    document.querySelectorAll('.control-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.control-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const mode = modes[btn.dataset.mode];
+        const item = document.getElementById('item1');
+        if (btn.dataset.mode === 'basis') {
+          item.style.flexBasis = '200px';
+          item.style.width = '100px';
+          item.style.minWidth = '0';
+        } else if (btn.dataset.mode === 'width') {
+          item.style.flexBasis = '0';
+          item.style.width = '150px';
+          item.style.minWidth = '0';
+        } else {
+          item.style.flexBasis = 'auto';
+          item.style.width = 'auto';
+          item.style.minWidth = '0';
+        }
+        document.getElementById('codeBlock').textContent = mode.css + ' /* ' + mode.desc + ' */';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/flex-context.html
+++ b/examples/css/demos/flexbox-deep/flex-context.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox 格式化上下文特性</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; line-height: 1.6; }
+    .warning { border-left: 3px solid #f78166; padding-left: 12px; }
+    .ok { border-left: 3px solid #3fb950; padding-left: 12px; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; }
+    .comparison { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .compare-box { background: #21262d; border-radius: 6px; padding: 12px; }
+    .compare-box h4 { font-size: 13px; color: #f0f6fc; margin-bottom: 8px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Flex 格式化上下文特性</h1>
+
+    <div class="section">
+      <h2>margin: auto 居中</h2>
+      <div class="comparison">
+        <div class="compare-box">
+          <h4>块级布局 margin:auto 不居中</h4>
+          <div style="background:#0d1117;padding:16px;border-radius:4px;text-align:center;">
+            <div style="width:100px;height:60px;background:#f78166;border-radius:4px;margin:0 auto;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">block</div>
+          </div>
+          <div class="info" style="margin-top:8px;font-size:11px;">margin: 0 auto 让块级元素居中，但不支持垂直居中</div>
+        </div>
+        <div class="compare-box">
+          <h4>Flex margin:auto 双向居中</h4>
+          <div style="background:#0d1117;padding:16px;border-radius:4px;display:flex;height:80px;">
+            <div style="margin:auto;width:100px;height:60px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">flex item</div>
+          </div>
+          <div class="info" style="margin-top:8px;font-size:11px;">flex item 上 margin: auto 会同时在主轴和交叉轴方向居中</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>float 对 flex item 无效</h2>
+      <div style="background:#0d1117;padding:16px;border-radius:4px;display:flex;gap:8px;margin-bottom:12px;">
+        <div style="float:left;width:60px;height:60px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;font-weight:600;">float:left</div>
+        <div style="float:left;width:60px;height:60px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;font-weight:600;">float:left</div>
+        <div style="width:60px;height:60px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;font-weight:600;">flex item</div>
+      </div>
+      <div class="info warning">float 对 flex item 无效！flex item 会无视 float 属性，按 flex 规则排列</div>
+    </div>
+
+    <div class="section">
+      <h2>vertical-align 对 flex item 无效</h2>
+      <div style="background:#0d1117;padding:16px;border-radius:4px;display:flex;align-items:flex-end;gap:8px;height:80px;margin-bottom:12px;">
+        <div style="vertical-align:bottom;width:60px;height:60px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;font-weight:600;">v-align</div>
+        <div style="width:60px;height:40px;background:#d29922;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;font-weight:600;">normal</div>
+      </div>
+      <div class="info warning">vertical-align 对 flex item 无效！改用 align-items 控制垂直对齐</div>
+    </div>
+
+    <div class="section">
+      <h2>Flex item 变成块级容器</h2>
+      <div style="background:#0d1117;padding:16px;border-radius:4px;display:flex;gap:8px;margin-bottom:12px;">
+        <div style="width:80px;height:80px;background:#58a6ff;border-radius:4px;display:flex;flex-direction:column;align-items:center;justify-content:center;color:white;font-size:11px;font-weight:600;gap:4px;">
+          <div style="width:30px;height:30px;background:#fff;border-radius:4px;"></div>
+          <span>子flex</span>
+        </div>
+      </div>
+      <div class="info ok">flex item 会变成块级容器，可以嵌套 flex 布局（column-* 属性不生效）</div>
+    </div>
+
+    <div class="section">
+      <h2>绝对定位子元素</h2>
+      <div style="background:#0d1117;padding:16px;border-radius:4px;display:flex;height:80px;position:relative;margin-bottom:12px;">
+        <div style="width:80px;height:60px;background:#58a6ff;border-radius:4px;position:relative;display:flex;align-items:center;justify-content:center;color:white;font-size:11px;font-weight:600;">
+          父 flex
+          <div style="position:absolute;bottom:-20px;right:-10px;width:40px;height:40px;background:#f78166;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:10px;font-weight:600;z-index:1;">abs</div>
+        </div>
+      </div>
+      <div class="info">flex item 的绝对定位子元素会以 flex item 为定位参照（不是 flex container）</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/flex-direction.html
+++ b/examples/css/demos/flexbox-deep/flex-direction.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox flex-direction 示例</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { display: flex; background: #21262d; border-radius: 6px; padding: 16px; margin-bottom: 12px; min-height: 120px; gap: 8px; }
+    .demo-item { width: 60px; height: 60px; background: linear-gradient(135deg, #58a6ff, #1f6feb); border-radius: 6px; display: flex; align-items: center; justify-content: center; font-weight: 600; color: white; font-size: 14px; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .control-btn { padding: 6px 14px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .control-btn:hover { background: #30363d; }
+    .control-btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>flex-direction 主轴方向</h1>
+
+    <div class="section">
+      <h2>flex-direction 四个方向</h2>
+      <div class="controls">
+        <button class="control-btn active" data-dir="row">row (默认)</button>
+        <button class="control-btn" data-dir="row-reverse">row-reverse</button>
+        <button class="control-btn" data-dir="column">column</button>
+        <button class="control-btn" data-dir="column-reverse">column-reverse</button>
+      </div>
+      <div class="demo-area" id="demo" style="flex-direction: row;">
+        <div class="demo-item">1</div>
+        <div class="demo-item">2</div>
+        <div class="demo-item">3</div>
+        <div class="demo-item">4</div>
+      </div>
+      <div class="code-block">flex-direction: row;</div>
+      <div class="info">row：主轴水平，items 从左到右排列（默认）<br>row-reverse：主轴水平，items 从右到左排列<br>column：主轴垂直，items 从上到下排列<br>column-reverse：主轴垂直，items 从下到上排列</div>
+    </div>
+
+    <div class="section">
+      <h2>主轴 vs 交叉轴</h2>
+      <div class="demo-area" style="flex-direction: row; height: 200px;">
+        <div class="demo-item" style="align-self: flex-start;">flex-start</div>
+        <div class="demo-item" style="align-self: center;">center</div>
+        <div class="demo-item" style="align-self: flex-end;">flex-end</div>
+        <div class="demo-item" style="align-self: stretch; height: auto;">stretch</div>
+      </div>
+      <div class="info">当 flex-direction: row 时：<br>主轴 = 水平方向（items 排列方向）<br>交叉轴 = 垂直方向（items 对齐方向）</div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.control-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.control-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const dir = btn.dataset.dir;
+        const demo = document.getElementById('demo');
+        demo.style.flexDirection = dir;
+        document.querySelector('.code-block').textContent = 'flex-direction: ' + dir + ';';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/flex-grow.html
+++ b/examples/css/demos/flexbox-deep/flex-grow.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox flex-grow 示例</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { background: #21262d; border-radius: 6px; padding: 16px; margin-bottom: 12px; min-height: 100px; display: flex; gap: 8px; width: 100%; }
+    .demo-item { background: linear-gradient(135deg, #58a6ff, #1f6feb); border-radius: 6px; display: flex; align-items: center; justify-content: center; font-weight: 600; color: white; font-size: 13px; min-width: 60px; height: 60px; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .control-btn { padding: 6px 14px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .control-btn:hover { background: #30363d; }
+    .control-btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; line-height: 1.6; }
+    .stats { display: flex; gap: 16px; margin-bottom: 12px; flex-wrap: wrap; }
+    .stat { background: #21262d; padding: 8px 12px; border-radius: 4px; font-size: 12px; }
+    .stat span { color: #58a6ff; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>flex-grow 放大比例</h1>
+
+    <div class="section">
+      <h2>flex-grow 比例分配</h2>
+      <div class="stats">
+        <div class="stat">容器宽度: <span id="containerWidth">600</span>px</div>
+        <div class="stat">item 基础总宽: <span id="itemWidth">180</span>px</div>
+        <div class="stat">剩余空间: <span id="remaining">420</span>px</div>
+      </div>
+      <div class="controls">
+        <button class="control-btn active" data-mode="equal">等比 (1:1:1)</button>
+        <button class="control-btn" data-mode="ratio124">比例 (1:2:4)</button>
+        <button class="control-btn" data-mode="one">只有一个 grow</button>
+        <button class="control-btn" data-mode="zero">全部为 0</button>
+      </div>
+      <div class="demo-area" id="demo">
+        <div class="demo-item" id="item1" style="flex-basis:60px;flex-grow:1;">60px</div>
+        <div class="demo-item" id="item2" style="flex-basis:60px;flex-grow:1;">60px</div>
+        <div class="demo-item" id="item3" style="flex-basis:60px;flex-grow:1;">60px</div>
+      </div>
+      <div class="code-block" id="codeBlock">flex-grow: 1 1 1;</div>
+      <div class="label" id="sizeLabel">实际宽度：~200px each</div>
+    </div>
+
+    <div class="section">
+      <h2>计算公式</h2>
+      <div class="info">
+        <strong>计算公式：</strong><br><br>
+        实际宽度 = 基础尺寸 + 剩余空间 x (grow / 总grow)<br><br>
+        <strong>示例（容器 600px，三个 item 各 60px）：</strong><br>
+        剩余空间 = 600 - 60x3 = 420px<br>
+        每个 item = 60 + 420x(1/3) = 200px
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>常见场景</h2>
+      <div style="background:#0d1117;border-radius:6px;padding:16px;display:flex;gap:8px;margin-bottom:12px;">
+        <div style="flex:1;height:60px;background:linear-gradient(135deg,#58a6ff,#1f6feb);border-radius:6px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;font-weight:600;">flex: 1</div>
+        <div style="flex:0 0 120px;height:60px;background:linear-gradient(135deg,#3fb950,#238636);border-radius:6px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;font-weight:600;">fixed 120px</div>
+      </div>
+      <div class="info">flex: 1 让第一个 item 占据所有剩余空间，第二个保持固定 120px</div>
+    </div>
+  </div>
+
+  <script>
+    function updateStats() {
+      const items = document.querySelectorAll('.demo-item');
+      let totalBasis = 0;
+      items.forEach(item => {
+        const basis = parseInt(item.style.flexBasis) || 60;
+        totalBasis += basis;
+      });
+      document.getElementById('containerWidth').textContent = 600;
+      document.getElementById('itemWidth').textContent = totalBasis;
+      document.getElementById('remaining').textContent = Math.max(0, 600 - totalBasis);
+    }
+
+    const modes = {
+      equal: { grow: [1, 1, 1], basis: [60, 60, 60], label: 'flex-grow: 1 -> ~200px each', code: 'flex-grow: 1 1 1;' },
+      ratio124: { grow: [1, 2, 4], basis: [60, 60, 60], label: '比例为 1:2:4 -> 120px / 180px / 300px', code: 'item1: grow=1, item2: grow=2, item3: grow=4' },
+      one: { grow: [1, 0, 0], basis: [60, 60, 60], label: '只有第一个 grow -> 第一个 480px', code: 'item1: flex-grow: 1, item2: 0, item3: 0' },
+      zero: { grow: [0, 0, 0], basis: [60, 60, 60], label: '全部为 0 -> 保持 60px，不分配剩余空间', code: 'flex-grow: 0 (默认，不放大)' }
+    };
+
+    document.querySelectorAll('.control-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.control-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const mode = modes[btn.dataset.mode];
+        const items = document.querySelectorAll('.demo-item');
+        items.forEach((item, i) => {
+          item.style.flexBasis = mode.basis[i] + 'px';
+          item.style.flexGrow = mode.grow[i];
+          item.textContent = mode.basis[i] + 'px + 剩余';
+        });
+        document.getElementById('codeBlock').textContent = mode.code;
+        document.getElementById('sizeLabel').textContent = mode.label;
+        updateStats();
+      });
+    });
+    updateStats();
+  </script>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/flex-shorthand.html
+++ b/examples/css/demos/flexbox-deep/flex-shorthand.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox flex 简写与 align-self, order</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { background: #21262d; border-radius: 6px; padding: 16px; margin-bottom: 12px; min-height: 120px; display: flex; gap: 8px; width: 100%; }
+    .demo-item { width: 80px; background: linear-gradient(135deg, #58a6ff, #1f6feb); border-radius: 6px; display: flex; align-items: center; justify-content: center; font-weight: 600; color: white; font-size: 12px; min-height: 80px; }
+    .demo-item.green { background: linear-gradient(135deg, #3fb950, #238636); }
+    .demo-item.orange { background: linear-gradient(135deg, #d29922, #9e6a03); }
+    .demo-item.red { background: linear-gradient(135deg, #f78166, #da3633); }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; line-height: 1.6; }
+    table { width: 100%; border-collapse: collapse; margin-top: 12px; font-size: 12px; }
+    th, td { padding: 8px 12px; text-align: left; border-bottom: 1px solid #30363d; }
+    th { color: #f0f6fc; font-weight: 500; }
+    td { color: #8b949e; }
+    td code { color: #79c0ff; font-family: 'SF Mono', Monaco, monospace; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>flex 简写 &amp; align-self &amp; order</h1>
+
+    <div class="section">
+      <h2>flex 简写模式</h2>
+      <table>
+        <thead>
+          <tr><th>简写</th><th>等价值</th><th>用途</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>flex: 0 0 100px</code></td><td>grow:0, shrink:0, basis:100px</td><td>固定尺寸，完全不伸缩</td></tr>
+          <tr><td><code>flex: 1</code></td><td>grow:1, shrink:1, basis:0%</td><td>等比伸缩，初始为0</td></tr>
+          <tr><td><code>flex: auto</code></td><td>grow:1, shrink:1, basis:auto</td><td>可伸缩，使用自身尺寸</td></tr>
+          <tr><td><code>flex: none</code></td><td>grow:0, shrink:0, basis:auto</td><td>完全不伸缩</td></tr>
+          <tr><td><code>flex: 2</code></td><td>grow:2, shrink:1, basis:0%</td><td>2倍伸缩比例</td></tr>
+        </tbody>
+      </table>
+      <div class="info" style="margin-top:12px;">
+        最常见错误：input { flex: 1; } 实际上等于 flex: 1 1 0%，初始尺寸是 0！<br>
+        正确写法：input { flex: 1 1 auto; }
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>align-self 覆盖 align-items</h2>
+      <div class="demo-area" style="align-items: flex-start; height: 160px;">
+        <div class="demo-item">flex-start<br>(继承)</div>
+        <div class="demo-item green" style="align-self: center;">center<br>(覆盖)</div>
+        <div class="demo-item orange" style="align-self: flex-end;">flex-end<br>(覆盖)</div>
+        <div class="demo-item red" style="align-self: stretch; height: auto;">stretch<br>(覆盖)</div>
+      </div>
+      <div class="code-block">align-self: auto | stretch | flex-start | center | flex-end | baseline</div>
+      <div class="info">align-self 允许单个 item 覆盖容器 align-items 的设置</div>
+    </div>
+
+    <div class="section">
+      <h2>order 控制排列顺序</h2>
+      <div class="demo-area">
+        <div class="demo-item" style="order:3;">A<br>(order=3)</div>
+        <div class="demo-item green" style="order:1;">B<br>(order=1)</div>
+        <div class="demo-item orange" style="order:2;">C<br>(order=2)</div>
+        <div class="demo-item red" style="order:0;">D<br>(order=0)</div>
+      </div>
+      <div class="info">
+        order 只改变视觉顺序，不改变 DOM 顺序！<br>
+        屏幕阅读器仍按 DOM 顺序读取，对无障碍不友好。<br>
+        order 默认为 0，数值越小越靠前。
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>组合示例：Sticky Footer</h2>
+      <div style="background:#21262d;border-radius:6px;overflow:hidden;height:300px;display:flex;flex-direction:column;">
+        <div style="background:linear-gradient(135deg,#58a6ff,#1f6feb);padding:16px;color:white;font-weight:600;font-size:14px;display:flex;align-items:center;gap:8px;">Header</div>
+        <div style="background:#0d1117;flex:1;padding:16px;color:#8b949e;font-size:14px;display:flex;align-items:center;justify-content:center;">Main Content (flex: 1)</div>
+        <div style="background:linear-gradient(135deg,#3fb950,#238636);padding:16px;color:white;font-weight:600;font-size:14px;">Footer</div>
+      </div>
+      <div class="code-block">body { display: flex; flex-direction: column; min-height: 100vh; }
+main { flex: 1; }</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/flex-shrink.html
+++ b/examples/css/demos/flexbox-deep/flex-shrink.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox flex-shrink 示例</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { background: #21262d; border-radius: 6px; padding: 16px; margin-bottom: 12px; min-height: 100px; display: flex; gap: 8px; width: 400px; }
+    .demo-item { background: linear-gradient(135deg, #58a6ff, #1f6feb); border-radius: 6px; display: flex; align-items: center; justify-content: center; font-weight: 600; color: white; font-size: 12px; flex-shrink: 1; flex-grow: 0; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .control-btn { padding: 6px 14px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .control-btn:hover { background: #30363d; }
+    .control-btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; line-height: 1.6; }
+    .warning { border-left: 3px solid #f78166; padding-left: 12px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>flex-shrink 缩小比例</h1>
+
+    <div class="section">
+      <h2>flex-shrink 对比</h2>
+      <p style="font-size:13px;color:#8b949e;margin-bottom:16px;">容器宽度 400px，三个 item 各 150px -> 总宽度 450px，溢出 50px</p>
+      <div class="controls">
+        <button class="control-btn active" data-mode="equal">等比缩小 (1:1:1)</button>
+        <button class="control-btn" data-mode="diff">差异缩小 (1:2:3)</button>
+        <button class="control-btn" data-mode="zero">不允许缩小 (0:0:0)</button>
+      </div>
+      <div class="demo-area" id="demo">
+        <div class="demo-item" id="item1" style="flex-basis:150px;flex-shrink:1;">150px</div>
+        <div class="demo-item" id="item2" style="flex-basis:150px;flex-shrink:1;">150px</div>
+        <div class="demo-item" id="item3" style="flex-basis:150px;flex-shrink:1;">150px</div>
+      </div>
+      <div class="code-block" id="codeBlock">flex-shrink: 1 1 1;</div>
+      <div class="label" id="sizeLabel">每个 item 实际宽度：~133px</div>
+    </div>
+
+    <div class="section">
+      <h2>为什么不溢出？</h2>
+      <div class="info warning">
+        <strong>flex-shrink: 0 的陷阱</strong><br><br>
+        如果设置 flex-shrink: 0，items 不会缩小，会导致溢出！
+      </div>
+      <div style="background:#0d1117;border-radius:6px;padding:16px;display:flex;flex-shrink:0;gap:8px;width:400px;margin-top:12px;">
+        <div style="flex-basis:150px;flex-shrink:0;height:60px;background:linear-gradient(135deg,#f78166,#da3633);border-radius:6px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;font-weight:600;">150px</div>
+        <div style="flex-basis:150px;flex-shrink:0;height:60px;background:linear-gradient(135deg,#f78166,#da3633);border-radius:6px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;font-weight:600;">150px</div>
+        <div style="flex-basis:150px;flex-shrink:0;height:60px;background:linear-gradient(135deg,#f78166,#da3633);border-radius:6px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;font-weight:600;">150px</div>
+      </div>
+      <div class="info warning" style="margin-top:8px;">三个 150px = 450px > 400px 容器，溢出 50px！</div>
+    </div>
+
+    <div class="section">
+      <h2>缩小计算公式</h2>
+      <div class="info">
+        <strong>简化计算：</strong><br><br>
+        溢出量 x (shrink x basis) / Sum(shrink x basis)<br><br>
+        <strong>示例（容器 400px，三个 150px items）：</strong><br>
+        溢出量 = 450 - 400 = 50px<br>
+        权重和 = 1x150 + 1x150 + 1x150 = 450<br>
+        每个 item 收缩 = 50 x (1x150/450) = 16.67px<br>
+        最终宽度 = 150 - 16.67 ~ 133px
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const modes = {
+      equal: { shrink: [1, 1, 1], label: '每个 item 实际宽度：~133px', code: 'flex-shrink: 1 1 1;' },
+      diff: { shrink: [1, 2, 3], label: 'item1 ~140px, item2 ~130px, item3 ~120px', code: 'flex-shrink: 1 2 3; (item3 收缩最多)' },
+      zero: { shrink: [0, 0, 0], label: '不允许缩小 -> 溢出！', code: 'flex-shrink: 0 0 0; (不缩小)' }
+    };
+
+    document.querySelectorAll('.control-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.control-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const mode = modes[btn.dataset.mode];
+        const items = document.querySelectorAll('.demo-item');
+        items.forEach((item, i) => {
+          item.style.flexShrink = mode.shrink[i];
+        });
+        document.getElementById('codeBlock').textContent = mode.code;
+        document.getElementById('sizeLabel').textContent = mode.label;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/flex-wrap.html
+++ b/examples/css/demos/flexbox-deep/flex-wrap.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox flex-wrap 示例</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { background: #21262d; border-radius: 6px; padding: 16px; margin-bottom: 12px; min-height: 120px; display: flex; gap: 8px; }
+    .demo-item { width: 100px; height: 60px; background: linear-gradient(135deg, #58a6ff, #1f6feb); border-radius: 6px; display: flex; align-items: center; justify-content: center; font-weight: 600; color: white; font-size: 14px; flex-shrink: 1; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .control-btn { padding: 6px 14px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .control-btn:hover { background: #30363d; }
+    .control-btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .comparison { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-top: 16px; }
+    .compare-box { background: #21262d; border-radius: 6px; padding: 12px; }
+    .compare-box h4 { font-size: 13px; color: #f0f6fc; margin-bottom: 8px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>flex-wrap 换行控制</h1>
+
+    <div class="section">
+      <h2>flex-wrap 三种模式</h2>
+      <div class="controls">
+        <button class="control-btn active" data-wrap="nowrap">nowrap (默认)</button>
+        <button class="control-btn" data-wrap="wrap">wrap</button>
+        <button class="control-btn" data-wrap="wrap-reverse">wrap-reverse</button>
+      </div>
+      <div class="demo-area" id="demo" style="flex-wrap: nowrap; width: 400px;">
+        <div class="demo-item">item1</div>
+        <div class="demo-item">item2</div>
+        <div class="demo-item">item3</div>
+        <div class="demo-item">item4</div>
+        <div class="demo-item">item5</div>
+        <div class="demo-item">item6</div>
+      </div>
+      <div class="code-block">flex-wrap: nowrap;</div>
+      <div class="info">nowrap：不换行，items 会被压缩以适应单行<br>wrap：多行，换行方向与交叉轴一致<br>wrap-reverse：多行，换行方向与交叉轴相反</div>
+    </div>
+
+    <div class="section">
+      <h2>换行 vs 不换行对比</h2>
+      <div class="comparison">
+        <div class="compare-box">
+          <h4>flex-wrap: nowrap</h4>
+          <div style="background:#0d1117; border-radius:6px; padding:12px; display:flex; flex-wrap:nowrap; width:300px; gap:8px;">
+            <div style="width:80px;height:40px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;flex-shrink:1;">80px</div>
+            <div style="width:80px;height:40px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;flex-shrink:1;">80px</div>
+            <div style="width:80px;height:40px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;flex-shrink:1;">80px</div>
+            <div style="width:80px;height:40px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;flex-shrink:1;">80px</div>
+            <div style="width:80px;height:40px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;flex-shrink:1;">80px</div>
+          </div>
+          <div class="info" style="margin-top:8px;font-size:11px;">5x80px = 400px，超出容器宽度，items 被压缩</div>
+        </div>
+        <div class="compare-box">
+          <h4>flex-wrap: wrap</h4>
+          <div style="background:#0d1117; border-radius:6px; padding:12px; display:flex; flex-wrap:wrap; width:300px; gap:8px;">
+            <div style="width:80px;height:40px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">80px</div>
+            <div style="width:80px;height:40px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">80px</div>
+            <div style="width:80px;height:40px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">80px</div>
+            <div style="width:80px;height:40px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">80px</div>
+            <div style="width:80px;height:40px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">80px</div>
+          </div>
+          <div class="info" style="margin-top:8px;font-size:11px;">5x80px = 400px，第三行溢出后自动换行，保持原始尺寸</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>flex-flow 简写</h2>
+      <div class="info">flex-flow 是 flex-direction 和 flex-wrap 的简写：<br><br>flex-flow: row wrap; = flex-direction: row + flex-wrap: wrap<br>flex-flow: column nowrap; = flex-direction: column + flex-wrap: nowrap</div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.control-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.control-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const wrap = btn.dataset.wrap;
+        document.getElementById('demo').style.flexWrap = wrap;
+        document.querySelector('.code-block').textContent = 'flex-wrap: ' + wrap + ';';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/justify-content.html
+++ b/examples/css/demos/flexbox-deep/justify-content.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox justify-content 示例</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { background: #21262d; border-radius: 6px; padding: 16px; margin-bottom: 12px; min-height: 100px; display: flex; gap: 8px; width: 600px; }
+    .demo-item { width: 80px; height: 60px; background: linear-gradient(135deg, #58a6ff, #1f6feb); border-radius: 6px; display: flex; align-items: center; justify-content: center; font-weight: 600; color: white; font-size: 13px; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .control-btn { padding: 6px 14px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; white-space: nowrap; }
+    .control-btn:hover { background: #30363d; }
+    .control-btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; line-height: 1.6; }
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .grid-item { background: #21262d; border-radius: 6px; padding: 12px; }
+    .grid-item h4 { font-size: 13px; color: #f0f6fc; margin-bottom: 8px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>justify-content 主轴对齐</h1>
+
+    <div class="section">
+      <h2>justify-content 六种模式</h2>
+      <div class="controls">
+        <button class="control-btn" data-jc="flex-start">flex-start</button>
+        <button class="control-btn active" data-jc="center">center</button>
+        <button class="control-btn" data-jc="flex-end">flex-end</button>
+        <button class="control-btn" data-jc="space-between">space-between</button>
+        <button class="control-btn" data-jc="space-around">space-around</button>
+        <button class="control-btn" data-jc="space-evenly">space-evenly</button>
+      </div>
+      <div class="demo-area" id="demo" style="justify-content: center;">
+        <div class="demo-item">1</div>
+        <div class="demo-item">2</div>
+        <div class="demo-item">3</div>
+      </div>
+      <div class="code-block">justify-content: center;</div>
+    </div>
+
+    <div class="section">
+      <h2>间距对比</h2>
+      <div class="grid">
+        <div class="grid-item">
+          <h4>space-between</h4>
+          <div style="background:#0d1117;border-radius:6px;padding:12px;display:flex;justify-content:space-between;gap:0;">
+            <div style="width:60px;height:40px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">左</div>
+            <div style="width:60px;height:40px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">中</div>
+            <div style="width:60px;height:40px;background:#58a6ff;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">右</div>
+          </div>
+          <div class="info" style="margin-top:8px;font-size:11px;">两端对齐，item间距相等</div>
+        </div>
+        <div class="grid-item">
+          <h4>space-around</h4>
+          <div style="background:#0d1117;border-radius:6px;padding:12px;display:flex;justify-content:space-around;gap:0;">
+            <div style="width:60px;height:40px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">左</div>
+            <div style="width:60px;height:40px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">中</div>
+            <div style="width:60px;height:40px;background:#3fb950;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">右</div>
+          </div>
+          <div class="info" style="margin-top:8px;font-size:11px;">每个item两侧间距相等（边缘减半）</div>
+        </div>
+        <div class="grid-item">
+          <h4>space-evenly</h4>
+          <div style="background:#0d1117;border-radius:6px;padding:12px;display:flex;justify-content:space-evenly;gap:0;">
+            <div style="width:60px;height:40px;background:#d29922;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">左</div>
+            <div style="width:60px;height:40px;background:#d29922;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">中</div>
+            <div style="width:60px;height:40px;background:#d29922;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">右</div>
+          </div>
+          <div class="info" style="margin-top:8px;font-size:11px;">所有间距（含边缘）完全相等</div>
+        </div>
+        <div class="grid-item">
+          <h4>center</h4>
+          <div style="background:#0d1117;border-radius:6px;padding:12px;display:flex;justify-content:center;gap:8px;">
+            <div style="width:60px;height:40px;background:#f78166;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">左</div>
+            <div style="width:60px;height:40px;background:#f78166;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">中</div>
+            <div style="width:60px;height:40px;background:#f78166;border-radius:4px;display:flex;align-items:center;justify-content:center;color:white;font-size:12px;">右</div>
+          </div>
+          <div class="info" style="margin-top:8px;font-size:11px;">居中对齐</div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.control-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.control-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const jc = btn.dataset.jc;
+        document.getElementById('demo').style.justifyContent = jc;
+        document.querySelector('.code-block').textContent = 'justify-content: ' + jc + ';';
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/order.html
+++ b/examples/css/demos/flexbox-deep/order.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox order 示例</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { background: #21262d; border-radius: 6px; padding: 16px; margin-bottom: 12px; min-height: 100px; display: flex; gap: 8px; width: 100%; }
+    .demo-item { width: 80px; min-height: 80px; background: linear-gradient(135deg, #58a6ff, #1f6feb); border-radius: 6px; display: flex; align-items: center; justify-content: center; font-weight: 600; color: white; font-size: 13px; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+    .control-btn { padding: 6px 14px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .control-btn:hover { background: #30363d; }
+    .control-btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; white-space: pre-wrap; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; line-height: 1.6; }
+    .warning { border-left: 3px solid #f78166; padding-left: 12px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>order 排列顺序</h1>
+
+    <div class="section">
+      <h2>DOM 顺序 vs 视觉顺序</h2>
+      <div class="controls">
+        <button class="control-btn active" data-mode="default">默认顺序</button>
+        <button class="control-btn" data-mode="reverse">反转顺序</button>
+        <button class="control-btn" data-mode="custom">自定义顺序</button>
+      </div>
+      <div class="demo-area" id="demo">
+        <div class="demo-item" data-order="0" style="order:0;">A<br><span style="font-size:10px;opacity:0.7">order=0</span></div>
+        <div class="demo-item" data-order="1" style="order:1;">B<br><span style="font-size:10px;opacity:0.7">order=1</span></div>
+        <div class="demo-item" data-order="2" style="order:2;">C<br><span style="font-size:10px;opacity:0.7">order=2</span></div>
+        <div class="demo-item" data-order="3" style="order:3;">D<br><span style="font-size:10px;opacity:0.7">order=3</span></div>
+        <div class="demo-item" data-order="4" style="order:4;">E<br><span style="font-size:10px;opacity:0.7">order=4</span></div>
+      </div>
+      <div class="code-block" id="codeBlock">/* DOM: A -> B -> C -> D -> E */
+/* 视觉: A -> B -> C -> D -> E (默认) */</div>
+    </div>
+
+    <div class="section">
+      <h2>典型应用：响应式布局</h2>
+      <div style="background:#0d1117;border-radius:6px;padding:16px;display:flex;flex-wrap:wrap;gap:8px;margin-bottom:12px;">
+        <div style="flex:0 0 100%;min-height:60px;background:linear-gradient(135deg,#58a6ff,#1f6feb);border-radius:6px;display:flex;align-items:center;justify-content:center;color:white;font-weight:600;font-size:13px;order:1;">主要内容和底部可以换序</div>
+        <div style="flex:0 0 50%;min-height:60px;background:linear-gradient(135deg,#3fb950,#238636);border-radius:6px 0 0 6px;display:flex;align-items:center;justify-content:center;color:white;font-weight:600;font-size:13px;order:2;">侧边栏</div>
+        <div style="flex:0 0 50%;min-height:60px;background:linear-gradient(135deg,#d29922,#9e6a03);border-radius:0 6px 6px 0;display:flex;align-items:center;justify-content:center;color:white;font-weight:600;font-size:13px;order:3;">附加信息</div>
+        <div style="flex:0 0 100%;min-height:60px;background:linear-gradient(135deg,#f78166,#da3633);border-radius:6px;display:flex;align-items:center;justify-content:center;color:white;font-weight:600;font-size:13px;order:0;">底部信息</div>
+      </div>
+      <div class="info">移动端优先：可以用 order 把主要内容放到最前面显示</div>
+    </div>
+
+    <div class="section">
+      <div class="info warning">
+        <strong>无障碍警告：</strong>order 只改变视觉顺序，不改变 DOM 顺序！<br><br>
+        屏幕阅读器按 DOM 顺序读取，不会受 order 影响。
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const modes = {
+      default: { orders: [0, 1, 2, 3, 4], code: '/* 默认顺序 */' },
+      reverse: { orders: [-1, 0, 1, 2, 3], code: '/* 反转: A:-1, B:0, C:1, D:2, E:3 */' },
+      custom: { orders: [3, 0, 4, 1, 2], code: '/* A:3, B:0, C:4, D:1, E:2 -> 视觉: B D E A C */' }
+    };
+
+    document.querySelectorAll('.control-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.control-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const mode = modes[btn.dataset.mode];
+        const items = document.querySelectorAll('.demo-item');
+        items.forEach((item, i) => {
+          item.style.order = mode.orders[i];
+        });
+        document.getElementById('codeBlock').textContent = mode.code;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/sticky-footer.html
+++ b/examples/css/demos/flexbox-deep/sticky-footer.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox Sticky Footer 示例</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; line-height: 1.6; }
+    .demo-frame { background: #21262d; border-radius: 6px; overflow: hidden; }
+    .demo-controls { display: flex; gap: 8px; margin-bottom: 12px; flex-wrap: wrap; }
+    .demo-btn { padding: 6px 14px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .demo-btn:hover { background: #30363d; }
+    .demo-btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Sticky Footer 粘性页脚</h1>
+
+    <div class="section">
+      <h2>Flexbox 实现 Sticky Footer</h2>
+      <div class="demo-controls">
+        <button class="demo-btn active" data-mode="short">内容少</button>
+        <button class="demo-btn" data-mode="long">内容多</button>
+      </div>
+      <div class="demo-frame" id="frame" style="height: 400px; display: flex; flex-direction: column;">
+        <div style="background: linear-gradient(135deg, #58a6ff, #1f6feb); padding: 16px 20px; color: white; font-weight: 600; font-size: 15px; display: flex; align-items: center; gap: 8px;">Header</div>
+        <div id="mainContent" style="background: #0d1117; flex: 1; padding: 20px; color: #8b949e; font-size: 14px; display: flex; align-items: center; justify-content: center; text-align: center; min-height: 0;">
+          <div><p style="margin-bottom:8px;font-size:16px;color:#c9d1d9;">内容区域</p><p style="font-size:12px;">flex: 1 占据所有剩余空间</p></div>
+        </div>
+        <div style="background: linear-gradient(135deg, #3fb950, #238636); padding: 16px 20px; color: white; font-weight: 600; font-size: 15px;">Footer - 始终在底部</div>
+      </div>
+      <div class="code-block">html, body { height: 100%; }
+body { display: flex; flex-direction: column; }
+main { flex: 1; }</div>
+      <div class="info">核心原理：flex: 1 让 main 区域占据所有剩余空间，footer 被推到最下方</div>
+    </div>
+
+    <div class="section">
+      <h2>常见错误写法</h2>
+      <div class="info" style="border-left: 3px solid #f78166;">
+        <strong>错误：使用 position: absolute</strong><br>
+        footer { position: absolute; bottom: 0; }<br>
+        会导致 footer 覆盖内容，且不占文档流高度
+      </div>
+      <div class="info" style="border-left: 3px solid #3fb950; margin-top: 12px;">
+        <strong>正确：Flexbox</strong><br>
+        body { display: flex; flex-direction: column; min-height: 100vh; }<br>
+        main { flex: 1; }<br>
+        Footer 自然在底部，内容区域自适应
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const contents = {
+      short: '<div><p style="margin-bottom:8px;font-size:16px;color:#c9d1d9;">内容区域</p><p style="font-size:12px;">flex: 1 占据所有剩余空间</p></div>',
+      long: '<div style="text-align:left;display:block;"><p style="margin-bottom:8px;font-size:16px;color:#c9d1d9;">更多内容</p><p style="font-size:13px;margin-bottom:6px;">这是多行内容...</p><p style="font-size:13px;margin-bottom:6px;">Lorem ipsum dolor sit amet...</p><p style="font-size:13px;margin-bottom:6px;">内容足够多时会撑开页面...</p></div>'
+    };
+    document.querySelectorAll('.demo-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.demo-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById('mainContent').innerHTML = contents[btn.dataset.mode];
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/flexbox-deep/两端对齐.html
+++ b/examples/css/demos/flexbox-deep/两端对齐.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Flexbox 两端对齐布局</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 24px; color: #f0f6fc; }
+    .container { max-width: 900px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { background: #21262d; border-radius: 6px; padding: 16px; margin-bottom: 12px; min-height: 120px; display: flex; flex-wrap: wrap; gap: 8px; width: 100%; }
+    .demo-item { width: 80px; height: 60px; background: linear-gradient(135deg, #58a6ff, #1f6feb); border-radius: 6px; display: flex; align-items: center; justify-content: center; font-weight: 600; color: white; font-size: 12px; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; color: #79c0ff; margin-top: 12px; white-space: pre-wrap; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 8px; padding: 12px; background: #0d1117; border-radius: 4px; line-height: 1.6; }
+    .warning { border-left: 3px solid #d29922; padding-left: 12px; }
+    .ok { border-left: 3px solid #3fb950; padding-left: 12px; }
+    .controls { display: flex; gap: 8px; margin-bottom: 12px; flex-wrap: wrap; }
+    .demo-btn { padding: 6px 14px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .demo-btn:hover { background: #30363d; }
+    .demo-btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .pseudo { height: 60px; width: 80px; background: #30363d; border-radius: 6px; visibility: hidden; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>两端对齐布局</h1>
+
+    <div class="section">
+      <h2>问题：最后一行不在左侧</h2>
+      <div class="demo-area" style="justify-content: space-between;">
+        <div class="demo-item">1</div><div class="demo-item">2</div><div class="demo-item">3</div><div class="demo-item">4</div><div class="demo-item">5</div>
+      </div>
+      <div class="demo-area" style="justify-content: space-between; margin-top: 8px;">
+        <div class="demo-item">6</div><div class="demo-item">7</div>
+      </div>
+      <div class="info warning">space-between 的问题：当最后一行 item 数量少于一行时，会出现不均匀间距</div>
+    </div>
+
+    <div class="section">
+      <h2>解决方案：伪元素填充</h2>
+      <div class="controls">
+        <button class="demo-btn active" data-mode="fix">已修复</button>
+        <button class="demo-btn" data-mode="original">原始问题</button>
+      </div>
+      <div class="demo-area" id="demo" style="justify-content: space-between;">
+        <div class="demo-item">1</div><div class="demo-item">2</div><div class="demo-item">3</div><div class="demo-item">4</div><div class="demo-item">5</div><div class="demo-item">6</div><div class="demo-item">7</div>
+        <div id="pseudo" class="pseudo"></div><div id="pseudo2" class="pseudo"></div>
+      </div>
+      <div class="code-block">/* 关键代码 */
+.container::after {
+  content: '';
+  flex: 9999999999;
+}</div>
+      <div class="info ok" style="margin-top:8px;">通过添加一个 flex: 9999999999 的伪元素，消耗剩余空间，让最后一行"看起来"左对齐</div>
+    </div>
+
+    <div class="section">
+      <h2>圣杯布局（Holy Grail Layout）</h2>
+      <div style="background:#21262d;border-radius:6px;overflow:hidden;height:280px;display:flex;flex-direction:column;">
+        <div style="background:#58a6ff;padding:12px 16px;color:white;font-weight:600;font-size:13px;">Header</div>
+        <div style="display:flex;flex:1;min-height:0;">
+          <div style="flex:0 0 100px;background:#3fb950;padding:12px;color:white;font-size:12px;font-weight:600;display:flex;align-items:center;justify-content:center;">Sidebar</div>
+          <div style="flex:1;background:#0d1117;padding:12px;color:#8b949e;font-size:12px;display:flex;align-items:center;justify-content:center;">Main Content</div>
+          <div style="flex:0 0 100px;background:#d29922;padding:12px;color:white;font-size:12px;font-weight:600;display:flex;align-items:center;justify-content:center;">Aside</div>
+        </div>
+        <div style="background:#f78166;padding:12px 16px;color:white;font-weight:600;font-size:13px;">Footer</div>
+      </div>
+      <div class="code-block">.container { display: flex; flex-direction: column; }
+.main { display: flex; flex: 1; }
+.sidebar, .aside { flex: 0 0 100px; }
+.content { flex: 1; }</div>
+    </div>
+  </div>
+
+  <script>
+    document.querySelectorAll('.demo-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.demo-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const pseudo = document.getElementById('pseudo');
+        const pseudo2 = document.getElementById('pseudo2');
+        if (btn.dataset.mode === 'fix') {
+          pseudo.style.visibility = 'hidden';
+          pseudo2.style.visibility = 'hidden';
+        } else {
+          pseudo.style.visibility = 'visible';
+          pseudo2.style.visibility = 'visible';
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/src/topics/01.basics/11.color-contrast/index.mdx
+++ b/src/topics/01.basics/11.color-contrast/index.mdx
@@ -1,0 +1,172 @@
+---
+title: "CSS contrast-color() 色彩对比度函数"
+category: "基础知识"
+tags:
+  - CSS
+  - 色彩
+  - contrast-color
+  - 对比度
+  - CSS Color Level 5
+description: "详解 CSS Color Level 5 新增的 contrast-color() 函数，自动选择具有足够对比度的文本颜色"
+keywords: "CSS, contrast-color, 色彩对比度, 无障碍, WCAG, CSS Color Level 5"
+---
+
+# CSS `contrast-color()` 色彩对比度函数
+
+## 概述
+
+`contrast-color()` 是 CSS Color Module Level 5 规范中新增的颜色函数，用于**根据背景色自动选择具有足够对比度的前景色**。这对于实现无障碍设计尤为重要，因为它能确保文本与其背景之间保持 WCAG 规定的最小对比度要求。
+
+该函数最早在 [CSS Color Level 5 规范](https://drafts.csswg.org/css-color-5/#funcdef-contrast-color) 中定义，由 Chris Lilley、Una Kravets、Lea Verou 和 Adam Argyle 等人共同编辑。
+
+## 语法详解
+
+### 基本语法
+
+```css
+contrast-color(<background-color>, <target-colors>)
+```
+
+**参数说明：**
+
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| `<background-color>` | `<color>` | 背景颜色，函数会根据这个颜色来计算对比度 |
+| `<target-colors>` | `<color>#` | 一个或多个目标颜色列表，函数会选择与背景对比度最高的那个 |
+
+**返回值：** 从目标颜色列表中选出与背景色对比度最高的那个颜色。
+
+### 对比度计算
+
+对比度计算遵循 WCAG 2.1 规范，使用相对亮度（Relative Luminance）公式：
+
+1. 将 RGB 各通道值从 0-255 线性化为 0-1 范围
+2. 对每个通道应用 gamma 校正
+3. 计算相对亮度：L = 0.2126 × R + 0.7152 × G + 0.0722 × B
+4. 对比度 = (L1 + 0.05) / (L2 + 0.05)，其中 L1 > L2
+
+### 使用示例
+
+```css
+/* 最基本用法：从白色和黑色中选择一个与背景对比度高的 */
+color: contrast-color(blue, white, black);  /* 返回 white */
+
+/* 暗黑模式下的自动文本颜色 */
+--text-color: contrast-color(var(--bg-color), #fff, #000);
+
+/* 复杂背景下的品牌色选择 */
+.button-text {
+  color: contrast-color(var(--brand-bg), var(--primary), var(--secondary));
+}
+```
+
+## 实际应用场景
+
+### 1. 暗黑模式与亮色模式自动切换
+
+```css
+/* 定义主题变量 */
+:root {
+  --bg-color: #ffffff;
+  --text-color: contrast-color(var(--bg-color), #1a1a1a, #ffffff);
+}
+
+[data-theme="dark"] {
+  --bg-color: #1a1a1a;
+  --text-color: contrast-color(var(--bg-color), #1a1a1a, #ffffff);
+}
+
+body {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+```
+
+### 2. 动态卡片组件
+
+```css
+.card {
+  --card-bg: var(--dynamic-color);
+  background-color: var(--card-bg);
+  color: contrast-color(var(--card-bg), #fff, #000);
+}
+```
+
+### 3. 用户生成内容的可访问性
+
+```css
+/* 用户上传的头像边框自动适配 */
+.avatar-ring {
+  --avatar-bg: var(--user-defined-color);
+  border-color: contrast-color(var(--avatar-bg), rgba(0,0,0,0.5), rgba(255,255,255,0.5));
+}
+```
+
+### 4. 数据可视化自动配色
+
+```css
+.chart-bar {
+  --chart-bg: var(--bar-color);
+  background-color: var(--chart-bg);
+}
+
+/* 条形图标签始终可见 */
+.chart-label {
+  color: contrast-color(var(--chart-bg), #333, #eee);
+}
+```
+
+## 与 `light-dark()` 的区别
+
+| 特性 | `contrast-color()` | `light-dark()` |
+|------|-------------------|----------------|
+| 颜色数量 | 从列表中自动选择 | 只支持两种固定颜色 |
+| 选择依据 | 对比度计算 | 固定的亮/暗主题 |
+| 灵活性 | 高，可指定任意数量颜色 | 低，只有两种选择 |
+| 适用场景 | 动态背景、用户自定义颜色 | 明确的主题切换 |
+
+```css
+/* light-dark 只知道"亮"和"暗" */
+color: light-dark(black, white);
+
+/* contrast-color 知道"哪个颜色更易读" */
+color: contrast-color(dynamic-bg, #fff, #000, #ff0);
+```
+
+## 浏览器兼容性
+
+> ⚠️ `contrast-color()` 目前处于实验性阶段，浏览器支持非常有限。
+
+| 特性 | Chrome | Firefox | Safari | Edge |
+|------|--------|---------|--------|------|
+| `contrast-color()` | ❌ 不支持 | ❌ 不支持 | ❌ 不支持 | ❌ 不支持 |
+
+### 当前状态
+
+- **规范状态**：`contrast-color()` 是 CSS Color Level 5 Editor's Draft 的一部分
+- **实验性**：函数签名和语法可能在未来版本中发生变化
+- **WPT 测试**：规范中列出了相关的 [Web Platform Tests](https://wpt.fyi/results/css/css-color?label=experimental)
+
+### 渐进增强策略
+
+```css
+/* 使用 @supports 进行特性检测 */
+.button {
+  /* 默认回退方案 */
+  background-color: var(--btn-bg);
+  color: #fff;
+}
+
+@supports (color: contrast-color(red, white, black)) {
+  .button {
+    /* 启用 contrast-color */
+    color: contrast-color(var(--btn-bg), #fff, #000);
+  }
+}
+```
+
+## 参考资料
+
+- [CSS Color Module Level 5 规范](https://drafts.csswg.org/css-color-5/#funcdef-contrast-color)
+- [WCAG 2.1 对比度要求](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)
+- [MDN CSS 颜色文档](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_colors)

--- a/src/topics/02.layout/flexbox-deep/index.mdx
+++ b/src/topics/02.layout/flexbox-deep/index.mdx
@@ -1,0 +1,327 @@
+---
+title: CSS Flexbox 深入解析
+category: 布局进阶
+tags: [flexbox, flex, layout, css, 布局]
+description: 深入理解 Flexbox 一维布局机制，系统掌握 flex container 和 flex item 属性，理解常见布局场景与兼容性问题。
+keywords: [CSS Flexbox, flex-grow, flex-shrink, flex-basis, align-items, justify-content, flex-wrap]
+---
+
+# CSS Flexbox 深入解析
+
+Flexbox 是 CSS 弹性布局模块，设计目标是**在一维方向上高效分配空间和对齐元素**。与二维布局模型 Grid 不同，Flexbox 专注于单轴（主轴或交叉轴）上的排列控制。
+
+## 深入理解 Flexbox 一维布局
+
+### 核心概念
+
+- **主轴（main axis）**：Flex item 排列的主要方向，由 `flex-direction` 决定
+- **交叉轴（cross axis）**：垂直于主轴的方向
+- **主尺寸（main size）**：item 在主轴方向上的尺寸
+- **交叉尺寸（cross size）**：item 在交叉轴方向上的尺寸
+
+### Flex 格式化上下文
+
+当元素变成 flex container 时，会建立新的 **flex formatting context**：
+
+```css
+.container {
+  display: flex;          /* 触发 flex 格式化上下文 */
+  /* 或 display: inline-flex */
+}
+```
+
+**与普通块级盒的关键差异：**
+- `margin: auto` 在 flex item 上会正确居中（不再折叠）
+- `float` 对 flex item **无效**
+- `vertical-align` 对 flex item **无效**
+- Flex item 成为 **block 化容器**
+
+> 演示：[flex-context.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/flex-context.html)
+
+---
+
+## flex container 属性详解
+
+### display: flex | inline-flex
+
+| 值 | 行为 |
+|---|---|
+| `flex` | 块级 flex container |
+| `inline-flex` | 行内级 flex container |
+
+> 演示：[display-flex.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/display-flex.html)
+
+### flex-direction
+
+定义主轴方向，即 flex item 的排列方向。
+
+| 值 | 效果 |
+|---|---|
+| `row` (默认) | 左 → 右 |
+| `row-reverse` | 右 → 左 |
+| `column` | 上 → 下 |
+| `column-reverse` | 下 → 上 |
+
+> 演示：[flex-direction.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/flex-direction.html)
+
+### flex-wrap
+
+控制 flex item 是单行还是多行排列。
+
+| 值 | 行为 |
+|---|---|
+| `nowrap` (默认) | 单行，item 会被压缩 |
+| `wrap` | 多行，换行方向与 cross axis 一致 |
+| `wrap-reverse` | 多行，换行方向与 cross axis 相反 |
+
+> 演示：[flex-wrap.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/flex-wrap.html)
+
+### flex-flow
+
+`flex-direction` 和 `flex-wrap` 的简写。
+
+```css
+.container { flex-flow: <flex-direction> <flex-wrap>; }
+```
+
+### justify-content
+
+定义 item 在主轴上的对齐方式。
+
+| 值 | 效果 |
+|---|---|
+| `flex-start` | 靠主轴起点对齐 |
+| `flex-end` | 靠主轴终点对齐 |
+| `center` | 居中对齐 |
+| `space-between` | 两端对齐，item 之间等间距 |
+| `space-around` | 每个 item 两侧间距相等 |
+| `space-evenly` | 所有间距（含边缘）完全相等 |
+
+> 演示：[justify-content.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/justify-content.html)
+
+### align-items
+
+定义 item 在交叉轴上的对齐方式（单行有效）。
+
+| 值 | 效果 |
+|---|---|
+| `stretch` (默认) | 拉伸至填满容器 |
+| `flex-start` | 靠交叉轴起点对齐 |
+| `flex-end` | 靠交叉轴终点对齐 |
+| `center` | 居中对齐 |
+| `baseline` | 按文字 baseline 对齐 |
+
+> 演示：[align-items.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/align-items.html)
+
+### align-content
+
+定义**多行**时 item 在交叉轴上的对齐方式（单行无效）。
+
+> 演示：[align-content.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/align-content.html)
+
+---
+
+## flex item 属性详解
+
+### flex-grow
+
+定义 item 的**放大比例**，当主轴有剩余空间时如何分配。
+
+```css
+.item { flex-grow: <number>; /* 默认 0 */ }
+```
+
+**计算公式：**
+```
+实际宽度 = 自身基础尺寸 + 剩余空间 × (grow / 总grow)
+```
+
+> 演示：[flex-grow.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/flex-grow.html)
+
+### flex-shrink
+
+定义 item 的**缩小比例**，当主轴空间不足时如何收缩。
+
+```css
+.item { flex-shrink: <number>; /* 默认 1 */ }
+```
+
+> 注意： `flex-shrink: 0` 会导致溢出而非收缩！
+> 演示：[flex-shrink.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/flex-shrink.html)
+
+### flex-basis
+
+定义 item 在分配剩余空间前的**初始主尺寸**。
+
+```css
+.item { flex-basis: <length> | auto; /* 默认 auto */ }
+```
+
+**优先级链：**
+```
+max-width/max-height > flex-basis > width/height > 内容尺寸
+```
+
+> 演示：[flex-basis.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/flex-basis.html)
+
+### flex 简写
+
+```css
+.item { flex: <flex-grow> <flex-shrink> <flex-basis>; }
+```
+
+| 简写 | 等价于 | 用途 |
+|---|---|---|
+| `flex: 0 0 100px` | - | 固定尺寸，不可伸缩 |
+| `flex: 1` | `1 1 0%` | 可伸缩，初始尺寸 0 |
+| `flex: auto` | `1 1 auto` | 可伸缩，使用 auto 尺寸 |
+| `flex: none` | `0 0 auto` | 完全不可伸缩 |
+
+> 注意：常见错误是 `flex: 1` 的初始尺寸是 0，会导致内容被压缩！需要保持内容尺寸时用 `flex: auto`。
+
+> 演示：[flex-shorthand.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/flex-shorthand.html)
+
+### align-self
+
+覆盖 container 的 `align-items`，控制单个 item 在交叉轴上的对齐。
+
+> 演示：[flex-shorthand.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/flex-shorthand.html)
+
+### order
+
+控制 item 的排列顺序（数值越小越靠前）。
+
+> 注意： order 仅改变视觉顺序，不改变 DOM 顺序，屏幕阅读器仍按 DOM 顺序读取。
+
+> 演示：[order.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/order.html)
+
+---
+
+## 常见布局场景
+
+### 场景一：水平居中
+
+```css
+.container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+```
+
+### 场景二：两端对齐，最后一行左对齐
+
+```css
+.container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+.container::after {
+  content: '';
+  flex: 9999999999;
+}
+```
+
+> 演示：[两端对齐.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/两端对齐.html)
+
+### 场景三：Sticky Footer（粘性页脚）
+
+```css
+body {
+  display: flex;
+  flex-direction: column;
+}
+main {
+  flex: 1; /* 占据剩余空间 */
+}
+```
+
+> 演示：[sticky-footer.html](https://github.com/zenHeart/learn-css/tree/main/examples/css/demos/flexbox-deep/sticky-footer.html)
+
+### 场景四：等高列
+
+```css
+.container { display: flex; }
+.column { flex: 1; }
+```
+
+### 场景五：圣杯布局
+
+```css
+.container { display: flex; flex-direction: column; }
+.header, .footer { flex: 0 0 auto; }
+.main { flex: 1; display: flex; }
+.sidebar { flex: 0 0 200px; }
+.content { flex: 1; }
+```
+
+### 场景六：输入框 + 按钮组合
+
+```css
+.input-group { display: flex; }
+.input-group input { flex: 1; border-radius: 4px 0 0 4px; }
+.input-group button { flex: 0 0 auto; border-radius: 0 4px 4px 0; }
+```
+
+### 场景七：媒体对象（Media Object）
+
+```css
+.media { display: flex; align-items: flex-start; }
+.media-figure { flex: 0 0 80px; margin-right: 1em; }
+.media-body { flex: 1; }
+```
+
+---
+
+## 兼容性与坑点
+
+### 浏览器兼容性
+
+| 特性 | Chrome | Firefox | Safari | Edge |
+|---|---|---|---|---|
+| `display: flex` | 29+ | 28+ | 9+ | 12+ |
+| `flex-wrap` | 29+ | 28+ | 9+ | 12+ |
+| `flex-grow/shrink` | 29+ | 28+ | 9+ | 12+ |
+| `flex-basis` | 29+ | 28+ | 9+ | 12+ |
+| `align-content` | 29+ | 28+ | 9+ | 12+ |
+
+> 注意： IE 11 有部分支持，但存在大量 bug。如需兼容，请使用 Autoprefixer。
+
+### 常见坑点
+
+#### 坑点 1：flex-basis 与 width 的优先级
+
+**优先级：** `max-width/min-width` > `flex-basis` > `width/height` > 内容尺寸
+
+#### 坑点 2：flex-shrink 为 0 时的溢出
+
+`flex-shrink: 0` 会导致溢出而非收缩！
+
+#### 坑点 3：flex-grow: 1 导致内容被压缩
+
+```css
+/* 问题 */
+input { flex: 1; }  /* flex-basis 默认是 0% */
+/* 解决 */
+input { flex: 1 1 auto; }
+```
+
+#### 坑点 4：align-content 对单行无效
+
+必须配合 `flex-wrap: wrap` 且 items 确实换行。
+
+#### 坑点 5：flex-direction: column 时的 height 问题
+
+在 `flex-direction: column` 时，`flex-grow` 控制的是**高度**而非宽度。
+
+#### 坑点 6：min-width/min-height 与 flex
+
+Flex item 的 `min-width`（默认 `auto`）会限制 `flex-basis`。
+
+### 推荐阅读
+
+- [CSS Flexbox 完整指南（英文）](https://css-tricks.com/snippets/css/a-guide-to-flexbox/)
+- [Flexbox 完全指南 - 中文](https://www.ruanyifeng.com/blog/2015/07/flex-grammar.html)
+- [flex-grow 秘密](https://css-tricks.com/understanding-flex-grow/)
+- [flex-shrink 详解](https://css-tricks.com/flexbox-shrinking/)

--- a/src/topics/06.text/css-content/index.mdx
+++ b/src/topics/06.text/css-content/index.mdx
@@ -1,0 +1,317 @@
+---
+title: "CSS content 属性"
+category: "文本"
+tags:
+  - content
+  - 伪元素
+  - ::before
+  - ::after
+  - attr
+  - counter
+description: "详解 CSS content 属性的各种用法，包括文本、图片、计数器、字符串拼接等"
+keywords: "CSS content, content 属性, ::before, ::after, attr(), counter(), 图片, 计数器"
+---
+
+# CSS content 属性
+
+`content` 属性是 CSS 中最强大的属性之一，它与 `::before` 和 `::after` 伪元素配合，可以完成文本、图片、计数器、图标注入等多种功能。本篇文章将全面解析 `content` 属性的用法和实战技巧。
+
+## 快速预览
+
+下面是一个综合示例，展示了 `content` 属性的常见用法：
+
+{/* @playground id="css-content-overview" mode="demo" */}
+
+## 基本概念
+
+`content` 属性主要与 `::before` 和 `::after` 伪元素配合使用：
+
+- `::before` — 在元素内容之前插入内容
+- `::after` — 在元素内容之后插入内容
+
+```css
+.element::before {
+  content: "前缀";
+}
+
+.element::after {
+  content: "后缀";
+}
+```
+
+> ⚠️ **注意**：伪元素需要设置 `content` 属性才会渲染，即使 `content: ""` 也可以。
+
+## 语法详解
+
+```css
+/* 关键词 */
+content: normal;
+content: none;
+
+/* 文本字符串 */
+content: "固定文本";
+content: "前缀" "后缀";
+
+/* 图片 */
+content: url("image.png");
+content: linear-gradient(blue, red);
+
+/* 计数器 */
+content: counter(counter-name);
+content: counters(counter-name, ".");
+
+/* 属性值 */
+content: attr(data-label);
+
+/* 引号 */
+content: open-quote;
+content: close-quote;
+content: no-open-quote;
+content: no-close-quote;
+
+/* 混合使用 */
+content: "序号 " counter(index) "：";
+content: url("icon.png") " 标签文本";
+```
+
+## 文本内容
+
+最基础的用法是插入纯文本：
+
+```css
+.required::after {
+  content: " *";
+  color: red;
+}
+```
+
+{/* @playground id="content-text" mode="demo" */}
+
+## 图片内容
+
+使用 `url()` 函数可以插入图片：
+
+```css
+.pin::before {
+  content: url("pin.png");
+}
+```
+
+{/* @playground id="content-image" mode="demo" */}
+
+### 图片与文本组合
+
+可以同时插入图片和文本：
+
+```css
+.location::before {
+  content: url("pin.png") " 当前位置：";
+}
+```
+
+> 💡 **提示**：在 Chrome 浏览器中，`content` 属性还支持 `linear-gradient()` 渐变，但其他浏览器支持较差。
+
+## 计数器
+
+计数器是 `content` 属性最强大的功能之一。详情请参考 [CSS 计数器专题](/topics/01.basics/10.counter)。
+
+### 基本计数器
+
+```css
+ol {
+  counter-reset: item;  /* 声明计数器 */
+}
+
+li {
+  counter-increment: item;  /* 递增计数器 */
+}
+
+li::before {
+  content: counter(item);  /* 输出计数器值 */
+}
+```
+
+{/* @playground id="content-counter-basic" mode="demo" */}
+
+### 嵌套计数器（counters）
+
+`counters()` 函数支持嵌套计数器：
+
+```css
+ol {
+  counter-reset: section;
+  list-style: none;
+}
+
+li {
+  counter-increment: section;
+}
+
+li::before {
+  content: counters(section, ".") " ";
+}
+```
+
+{/* @playground id="content-counter-nested" mode="demo" */}
+
+## attr() 函数
+
+`attr()` 函数可以读取 HTML 属性的值：
+
+```css
+[data-label]::before {
+  content: attr(data-label) ": ";
+}
+```
+
+### 打印样式中的 URL 显示
+
+这是 `attr()` 最实用的场景之一——在打印样式中显示链接目标：
+
+```css
+@media print {
+  a[href^="http://"]::after,
+  a[href^="https://"]::after {
+    content: " (" attr(href) ")";
+  }
+}
+```
+
+{/* @playground id="content-attr" mode="demo" */}
+
+## 引号处理
+
+CSS 提供了四个引号相关的关键词：
+
+| 关键词 | 作用 |
+|--------|------|
+| `open-quote` | 插入左引号 |
+| `close-quote` | 插入右引号 |
+| `no-open-quote` | 不插入内容，但增加引号嵌套层级 |
+| `no-close-quote` | 不插入内容，但减少引号嵌套层级 |
+
+### 自动引号嵌套
+
+```css
+blockquote {
+  quotes: "«" "»" "‹" "›";
+}
+
+blockquote::before {
+  content: open-quote;
+}
+
+blockquote::after {
+  content: close-quote;
+}
+```
+
+{/* @playground id="content-quotes" mode="demo" */}
+
+不同语言有不同的引号习惯：
+
+```css
+/* 法语 */
+blockquote[lang="fr"] {
+  quotes: "«" "»" "‹" "›";
+}
+```
+
+## 替代文本（无障碍）
+
+`content` 属性支持为图片添加替代文本，使用 `/` 分隔：
+
+```css
+.hot::before {
+  content: url("fire.png") / "热门";
+}
+```
+
+> ⚠️ **浏览器支持**：目前只有 Chrome 浏览器支持替代文本，其他浏览器会忽略包含替代文本的伪元素。
+
+## 实战案例
+
+### 案例一：面包屑导航
+
+{/* @playground id="content-breadcrumb" mode="demo" */}
+
+### 案例二：浮动元素清除
+
+使用 `::after` 伪元素清除浮动：
+
+```css
+.clearfix::after {
+  content: "";
+  display: block;
+  clear: both;
+}
+```
+
+{/* @playground id="content-clearfix" mode="demo" */}
+
+### 案例三：自定义列表编号
+
+{/* @playground id="content-list-style" mode="demo" */}
+
+### 案例四：图标注入
+
+通过 `content` 注入 SVG 图标（Base64 编码）：
+
+```css
+.icon-arrow::after {
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23333' d='M4 2l4 4-4 4'/%3E%3C/svg%3E");
+}
+```
+
+{/* @playground id="content-icon-inject" mode="demo" */}
+
+### 案例五：文件类型标识
+
+在下载链接后显示文件类型和大小：
+
+```css
+a[href$=".pdf"]::after {
+  content: " (PDF)";
+  color: red;
+}
+
+a[href$=".zip"]::after {
+  content: " (ZIP)";
+  color: green;
+}
+```
+
+{/* @playground id="content-file-type" mode="demo" */}
+
+### 案例六：表单必填标记
+
+{/* @playground id="content-required" mode="demo" */}
+
+## 浏览器支持
+
+| 功能 | Chrome | Firefox | Safari | Edge |
+|------|--------|---------|--------|------|
+| 文本内容 | ✅ | ✅ | ✅ | ✅ |
+| 图片 url() | ✅ | ✅ | ✅ | ✅ |
+| 渐变 content | ✅ | ❌ | ❌ | ❌ |
+| 计数器 | ✅ | ✅ | ✅ | ✅ |
+| attr() | ✅ | ✅ | ✅ | ✅ |
+| 引号关键词 | ✅ | ✅ | ✅ | ✅ |
+| 替代文本 | ✅ | ❌ | ❌ | ❌ |
+
+## 注意事项
+
+1. **content 只用于伪元素**：虽然可以在普通元素上使用 `content`，但效果有限，主要用于替换内容。
+
+2. **屏幕阅读器可访问性**：通过 `content` 添加的内容对屏幕阅读器不可见（除非使用替代文本）。对于重要的文本内容，应该放在 HTML 中。
+
+3. **打印样式**：在打印场景中，`content` 配合 `attr()` 可以显示 URL 等信息，提升打印物的可用性。
+
+4. **多语言站点**：如果站点有多语言版本，使用 `content` 添加文本内容会带来翻译困难，应优先考虑使用 HTML 结构。
+
+## 扩展阅读
+
+- [MDN: content](https://developer.mozilla.org/en-US/docs/Web/CSS/content)
+- [Here's what I didn't know about content](https://www.matuzo.at/blog/heres-what-i-didnt-know-about-content/) — Manuel Matuzović
+- [CSS 计数器详解](/topics/01.basics/10.counter)
+- [伪元素详解](/topics/01.basics/12.pseudo-elements.mdx)


### PR DESCRIPTION
## 描述

添加 CSS content 属性的完整学习文档和交互演示。

### 文档内容 (src/topics/06.text/css-content/index.mdx)

- content 属性在 ::before/::after 伪元素中的使用
- 文本、图片、计数器(attr)、字符串拼接
- 引号处理 (open-quote/close-quote)
- 替代文本（无障碍支持）
- 实战案例：计数器、浮动清除、图标注入、面包屑等

### 演示示例 (examples/css/demos/css-content/)

| 文件 | 内容 |
|------|------|
| content-text.html | 文本内容基础用法 |
| content-image.html | 图片和 SVG 注入 |
| content-counter-basic.html | 基本计数器 |
| content-counter-nested.html | 嵌套计数器 |
| content-attr.html | attr() 函数 |
| content-quotes.html | 引号处理 |
| content-breadcrumb.html | 面包屑导航 |
| content-clearfix.html | 浮动清除 |
| content-icon-inject.html | 图标注入 |
| content-file-type.html | 文件类型标识 |
| content-required.html | 表单必填标记 |

参考：
- https://www.matuzo.at/blog/heres-what-i-didnt-know-about-content/
- https://developer.mozilla.org/en-US/docs/Web/CSS/content