### PR TITLE
docs: add CSS @container 容器查询 documentation and demos

### DIFF
--- a/examples/css/demos/box-alignment/index.html
+++ b/examples/css/demos/box-alignment/index.html
@@ -1,0 +1,252 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Box Alignment 盒对齐模块 - 交互演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 13px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; align-items: center; }
+    .btn { padding: 6px 12px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .desc { font-size: 12px; color: #6e7681; margin-top: 8px; line-height: 1.6; }
+    .tag { display: inline-block; padding: 2px 6px; border-radius: 3px; font-size: 11px; background: #388bfd33; color: #58a6ff; margin-right: 4px; }
+    
+    /* Flex 演示容器 */
+    .flex-demo {
+      display: flex;
+      height: 200px;
+      background: #0d1117;
+      border-radius: 8px;
+      padding: 8px;
+    }
+    
+    .flex-item {
+      width: 60px;
+      height: 60px;
+      background: #388bfd33;
+      border-radius: 4px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 14px;
+      font-weight: 600;
+      color: #58a6ff;
+    }
+    
+    .flex-item:nth-child(2) { background: #a371f733; color: #a371f7; }
+    .flex-item:nth-child(3) { background: #3fb95033; color: #3fb950; }
+    
+    .flex-item.tall { height: 100px; }
+    
+    /* Grid 演示容器 */
+    .grid-demo {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      grid-template-rows: repeat(2, 80px);
+      gap: 8px;
+      background: #0d1117;
+      border-radius: 8px;
+      padding: 8px;
+    }
+    
+    .grid-item {
+      background: #388bfd33;
+      border-radius: 4px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 14px;
+      font-weight: 600;
+      color: #58a6ff;
+    }
+    
+    .grid-item:nth-child(2) { background: #a371f733; color: #a371f7; }
+    .grid-item:nth-child(3) { background: #3fb95033; color: #3fb950; }
+    .grid-item:nth-child(4) { background: #f0883e33; color: #f0883e; }
+    .grid-item:nth-child(5) { background: #f8514933; color: #f85149; }
+    .grid-item:nth-child(6) { background: #7ee78733; color: #7ee787; }
+    
+    .grid-item.special {
+      background: #ffa65733;
+      color: #ffa657;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Box Alignment 盒对齐模块</h1>
+    <p class="subtitle">justify-content | align-items | place-items | 交互演示</p>
+
+    <!-- Flexbox justify-content -->
+    <div class="section">
+      <h2>Flexbox justify-content（主轴对齐）</h2>
+      <div class="controls">
+        <button class="btn active" data-justify="flex-start">flex-start</button>
+        <button class="btn" data-justify="center">center</button>
+        <button class="btn" data-justify="flex-end">flex-end</button>
+        <button class="btn" data-justify="space-between">space-between</button>
+        <button class="btn" data-justify="space-around">space-around</button>
+        <button class="btn" data-justify="space-evenly">space-evenly</button>
+      </div>
+      <div class="flex-demo" id="justify-demo" style="justify-content: flex-start;">
+        <div class="flex-item">1</div>
+        <div class="flex-item">2</div>
+        <div class="flex-item">3</div>
+      </div>
+      <div class="code-block" id="justify-code">justify-content: flex-start;</div>
+    </div>
+
+    <!-- Flexbox align-items -->
+    <div class="section">
+      <h2>Flexbox align-items（交叉轴对齐）</h2>
+      <div class="controls">
+        <button class="btn active" data-align="stretch">stretch</button>
+        <button class="btn" data-align="flex-start">flex-start</button>
+        <button class="btn" data-align="center">center</button>
+        <button class="btn" data-align="flex-end">flex-end</button>
+        <button class="btn" data-align="baseline">baseline</button>
+      </div>
+      <div class="flex-demo" id="align-demo" style="align-items: stretch;">
+        <div class="flex-item">1</div>
+        <div class="flex-item tall">2</div>
+        <div class="flex-item">3</div>
+      </div>
+      <div class="code-block" id="align-code">align-items: stretch;</div>
+    </div>
+
+    <!-- Flexbox align-self -->
+    <div class="section">
+      <h2>Flexbox align-self（单个项目对齐）</h2>
+      <div class="controls">
+        <button class="btn" data-self="flex-start">flex-start</button>
+        <button class="btn active" data-self="center">center</button>
+        <button class="btn" data-self="flex-end">flex-end</button>
+        <button class="btn" data-self="stretch">stretch</button>
+      </div>
+      <div class="flex-demo" id="self-demo" style="align-items: stretch;">
+        <div class="flex-item">1</div>
+        <div class="flex-item special" id="self-item" style="align-self: center;">2</div>
+        <div class="flex-item">3</div>
+      </div>
+      <div class="code-block" id="self-code">align-self: center;</div>
+    </div>
+
+    <!-- Grid align-items -->
+    <div class="section">
+      <h2>Grid align-items / justify-items</h2>
+      <div class="controls">
+        <button class="btn active" data-grid="stretch">stretch</button>
+        <button class="btn" data-grid="start">start</button>
+        <button class="btn" data-grid="center">center</button>
+        <button class="btn" data-grid="end">end</button>
+      </div>
+      <div class="grid-demo" id="grid-demo" style="align-items: stretch; justify-items: stretch;">
+        <div class="grid-item">1</div>
+        <div class="grid-item">2</div>
+        <div class="grid-item">3</div>
+        <div class="grid-item">4</div>
+        <div class="grid-item">5</div>
+        <div class="grid-item">6</div>
+      </div>
+      <div class="code-block" id="grid-code">align-items: stretch; justify-items: stretch;</div>
+    </div>
+
+    <!-- place-items 简写 -->
+    <div class="section">
+      <h2>place-items 简写</h2>
+      <div class="controls">
+        <button class="btn" data-place="start center">start center</button>
+        <button class="btn active" data-place="center center">center center</button>
+        <button class="btn" data-place="end end">end end</button>
+        <button class="btn" data-place="stretch stretch">stretch stretch</button>
+      </div>
+      <div class="flex-demo" id="place-demo" style="place-items: center center;">
+        <div class="flex-item">1</div>
+        <div class="flex-item">2</div>
+        <div class="flex-item">3</div>
+      </div>
+      <div class="code-block" id="place-code">place-items: center center;</div>
+    </div>
+
+    <!-- 浏览器兼容性 -->
+    <div class="section">
+      <h2>浏览器兼容性</h2>
+      <div class="desc">
+        <ul style="font-size: 12px; color: #8b949e; margin-top: 8px; padding-left: 20px;">
+          <li>Chrome 57+ ✓</li>
+          <li>Firefox 52+ ✓</li>
+          <li>Safari 10.1+ ✓</li>
+          <li>Edge 16+ ✓</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // justify-content 切换
+    document.querySelectorAll('[data-justify]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('[data-justify]').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const value = btn.dataset.justify;
+        document.getElementById('justify-demo').style.justifyContent = value;
+        document.getElementById('justify-code').textContent = `justify-content: ${value};`;
+      });
+    });
+    
+    // align-items 切换
+    document.querySelectorAll('[data-align]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('[data-align]').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const value = btn.dataset.align;
+        document.getElementById('align-demo').style.alignItems = value;
+        document.getElementById('align-code').textContent = `align-items: ${value};`;
+      });
+    });
+    
+    // align-self 切换
+    document.querySelectorAll('[data-self]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('[data-self]').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const value = btn.dataset.self;
+        document.getElementById('self-item').style.alignSelf = value;
+        document.getElementById('self-code').textContent = `align-self: ${value};`;
+      });
+    });
+    
+    // Grid align/justify-items 切换
+    document.querySelectorAll('[data-grid]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('[data-grid]').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const value = btn.dataset.grid;
+        document.getElementById('grid-demo').style.alignItems = value;
+        document.getElementById('grid-demo').style.justifyItems = value;
+        document.getElementById('grid-code').textContent = `align-items: ${value}; justify-items: ${value};`;
+      });
+    });
+    
+    // place-items 切换
+    document.querySelectorAll('[data-place]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('[data-place]').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const value = btn.dataset.place;
+        document.getElementById('place-demo').style.placeItems = value;
+        document.getElementById('place-code').textContent = `place-items: ${value};`;
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/color-contrast/index.html
+++ b/examples/css/demos/color-contrast/index.html
@@ -1,0 +1,269 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS color-contrast() 颜色对比函数 - 交互演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 13px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { display: flex; gap: 16px; min-height: 120px; padding: 20px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; align-items: center; flex-wrap: wrap; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; align-items: center; }
+    .btn { padding: 6px 12px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .desc { font-size: 12px; color: #6e7681; margin-top: 8px; line-height: 1.6; }
+    .tag { display: inline-block; padding: 2px 6px; border-radius: 3px; font-size: 11px; background: #388bfd33; color: #58a6ff; margin-right: 4px; }
+    .tag.green { background: #3fb95033; color: #3fb950; }
+    .tag.orange { background: #f0883e33; color: #f0883e; }
+    
+    .demo-box { padding: 20px 30px; border-radius: 8px; font-size: 16px; font-weight: 600; text-align: center; min-width: 120px; }
+    .color-picker { width: 60px; height: 60px; border-radius: 8px; border: 2px solid #30363d; cursor: pointer; }
+    .contrast-ratio { font-size: 14px; color: #8b949e; margin-top: 8px; }
+    
+    .support-badge { display: inline-block; padding: 4px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; }
+    .support-badge.supported { background: #3fb95033; color: #3fb950; }
+    .support-badge.unsupported { background: #f8514933; color: #f85149; }
+    
+    .comparison-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(100px, 1fr)); gap: 12px; margin-top: 12px; }
+    .comparison-item { padding: 16px; border-radius: 8px; text-align: center; font-size: 14px; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS color-contrast() 颜色对比函数</h1>
+    <p class="subtitle">CSS Color Level 5 规范 | 交互演示</p>
+
+    <!-- 浏览器支持 -->
+    <div class="section">
+      <h2>浏览器支持状态</h2>
+      <div class="demo-area" style="flex-direction: column; align-items: flex-start; gap: 12px;">
+        <div>
+          <span class="support-badge unsupported">不支持</span>
+          <span style="font-size: 12px; color: #8b949e; margin-left: 8px;">Chrome / Firefox / Edge</span>
+        </div>
+        <div>
+          <span class="support-badge supported">技术预览</span>
+          <span style="font-size: 12px; color: #8b949e; margin-left: 8px;">Safari 17.4+</span>
+        </div>
+      </div>
+      <p class="desc"><span class="tag">提示</span> 由于浏览器支持有限，下方演示使用 JavaScript 模拟 color-contrast() 的功能。</p>
+    </div>
+
+    <!-- 基础演示 -->
+    <div class="section">
+      <h2>基础用法 — 黑白色对比</h2>
+      <div class="controls">
+        <label style="font-size: 12px; color: #8b949e;">选择背景色：
+          <input type="color" id="bg-color" class="color-picker" value="#0066cc">
+        </label>
+      </div>
+      <div class="demo-area" style="justify-content: center;">
+        <div class="demo-box" id="contrast-demo" style="background: #0066cc; color: white;">
+          对比文字
+        </div>
+      </div>
+      <div class="code-block">color-contrast(<span id="code-bg">#0066cc</span> vs white, black)
+对比度: <span id="contrast-ratio">4.52</span>:1</div>
+      <p class="desc"><span class="tag">结果</span> 函数自动选择对比度更高的颜色（<span id="result-text">white</span>）</p>
+    </div>
+
+    <!-- 多颜色候选 -->
+    <div class="section">
+      <h2>多颜色候选对比</h2>
+      <div class="demo-area" style="justify-content: center;">
+        <div class="demo-box" id="multi-demo" style="background: #4CAF50;">
+          按钮文字
+        </div>
+      </div>
+      <div class="code-block">color-contrast(<span id="multi-bg">#4CAF50</span> vs white, black, #ffeb3b, #e91e63)</div>
+      <p class="desc">从多个候选颜色中选择对比度最高的。</p>
+    </div>
+
+    <!-- WCAG 对比度级别 -->
+    <div class="section">
+      <h2>WCAG 对比度级别</h2>
+      <div class="comparison-grid">
+        <div class="comparison-item" id="aa-demo" style="background: #333; color: white;">
+          AA 级<br><span style="font-size: 12px; font-weight: normal;">4.5:1+</span>
+        </div>
+        <div class="comparison-item" id="aa-large-demo" style="background: #333; color: white;">
+          AA 大文本<br><span style="font-size: 12px; font-weight: normal;">3:1+</span>
+        </div>
+        <div class="comparison-item" id="aaa-demo" style="background: #333; color: white;">
+          AAA 级<br><span style="font-size: 12px; font-weight: normal;">7:1+</span>
+        </div>
+      </div>
+      <div class="code-block">/* AA 级（普通文本 4.5:1） */
+color-contrast(bg vs candidates to AA)
+
+/* AAA 级（7:1） */
+color-contrast(bg vs candidates to AAA)</div>
+    </div>
+
+    <!-- 实际应用 -->
+    <div class="section">
+      <h2>实际应用：卡片系统</h2>
+      <div class="demo-area" style="flex-direction: column; gap: 12px;">
+        <div class="demo-box" id="card1" style="background: #0066cc; width: 100%;">
+          卡片 1 - 主要颜色
+        </div>
+        <div class="demo-box" id="card2" style="background: #22c55e; width: 100%;">
+          卡片 2 - 成功颜色
+        </div>
+        <div class="demo-box" id="card3" style="background: #f59e0b; width: 100%;">
+          卡片 3 - 警告颜色
+        </div>
+        <div class="demo-box" id="card4" style="background: #ef4444; width: 100%;">
+          卡片 4 - 错误颜色
+        </div>
+      </div>
+      <div class="code-block">/* 自动选择对比度最高的文字颜色 */
+.card {
+  background-color: var(--card-color);
+  color: color-contrast(var(--card-color) vs white, black);
+}</div>
+    </div>
+
+    <!-- 代码示例 -->
+    <div class="section">
+      <h2>JavaScript 模拟实现</h2>
+      <div class="code-block">// 计算相对亮度
+function getLuminance(r, g, b) {
+  const [rs, gs, bs] = [r, g, b].map(c => {
+    c = c / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  });
+  return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+}
+
+// 计算对比度
+function getContrastRatio(color1, color2) {
+  const l1 = getLuminance(...color1);
+  const l2 = getLuminance(...color2);
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+}
+
+// 模拟 color-contrast()
+function colorContrast(bgColor, candidates) {
+  const bg = hexToRgb(bgColor);
+  let best = candidates[0];
+  let bestRatio = 0;
+  
+  for (const candidate of candidates) {
+    const ratio = getContrastRatio(bg, hexToRgb(candidate));
+    if (ratio > bestRatio) {
+      bestRatio = ratio;
+      best = candidate;
+    }
+  }
+  
+  return { color: best, ratio: bestRatio };
+}</div>
+    </div>
+  </div>
+
+  <script>
+    // 颜色转换辅助函数
+    function hexToRgb(hex) {
+      const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+      return result ? [
+        parseInt(result[1], 16),
+        parseInt(result[2], 16),
+        parseInt(result[3], 16)
+      ] : [0, 0, 0];
+    }
+    
+    function rgbToHex(r, g, b) {
+      return '#' + [r, g, b].map(x => {
+        const hex = x.toString(16);
+        return hex.length === 1 ? '0' + hex : hex;
+      }).join('');
+    }
+    
+    // 计算相对亮度
+    function getLuminance(r, g, b) {
+      const [rs, gs, bs] = [r, g, b].map(c => {
+        c = c / 255;
+        return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+      });
+      return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+    }
+    
+    // 计算对比度
+    function getContrastRatio(color1, color2) {
+      const l1 = getLuminance(...color1);
+      const l2 = getLuminance(...color2);
+      return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+    }
+    
+    // 模拟 color-contrast
+    function colorContrast(bgHex, candidates) {
+      const bg = hexToRgb(bgHex);
+      let best = candidates[0];
+      let bestRatio = 0;
+      
+      for (const candidate of candidates) {
+        const ratio = getContrastRatio(bg, hexToRgb(candidate));
+        if (ratio > bestRatio) {
+          bestRatio = ratio;
+          best = candidate;
+        }
+      }
+      
+      return { color: best, ratio: bestRatio };
+    }
+    
+    // 更新演示
+    function updateDemo() {
+      const bgColor = document.getElementById('bg-color').value;
+      const result = colorContrast(bgColor, ['white', 'black']);
+      
+      document.getElementById('contrast-demo').style.background = bgColor;
+      document.getElementById('contrast-demo').style.color = result.color;
+      document.getElementById('code-bg').textContent = bgColor.toUpperCase();
+      document.getElementById('contrast-ratio').textContent = result.ratio.toFixed(2);
+      document.getElementById('result-text').textContent = result.color === '#ffffff' ? 'white' : 'black';
+    }
+    
+    document.getElementById('bg-color').addEventListener('input', updateDemo);
+    
+    // 多颜色演示
+    function updateMultiDemo() {
+      const bgColor = '#4CAF50';
+      const result = colorContrast(bgColor, ['white', 'black', '#ffeb3b', '#e91e63']);
+      
+      document.getElementById('multi-demo').style.background = bgColor;
+      document.getElementById('multi-demo').style.color = result.color;
+      document.getElementById('multi-bg').textContent = bgColor;
+    }
+    
+    updateMultiDemo();
+    
+    // 卡片演示
+    function updateCards() {
+      const cards = [
+        { id: 'card1', color: '#0066cc' },
+        { id: 'card2', color: '#22c55e' },
+        { id: 'card3', color: '#f59e0b' },
+        { id: 'card4', color: '#ef4444' }
+      ];
+      
+      cards.forEach(card => {
+        const result = colorContrast(card.color, ['white', 'black']);
+        const el = document.getElementById(card.id);
+        el.style.background = card.color;
+        el.style.color = result.color;
+      });
+    }
+    
+    updateCards();
+  </script>
+</body>
+</html>

--- a/examples/css/demos/color-mix/index.html
+++ b/examples/css/demos/color-mix/index.html
@@ -27,6 +27,11 @@
     .slider { flex: 1; -webkit-appearance: none; height: 6px; background: #30363d; border-radius: 3px; outline: none; }
     .slider::-webkit-slider-thumb { -webkit-appearance: none; width: 16px; height: 16px; background: #58a6ff; border-radius: 50%; cursor: pointer; }
     .slider-value { min-width: 50px; text-align: center; font-size: 12px; color: #79c0ff; }
+<<<<<<< Updated upstream
+=======
+    .color-strip { display: flex; width: 100%; height: 60px; border-radius: 4px; overflow: hidden; margin: 12px 0; }
+    .color-strip-item { display: flex; align-items: center; justify-content: center; font-size: 11px; color: white; text-shadow: 0 1px 2px rgba(0,0,0,0.5); }
+>>>>>>> Stashed changes
   </style>
 </head>
 <body>
@@ -34,6 +39,10 @@
     <h1>CSS color-mix() 颜色混合函数</h1>
     <p class="subtitle">CSS Color Level 5 规范 | 交互演示</p>
 
+<<<<<<< Updated upstream
+=======
+    <!-- 基础用法 -->
+>>>>>>> Stashed changes
     <div class="section">
       <h2>基础用法 — 50% 混合</h2>
       <div class="demo-area">
@@ -41,10 +50,19 @@
         <div class="color-box large" id="mixed" style="background: rgb(128, 0, 128);">Mixed</div>
         <div class="color-box" style="background: red;">Red</div>
       </div>
+<<<<<<< Updated upstream
       <div class="code-block">color-mix(in srgb, blue 50%, red);</div>
       <p class="desc"><span class="tag">srgb</span> 是默认颜色空间。50% 表示两种颜色各占一半。</p>
     </div>
 
+=======
+      <div class="code-block">/* 50% 混合，默认使用 srgb 颜色空间 */
+color-mix(in srgb, blue 50%, red);</div>
+      <p class="desc"><span class="tag">srgb</span> 是默认颜色空间，也是最常用的。50% 表示两种颜色各占一半。</p>
+    </div>
+
+    <!-- 混合比例调整 -->
+>>>>>>> Stashed changes
     <div class="section">
       <h2>混合比例调整</h2>
       <div class="slider-container">
@@ -58,8 +76,15 @@
         <div class="color-box" style="background: red;">Red</div>
       </div>
       <div class="code-block" id="ratio-code">color-mix(in srgb, blue 30%, red);</div>
+<<<<<<< Updated upstream
     </div>
 
+=======
+      <p class="desc">拖动滑块调整蓝色和红色的混合比例。</p>
+    </div>
+
+    <!-- 不同颜色空间 -->
+>>>>>>> Stashed changes
     <div class="section">
       <h2>不同颜色空间对比</h2>
       <div class="controls" id="colorspace-controls">
@@ -69,12 +94,22 @@
         <button class="btn" data-space="lab">lab</button>
       </div>
       <div class="demo-area" style="justify-content: center;">
+<<<<<<< Updated upstream
         <div class="color-box large" id="space-result" style="background: rgb(128, 68, 0);">50/50</div>
       </div>
       <div class="code-block" id="space-code">color-mix(in srgb, #0000ff 50%, #ff8800);</div>
       <p class="desc"><span class="tag">oklch</span> 和 <span class="tag">lab</span> 提供更符合人眼感知的混合效果。</p>
     </div>
 
+=======
+        <div class="color-box" id="space-result" style="background: rgb(128, 68, 0);">50/50</div>
+      </div>
+      <div class="code-block" id="space-code">color-mix(in srgb, #0000ff 50%, #ff8800);</div>
+      <p class="desc"><span class="tag">srgb</span> 最常用但混合可能不自然。<span class="tag">oklch</span> 和 <span class="tag">lab</span> 提供更符合人眼感知的混合效果。</p>
+    </div>
+
+    <!-- 主题色生成 -->
+>>>>>>> Stashed changes
     <div class="section">
       <h2>实际应用：主题色变体生成</h2>
       <div class="demo-area">
@@ -82,7 +117,13 @@
         <div class="color-box" id="theme-lighter" style="background: rgb(204, 229, 255); color: #333;">Lighter</div>
         <div class="color-box" id="theme-darker" style="background: rgb(0, 62, 153);">Darker</div>
       </div>
+<<<<<<< Updated upstream
       <div class="code-block">--primary-lighter: color-mix(in srgb, var(--primary) 20%, white);
+=======
+      <div class="code-block">/* 基于主题色生成浅色和深色变体 */
+--primary: #007bff;
+--primary-lighter: color-mix(in srgb, var(--primary) 20%, white);
+>>>>>>> Stashed changes
 --primary-darker: color-mix(in srgb, var(--primary) 70%, black);</div>
       <div class="controls" style="margin-top: 12px;">
         <button class="btn" id="theme-blue">蓝色</button>
@@ -91,9 +132,17 @@
       </div>
     </div>
 
+<<<<<<< Updated upstream
     <div class="section">
       <h2>浏览器兼容性</h2>
       <div class="info">
+=======
+    <!-- 浏览器兼容性 -->
+    <div class="section">
+      <h2>浏览器兼容性</h2>
+      <div class="info">
+        <p><strong>支持版本：</strong></p>
+>>>>>>> Stashed changes
         <ul style="font-size: 12px; color: #8b949e; margin-top: 8px; padding-left: 20px;">
           <li>Chrome 111+ ✓</li>
           <li>Firefox 113+ ✓</li>
@@ -105,9 +154,17 @@
   </div>
 
   <script>
+<<<<<<< Updated upstream
     const mixed = document.getElementById('mixed');
     mixed.style.background = 'color-mix(in srgb, blue 50%, red)';
 
+=======
+    // 基础混合示例
+    const mixed = document.getElementById('mixed');
+    mixed.style.background = 'color-mix(in srgb, blue 50%, red)';
+
+    // 比例滑块
+>>>>>>> Stashed changes
     const slider = document.getElementById('ratio-slider');
     const bluePercent = document.getElementById('blue-percent');
     const redPercent = document.getElementById('red-percent');
@@ -123,6 +180,10 @@
       ratioCode.textContent = `color-mix(in srgb, blue ${blue}%, red);`;
     });
 
+<<<<<<< Updated upstream
+=======
+    // 颜色空间切换
+>>>>>>> Stashed changes
     const colorspaceBtns = document.querySelectorAll('#colorspace-controls .btn');
     const spaceResult = document.getElementById('space-result');
     const spaceCode = document.getElementById('space-code');
@@ -137,6 +198,10 @@
       });
     });
 
+<<<<<<< Updated upstream
+=======
+    // 主题色切换
+>>>>>>> Stashed changes
     const themes = {
       blue: { primary: '#007bff', lighter: 'rgb(204, 229, 255)', darker: 'rgb(0, 62, 153)' },
       green: { primary: '#22c55e', lighter: 'rgb(198, 236, 209)', darker: 'rgb(13, 71, 38)' },

--- a/examples/css/demos/color-mix/index.html
+++ b/examples/css/demos/color-mix/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS color-mix() 颜色混合函数 - 交互演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 13px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { display: flex; gap: 16px; min-height: 120px; padding: 20px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; align-items: center; flex-wrap: wrap; }
+    .color-box { width: 80px; height: 80px; border-radius: 8px; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; color: white; text-shadow: 0 1px 2px rgba(0,0,0,0.5); flex-shrink: 0; }
+    .color-box.large { width: 120px; height: 120px; font-size: 14px; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; align-items: center; }
+    .btn { padding: 6px 12px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .desc { font-size: 12px; color: #6e7681; margin-top: 8px; line-height: 1.6; }
+    .info { font-size: 12px; color: #8b949e; margin-top: 12px; }
+    .tag { display: inline-block; padding: 2px 6px; border-radius: 3px; font-size: 11px; background: #388bfd33; color: #58a6ff; margin-right: 4px; }
+    .slider-container { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
+    .slider { flex: 1; -webkit-appearance: none; height: 6px; background: #30363d; border-radius: 3px; outline: none; }
+    .slider::-webkit-slider-thumb { -webkit-appearance: none; width: 16px; height: 16px; background: #58a6ff; border-radius: 50%; cursor: pointer; }
+    .slider-value { min-width: 50px; text-align: center; font-size: 12px; color: #79c0ff; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS color-mix() 颜色混合函数</h1>
+    <p class="subtitle">CSS Color Level 5 规范 | 交互演示</p>
+
+    <div class="section">
+      <h2>基础用法 — 50% 混合</h2>
+      <div class="demo-area">
+        <div class="color-box" style="background: blue;">Blue</div>
+        <div class="color-box large" id="mixed" style="background: rgb(128, 0, 128);">Mixed</div>
+        <div class="color-box" style="background: red;">Red</div>
+      </div>
+      <div class="code-block">color-mix(in srgb, blue 50%, red);</div>
+      <p class="desc"><span class="tag">srgb</span> 是默认颜色空间。50% 表示两种颜色各占一半。</p>
+    </div>
+
+    <div class="section">
+      <h2>混合比例调整</h2>
+      <div class="slider-container">
+        <span style="font-size: 12px; color: #58a6ff;">Blue: <span id="blue-percent">30</span>%</span>
+        <input type="range" class="slider" id="ratio-slider" min="0" max="100" value="30">
+        <span style="font-size: 12px; color: #f85149;">Red: <span id="red-percent">70</span>%</span>
+      </div>
+      <div class="demo-area">
+        <div class="color-box" style="background: blue;">Blue</div>
+        <div class="color-box large" id="ratio-result" style="background: rgb(179, 0, 76);">Mixed</div>
+        <div class="color-box" style="background: red;">Red</div>
+      </div>
+      <div class="code-block" id="ratio-code">color-mix(in srgb, blue 30%, red);</div>
+    </div>
+
+    <div class="section">
+      <h2>不同颜色空间对比</h2>
+      <div class="controls" id="colorspace-controls">
+        <button class="btn active" data-space="srgb">srgb</button>
+        <button class="btn" data-space="hsl">hsl</button>
+        <button class="btn" data-space="oklch">oklch</button>
+        <button class="btn" data-space="lab">lab</button>
+      </div>
+      <div class="demo-area" style="justify-content: center;">
+        <div class="color-box large" id="space-result" style="background: rgb(128, 68, 0);">50/50</div>
+      </div>
+      <div class="code-block" id="space-code">color-mix(in srgb, #0000ff 50%, #ff8800);</div>
+      <p class="desc"><span class="tag">oklch</span> 和 <span class="tag">lab</span> 提供更符合人眼感知的混合效果。</p>
+    </div>
+
+    <div class="section">
+      <h2>实际应用：主题色变体生成</h2>
+      <div class="demo-area">
+        <div class="color-box large" id="theme-primary" style="background: #007bff;">Primary</div>
+        <div class="color-box" id="theme-lighter" style="background: rgb(204, 229, 255); color: #333;">Lighter</div>
+        <div class="color-box" id="theme-darker" style="background: rgb(0, 62, 153);">Darker</div>
+      </div>
+      <div class="code-block">--primary-lighter: color-mix(in srgb, var(--primary) 20%, white);
+--primary-darker: color-mix(in srgb, var(--primary) 70%, black);</div>
+      <div class="controls" style="margin-top: 12px;">
+        <button class="btn" id="theme-blue">蓝色</button>
+        <button class="btn" id="theme-green">绿色</button>
+        <button class="btn" id="theme-purple">紫色</button>
+      </div>
+    </div>
+
+    <div class="section">
+      <h2>浏览器兼容性</h2>
+      <div class="info">
+        <ul style="font-size: 12px; color: #8b949e; margin-top: 8px; padding-left: 20px;">
+          <li>Chrome 111+ ✓</li>
+          <li>Firefox 113+ ✓</li>
+          <li>Safari 16.2+ ✓</li>
+          <li>Edge 111+ ✓</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const mixed = document.getElementById('mixed');
+    mixed.style.background = 'color-mix(in srgb, blue 50%, red)';
+
+    const slider = document.getElementById('ratio-slider');
+    const bluePercent = document.getElementById('blue-percent');
+    const redPercent = document.getElementById('red-percent');
+    const ratioResult = document.getElementById('ratio-result');
+    const ratioCode = document.getElementById('ratio-code');
+
+    slider.addEventListener('input', (e) => {
+      const blue = e.target.value;
+      const red = 100 - blue;
+      bluePercent.textContent = blue;
+      redPercent.textContent = red;
+      ratioResult.style.background = `color-mix(in srgb, blue ${blue}%, red)`;
+      ratioCode.textContent = `color-mix(in srgb, blue ${blue}%, red);`;
+    });
+
+    const colorspaceBtns = document.querySelectorAll('#colorspace-controls .btn');
+    const spaceResult = document.getElementById('space-result');
+    const spaceCode = document.getElementById('space-code');
+
+    colorspaceBtns.forEach(btn => {
+      btn.addEventListener('click', () => {
+        colorspaceBtns.forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        const space = btn.dataset.space;
+        spaceResult.style.background = `color-mix(in ${space}, #0000ff 50%, #ff8800)`;
+        spaceCode.textContent = `color-mix(in ${space}, #0000ff 50%, #ff8800);`;
+      });
+    });
+
+    const themes = {
+      blue: { primary: '#007bff', lighter: 'rgb(204, 229, 255)', darker: 'rgb(0, 62, 153)' },
+      green: { primary: '#22c55e', lighter: 'rgb(198, 236, 209)', darker: 'rgb(13, 71, 38)' },
+      purple: { primary: '#a855f7', lighter: 'rgb(233, 213, 255)', darker: 'rgb(88, 28, 135)' }
+    };
+
+    document.getElementById('theme-blue').addEventListener('click', () => {
+      const colors = themes.blue;
+      document.getElementById('theme-primary').style.background = colors.primary;
+      document.getElementById('theme-lighter').style.background = colors.lighter;
+      document.getElementById('theme-darker').style.background = colors.darker;
+    });
+
+    document.getElementById('theme-green').addEventListener('click', () => {
+      const colors = themes.green;
+      document.getElementById('theme-primary').style.background = colors.primary;
+      document.getElementById('theme-lighter').style.background = colors.lighter;
+      document.getElementById('theme-darker').style.background = colors.darker;
+    });
+
+    document.getElementById('theme-purple').addEventListener('click', () => {
+      const colors = themes.purple;
+      document.getElementById('theme-primary').style.background = colors.primary;
+      document.getElementById('theme-lighter').style.background = colors.lighter;
+      document.getElementById('theme-darker').style.background = colors.darker;
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/gap-decorations/index.html
+++ b/examples/css/demos/gap-decorations/index.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS gap 装饰与间距技巧 - 交互演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 13px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .section h3 { font-size: 14px; color: #8b949e; margin: 16px 0 8px; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; align-items: center; }
+    .btn { padding: 6px 12px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .slider-container { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
+    .slider { flex: 1; -webkit-appearance: none; height: 6px; background: #30363d; border-radius: 3px; outline: none; }
+    .slider::-webkit-slider-thumb { -webkit-appearance: none; width: 16px; height: 16px; background: #58a6ff; border-radius: 50%; cursor: pointer; }
+    .desc { font-size: 12px; color: #6e7681; margin-top: 8px; line-height: 1.6; }
+    .tag { display: inline-block; padding: 2px 6px; border-radius: 3px; font-size: 11px; background: #388bfd33; color: #58a6ff; margin-right: 4px; }
+    
+    /* 演示容器 */
+    .demo-box { background: #21262d; border-radius: 8px; padding: 16px; }
+    .demo-grid { display: grid; grid-template-columns: repeat(3, 1fr); background: #0d1117; border-radius: 8px; }
+    .demo-item { padding: 20px; background: #388bfd33; border-radius: 4px; text-align: center; font-size: 14px; font-weight: 600; color: #58a6ff; }
+    
+    .flex-demo { display: flex; flex-wrap: wrap; background: #0d1117; border-radius: 8px; }
+    .flex-item { width: calc(33.33% - 8px); padding: 20px; background: #3fb95033; border-radius: 4px; text-align: center; font-size: 14px; font-weight: 600; color: #3fb950; }
+    
+    .border-demo { display: flex; flex-direction: column; gap: 0; background: #0d1117; border-radius: 8px; overflow: hidden; }
+    .border-item { padding: 16px; background: #21262d; font-size: 14px; border-bottom: 1px solid #30363d; }
+    .border-item:last-child { border-bottom: none; }
+    
+    .gradient-demo { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0; background: linear-gradient(90deg, #667eea, #764ba2); padding: 2px; border-radius: 8px; }
+    .gradient-item { background: white; padding: 20px; text-align: center; font-size: 14px; font-weight: 600; }
+    .gradient-item:first-child { border-radius: 6px 0 0 6px; }
+    .gradient-item:last-child { border-radius: 0 6px 6px 0; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS gap 装饰与间距技巧</h1>
+    <p class="subtitle">gap | row-gap | column-gap | 交互演示</p>
+
+    <!-- Gap 大小调整 -->
+    <div class="section">
+      <h2>Gap 大小调整</h2>
+      <div class="slider-container">
+        <span style="font-size: 12px; color: #8b949e;">Gap:</span>
+        <input type="range" class="slider" id="gap-slider" min="0" max="40" value="16">
+        <span id="gap-value" style="font-size: 12px; color: #79c0ff; min-width: 40px;">16px</span>
+      </div>
+      <div class="demo-grid demo-box" id="gap-demo" style="gap: 16px;">
+        <div class="demo-item">1</div>
+        <div class="demo-item">2</div>
+        <div class="demo-item">3</div>
+        <div class="demo-item">4</div>
+        <div class="demo-item">5</div>
+        <div class="demo-item">6</div>
+      </div>
+      <div class="code-block" id="gap-code">gap: 16px;</div>
+    </div>
+
+    <!-- Flex Gap 演示 -->
+    <div class="section">
+      <h2>Flexbox Gap</h2>
+      <div class="demo-flex flex-demo" id="flex-demo" style="gap: 16px;">
+        <div class="flex-item">项目 1</div>
+        <div class="flex-item">项目 2</div>
+        <div class="flex-item">项目 3</div>
+        <div class="flex-item">项目 4</div>
+        <div class="flex-item">项目 5</div>
+        <div class="flex-item">项目 6</div>
+      </div>
+      <div class="code-block">.flex-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}</div>
+    </div>
+
+    <!-- 边框装饰 -->
+    <div class="section">
+      <h2>边框装饰技巧</h2>
+      <div class="demo-box">
+        <div class="border-demo" id="border-demo" style="gap: 0;">
+          <div class="border-item">卡片 1</div>
+          <div class="border-item">卡片 2</div>
+          <div class="border-item">卡片 3</div>
+        </div>
+      </div>
+      <div class="code-block">.card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.card {
+  padding: 16px;
+  border-bottom: 1px solid #30363d;
+}
+
+.card:last-child {
+  border-bottom: none;
+}</div>
+    </div>
+
+    <!-- 渐变边框 -->
+    <div class="section">
+      <h2>渐变边框装饰</h2>
+      <div class="gradient-demo" id="gradient-demo" style="gap: 0;">
+        <div class="gradient-item">区域 1</div>
+        <div class="gradient-item">区域 2</div>
+        <div class="gradient-item">区域 3</div>
+      </div>
+      <div class="code-block">.gradient-container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+  background: linear-gradient(90deg, #667eea, #764ba2);
+  padding: 2px;
+  border-radius: 8px;
+}
+
+.gradient-item {
+  background: white;
+  padding: 20px;
+}</div>
+    </div>
+
+    <!-- 分别设置行列间距 -->
+    <div class="section">
+      <h2>行列间距分别设置</h2>
+      <div class="slider-container">
+        <span style="font-size: 12px; color: #8b949e;">行间距:</span>
+        <input type="range" class="slider" id="row-gap-slider" min="0" max="40" value="16">
+        <span id="row-gap-value" style="font-size: 12px; color: #79c0ff; min-width: 40px;">16px</span>
+      </div>
+      <div class="slider-container">
+        <span style="font-size: 12px; color: #8b949e;">列间距:</span>
+        <input type="range" class="slider" id="col-gap-slider" min="0" max="40" value="24">
+        <span id="col-gap-value" style="font-size: 12px; color: #79c0ff; min-width: 40px;">24px</span>
+      </div>
+      <div class="demo-grid demo-box" id="row-col-demo" style="gap: 16px 24px;">
+        <div class="demo-item">1</div>
+        <div class="demo-item">2</div>
+        <div class="demo-item">3</div>
+        <div class="demo-item">4</div>
+        <div class="demo-item">5</div>
+        <div class="demo-item">6</div>
+      </div>
+      <div class="code-block" id="row-col-code">gap: 16px 24px; /* row-gap column-gap */</div>
+    </div>
+
+    <!-- 浏览器兼容性 -->
+    <div class="section">
+      <h2>浏览器兼容性</h2>
+      <div class="desc">
+        <ul style="font-size: 12px; color: #8b949e; margin-top: 8px; padding-left: 20px;">
+          <li>Chrome 66+ (Flexbox), 84+ (Grid) ✓</li>
+          <li>Firefox 61+ (Flexbox), 66+ (Grid) ✓</li>
+          <li>Safari 12+ (Flexbox), 16+ (Grid) ✓</li>
+          <li>Edge 79+ ✓</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // Gap 滑块
+    const gapSlider = document.getElementById('gap-slider');
+    const gapValue = document.getElementById('gap-value');
+    const gapDemo = document.getElementById('gap-demo');
+    const gapCode = document.getElementById('gap-code');
+    
+    gapSlider.addEventListener('input', (e) => {
+      const value = e.target.value;
+      gapValue.textContent = value + 'px';
+      gapDemo.style.gap = value + 'px';
+      gapCode.textContent = `gap: ${value}px;`;
+    });
+    
+    // Flex Gap 演示
+    const flexDemo = document.getElementById('flex-demo');
+    const flexItems = flexDemo.querySelectorAll('.flex-item');
+    
+    // 动态调整 flex-item 宽度以适应 gap
+    function updateFlexItems() {
+      const gap = parseInt(gapSlider.value);
+      flexItems.forEach(item => {
+        item.style.width = `calc(33.33% - ${gap * 2}px)`;
+      });
+    }
+    
+    gapSlider.addEventListener('input', updateFlexItems);
+    updateFlexItems();
+    
+    // 行间距和列间距
+    const rowGapSlider = document.getElementById('row-gap-slider');
+    const colGapSlider = document.getElementById('col-gap-slider');
+    const rowGapValue = document.getElementById('row-gap-value');
+    const colGapValue = document.getElementById('col-gap-value');
+    const rowColDemo = document.getElementById('row-col-demo');
+    const rowColCode = document.getElementById('row-col-code');
+    
+    rowGapSlider.addEventListener('input', updateRowCol);
+    colGapSlider.addEventListener('input', updateRowCol);
+    
+    function updateRowCol() {
+      const rowGap = rowGapSlider.value;
+      const colGap = colGapSlider.value;
+      rowGapValue.textContent = rowGap + 'px';
+      colGapValue.textContent = colGap + 'px';
+      rowColDemo.style.gap = rowGap + 'px ' + colGap + 'px';
+      rowColCode.textContent = `gap: ${rowGap}px ${colGap}px; /* row-gap column-gap */`;
+    }
+  </script>
+</body>
+</html>

--- a/examples/css/demos/grid-template-areas/index.html
+++ b/examples/css/demos/grid-template-areas/index.html
@@ -1,0 +1,304 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS grid-template-areas 可视化布局 - 交互演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 13px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .section h3 { font-size: 14px; color: #8b949e; margin: 16px 0 8px; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; align-items: center; }
+    .btn { padding: 6px 12px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .desc { font-size: 12px; color: #6e7681; margin-top: 8px; line-height: 1.6; }
+    .tag { display: inline-block; padding: 2px 6px; border-radius: 3px; font-size: 11px; background: #388bfd33; color: #58a6ff; margin-right: 4px; }
+    
+    /* Grid 布局演示 */
+    .grid-demo {
+      display: grid;
+      gap: 8px;
+      min-height: 280px;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    
+    .grid-item {
+      background: #21262d;
+      border-radius: 4px;
+      padding: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      font-weight: 600;
+      color: #f0f6fc;
+      transition: all 0.3s;
+    }
+    
+    .grid-item:hover {
+      background: #30363d;
+    }
+    
+    /* 布局模板可视化 */
+    .template-viz {
+      display: grid;
+      gap: 2px;
+      background: #0d1117;
+      border-radius: 4px;
+      padding: 8px;
+      margin-bottom: 16px;
+      font-family: 'SF Mono', Monaco, monospace;
+      font-size: 11px;
+    }
+    
+    .template-viz .cell {
+      padding: 4px 8px;
+      background: #21262d;
+      border-radius: 2px;
+      text-align: center;
+      color: #79c0ff;
+    }
+    
+    .template-viz .header { background: #388bfd33; color: #58a6ff; }
+    .template-viz .sidebar { background: #a371f733; color: #a371f7; }
+    .template-viz .main { background: #3fb95033; color: #3fb950; }
+    .template-viz .footer { background: #f0883e33; color: #f0883e; }
+    .template-viz .empty { background: transparent; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS grid-template-areas 可视化布局</h1>
+    <p class="subtitle">CSS Grid 布局 | 交互演示</p>
+
+    <!-- 模板可视化 -->
+    <div class="section">
+      <h2>布局模板可视化</h2>
+      <div class="template-viz" id="template-viz" style="grid-template-columns: repeat(3, 1fr);">
+        <div class="cell header">header</div>
+        <div class="cell header">header</div>
+        <div class="cell header">header</div>
+        <div class="cell sidebar">sidebar</div>
+        <div class="cell main">main</div>
+        <div class="cell main">main</div>
+        <div class="cell footer">footer</div>
+        <div class="cell footer">footer</div>
+        <div class="cell footer">footer</div>
+      </div>
+      <div class="code-block" id="grid-code">grid-template-areas:
+  "header header header"
+  "sidebar main main"
+  "footer footer footer";</div>
+    </div>
+
+    <!-- 布局切换 -->
+    <div class="section">
+      <h2>布局模板切换</h2>
+      <div class="controls">
+        <button class="btn active" data-layout="classic">经典布局</button>
+        <button class="btn" data-layout="holy-grail">圣杯布局</button>
+        <button class="btn" data-layout="dashboard">仪表盘</button>
+        <button class="btn" data-layout="blog">博客布局</button>
+      </div>
+      <div class="grid-demo" id="layout-demo" style="grid-template-columns: repeat(3, 1fr); grid-template-areas:
+        'header header header'
+        'sidebar main main'
+        'footer footer footer';">
+        <div class="grid-item" style="grid-area: header; background: #388bfd33;">Header</div>
+        <div class="grid-item" style="grid-area: sidebar; background: #a371f733;">Sidebar</div>
+        <div class="grid-item" style="grid-area: main; background: #3fb95033;">Main Content</div>
+        <div class="grid-item" style="grid-area: footer; background: #f0883e33;">Footer</div>
+      </div>
+      <div class="code-block" id="layout-code">grid-template-areas:
+  "header header header"
+  "sidebar main main"
+  "footer footer footer";</div>
+    </div>
+
+    <!-- 响应式布局 -->
+    <div class="section">
+      <h2>响应式布局演示</h2>
+      <div class="controls">
+        <button class="btn" id="mobile-btn">移动端视图</button>
+        <button class="btn" id="desktop-btn">桌面端视图</button>
+      </div>
+      <div class="grid-demo" id="responsive-demo" style="grid-template-columns: 1fr; grid-template-areas:
+        'header'
+        'main'
+        'sidebar'
+        'footer';">
+        <div class="grid-item" style="grid-area: header;">Header</div>
+        <div class="grid-item" style="grid-area: main;">Main</div>
+        <div class="grid-item" style="grid-area: sidebar;">Sidebar</div>
+        <div class="grid-item" style="grid-area: footer;">Footer</div>
+      </div>
+      <p class="desc"><span class="tag">提示</span> 点击按钮切换移动端和桌面端视图，观察 grid-template-areas 的变化。</p>
+    </div>
+
+    <!-- 完整代码示例 -->
+    <div class="section">
+      <h2>完整代码示例</h2>
+      <div class="code-block">/* 1. 定义网格容器 */
+.page {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    "header header"
+    "sidebar content"
+    "footer footer";
+  min-height: 100vh;
+  gap: 16px;
+}
+
+/* 2. 将元素分配到区域 */
+.header {
+  grid-area: header;
+  background: #388bfd;
+}
+
+.sidebar {
+  grid-area: sidebar;
+  background: #a371f7;
+}
+
+.main {
+  grid-area: content;
+  background: #3fb950;
+}
+
+.footer {
+  grid-area: footer;
+  background: #f0883e;
+}
+
+/* 3. 响应式调整 */
+@media (max-width: 768px) {
+  .page {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      "header"
+      "main"
+      "sidebar"
+      "footer";
+  }
+}</div>
+    </div>
+
+    <!-- 浏览器兼容性 -->
+    <div class="section">
+      <h2>浏览器兼容性</h2>
+      <div class="desc">
+        <ul style="font-size: 12px; color: #8b949e; margin-top: 8px; padding-left: 20px;">
+          <li>Chrome 57+ ✓</li>
+          <li>Firefox 52+ ✓</li>
+          <li>Safari 10.1+ ✓</li>
+          <li>Edge 16+ ✓</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // 布局模板配置
+    const layouts = {
+      classic: {
+        columns: 'repeat(3, 1fr)',
+        areas: `"header header header" "sidebar main main" "footer footer footer"`,
+        code: `grid-template-areas:
+  "header header header"
+  "sidebar main main"
+  "footer footer footer";`
+      },
+      'holy-grail': {
+        columns: 'auto 1fr auto',
+        areas: `"header header header" "nav main aside" "footer footer footer"`,
+        code: `grid-template-areas:
+  "header header header"
+  "nav main aside"
+  "footer footer footer";`
+      },
+      dashboard: {
+        columns: 'repeat(4, 1fr)',
+        areas: `"stats stats stats stats" "chart chart chart pie" "chart chart chart list"`,
+        code: `grid-template-areas:
+  "stats stats stats stats"
+  "chart chart chart pie"
+  "chart chart chart list";`
+      },
+      blog: {
+        columns: '1fr 300px',
+        areas: `"header header" "featured featured" "content sidebar" "footer footer"`,
+        code: `grid-template-areas:
+  "header header"
+  "featured featured"
+  "content sidebar"
+  "footer footer";`
+      }
+    };
+    
+    // 更新布局
+    function updateLayout(layoutName) {
+      const layout = layouts[layoutName];
+      const demo = document.getElementById('layout-demo');
+      const code = document.getElementById('layout-code');
+      
+      demo.style.gridTemplateColumns = layout.columns;
+      demo.style.gridTemplateAreas = layout.areas;
+      code.textContent = layout.code;
+      
+      // 更新模板可视化
+      updateTemplateViz(layout.areas);
+    }
+    
+    // 更新模板可视化
+    function updateTemplateViz(areas) {
+      const viz = document.getElementById('template-viz');
+      const rows = areas.trim().split('"').filter(s => s.trim() && !s.includes(' '));
+      
+      viz.style.gridTemplateColumns = `repeat(${rows[0].split(/\s+/).length}, 1fr)`;
+      viz.innerHTML = '';
+      
+      rows.forEach(row => {
+        const cells = row.trim().split(/\s+/);
+        cells.forEach(cell => {
+          const div = document.createElement('div');
+          div.className = `cell ${cell}`;
+          div.textContent = cell === '.' ? '' : cell;
+          viz.appendChild(div);
+        });
+      });
+    }
+    
+    // 布局按钮事件
+    document.querySelectorAll('[data-layout]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('[data-layout]').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        updateLayout(btn.dataset.layout);
+      });
+    });
+    
+    // 响应式布局切换
+    document.getElementById('mobile-btn').addEventListener('click', () => {
+      const demo = document.getElementById('responsive-demo');
+      demo.style.gridTemplateColumns = '1fr';
+      demo.style.gridTemplateAreas = `"header" "main" "sidebar" "footer"`;
+    });
+    
+    document.getElementById('desktop-btn').addEventListener('click', () => {
+      const demo = document.getElementById('responsive-demo');
+      demo.style.gridTemplateColumns = '200px 1fr 200px';
+      demo.style.gridTemplateAreas = `"header header header" "sidebar main aside" "footer footer footer"`;
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/houdini-animation-worklet/frame-sync-demo.html
+++ b/examples/css/demos/houdini-animation-worklet/frame-sync-demo.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Houdini Animation Worklet — 帧同步动画</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { border: 2px dashed #30363d; border-radius: 8px; padding: 40px; margin-bottom: 16px; display: flex; align-items: center; justify-content: center; min-height: 150px; position: relative; overflow: hidden; }
+    .anim-box { width: 80px; height: 80px; background: linear-gradient(135deg, #6366f1, #8b5cf6); border-radius: 12px; display: flex; align-items: center; justify-content: center; color: white; font-weight: 600; font-size: 14px; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 13px; color: #8b949e; margin-top: 12px; padding: 12px; background: rgba(88,166,255,0.1); border-radius: 4px; border-left: 3px solid #58a6ff; }
+    .warning { font-size: 13px; color: #f0883e; margin-bottom: 24px; padding: 12px; background: rgba(240,136,62,0.1); border-radius: 4px; border-left: 3px solid #f0883e; }
+    .controls { display: flex; gap: 8px; margin-top: 16px; }
+    .btn { padding: 8px 16px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 13px; cursor: pointer; }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Houdini Animation Worklet — 帧同步动画</h1>
+
+    <div class="warning">
+      ⚠️ Animation Worklet 需要通过 <strong>HTTP 服务器</strong> 访问。请用 <code>python -m http.server 8080</code> 启动。
+    </div>
+
+    <div class="section">
+      <h2>Worklet 实现</h2>
+      <div class="code-block">class FrameAnimator {
+  animate(currentTime, effect) {
+    const duration = 3000; // 3秒循环
+    const progress = (currentTime % duration) / duration;
+
+    let x, opacity;
+    if (progress < 0.25) {
+      // 0-25%: 滑入
+      const t = progress / 0.25;
+      const eased = 1 - Math.pow(1 - t, 3);
+      x = (eased - 1) * 100;
+      opacity = eased;
+    } else if (progress < 0.5) {
+      // 25-50%: 停留
+      x = 0; opacity = 1;
+    } else if (progress < 0.75) {
+      // 50-75%: 向右
+      const t = (progress - 0.5) / 0.25;
+      x = 30 * (1 - Math.pow(1 - t, 3));
+      opacity = 1;
+    } else {
+      // 75-100%: 淡出
+      const t = (progress - 0.75) / 0.25;
+      opacity = 1 - Math.pow(1 - t, 2);
+      x = 30 + t * 20;
+    }
+
+    effect.target.style.transform = `translateX(${x}px)`;
+    effect.target.style.opacity = opacity;
+  }
+}
+registerAnimator('frame', FrameAnimator);</div>
+    </div>
+
+    <div class="section">
+      <h2>动画演示（Fallback — CSS Animation）</h2>
+      <p style="font-size:13px;color:#8b949e;margin-bottom:12px;">
+        启用 Worklet 后使用 <code>WorkletAnimation</code> 播放，当前为 CSS Animation 降级演示
+      </p>
+      <div class="demo-area">
+        <div class="anim-box" id="animBox">动画</div>
+      </div>
+      <div class="controls">
+        <button class="btn" id="playBtn">▶ 播放</button>
+        <button class="btn" id="pauseBtn">⏸ 暂停</button>
+        <button class="btn" id="resetBtn">↺ 重置</button>
+      </div>
+      <div class="code-block">/* WorkletAnimation 方式 */
+const effect = new KeyframeEffect(elem, [], { duration: 0 });
+const anim = new WorkletAnimation('frame', effect);
+anim.play();</div>
+    </div>
+
+    <div class="section">
+      <h2>关键 API</h2>
+      <div class="info">
+        <strong>currentTime</strong>：由浏览器驱动的当前时间（毫秒）<br>
+        <strong>effect.target</strong>：动画关联的 DOM 元素<br>
+        <strong>currentTime % duration</strong>：取模实现循环动画<br>
+        <strong>WorkletAnimation</strong>：主线程接口，用于创建和管理 worklet 动画
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const box = document.getElementById('animBox');
+    const playBtn = document.getElementById('playBtn');
+    const pauseBtn = document.getElementById('pauseBtn');
+    const resetBtn = document.getElementById('resetBtn');
+
+    let anim;
+
+    // CSS Animation fallback
+    const keyframes = [
+      { transform: 'translateX(-100px)', opacity: 0 },
+      { transform: 'translateX(0)', opacity: 1, offset: 0.25 },
+      { transform: 'translateX(0)', opacity: 1, offset: 0.5 },
+      { transform: 'translateX(30px)', opacity: 1, offset: 0.75 },
+      { transform: 'translateX(50px)', opacity: 0 }
+    ];
+
+    anim = box.animate(keyframes, {
+      duration: 3000,
+      iterations: Infinity,
+      easing: 'linear'
+    });
+
+    playBtn.addEventListener('click', () => { anim.play(); playBtn.classList.add('active'); pauseBtn.classList.remove('active'); });
+    pauseBtn.addEventListener('click', () => { anim.pause(); pauseBtn.classList.add('active'); playBtn.classList.remove('active'); });
+    resetBtn.addEventListener('click', () => { anim.cancel(); anim.play(); });
+
+    // Worklet 版本
+    if ('animationWorklet' in CSS) {
+      CSS.animationWorklet.addModule('worklets/frame-animator.js').then(() => {
+        const effect = new KeyframeEffect(box, [], { duration: 0 });
+        const workletAnim = new WorkletAnimation('frame', effect);
+        // 实际使用 workletAnim 替代 CSS Animation
+      }).catch(e => console.warn('Worklet load failed:', e));
+    }
+  </script>
+</body>
+</html>

--- a/examples/css/demos/houdini-animation-worklet/index.html
+++ b/examples/css/demos/houdini-animation-worklet/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Houdini Animation Worklet — 示例总览</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 28px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 14px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .info { font-size: 13px; color: #8b949e; margin-bottom: 24px; padding: 12px; background: rgba(88,166,255,0.1); border-radius: 4px; border-left: 3px solid #58a6ff; }
+    .warning { font-size: 13px; color: #f0883e; margin-bottom: 24px; padding: 12px; background: rgba(240,136,62,0.1); border-radius: 4px; border-left: 3px solid #f0883e; }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }
+    .demo-card { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; transition: all 0.15s; cursor: pointer; text-decoration: none; color: inherit; display: block; }
+    .demo-card:hover { border-color: #58a6ff; transform: translateY(-2px); }
+    .demo-card h3 { font-size: 15px; color: #f0f6fc; margin-bottom: 8px; }
+    .demo-card p { font-size: 13px; color: #8b949e; line-height: 1.5; }
+    .demo-card .tag { display: inline-block; padding: 2px 8px; background: #21262d; border-radius: 4px; font-size: 11px; color: #58a6ff; margin-top: 8px; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 600; margin-right: 4px; }
+    .badge-yes { background: #238636; color: #fff; }
+    .badge-no { background: #da3633; color: #fff; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Houdini Animation Worklet</h1>
+    <p class="subtitle">通过 registerAnimator 注册自定义动画器，实现高性能的线程化动画</p>
+
+    <div class="warning">
+      ⚠️ Animation Worklet 需要通过 <strong>HTTP 服务器</strong> 或 <strong>localhost</strong> 访问。<br>
+      启动方式：<code>python -m http.server 8080</code> 或 <code>npx serve .</code>
+    </div>
+
+    <div class="info">
+      <strong>浏览器支持：</strong>
+      <span class="badge badge-yes">Chrome 84+</span>
+      <span class="badge badge-yes">Edge 84+</span>
+      <span class="badge badge-no">Firefox ❌</span>
+      <span class="badge badge-no">Safari ❌</span>
+    </div>
+
+    <div class="demo-grid">
+      <a class="demo-card" href="scroll-linked-demo.html">
+        <h3>滚动关联动画</h3>
+        <p>演示基于滚动位置触发的动画效果，Animation Worklet 运行在独立线程实现流畅的 scroll-linked 动画。</p>
+        <span class="tag">核心</span>
+      </a>
+
+      <a class="demo-card" href="frame-sync-demo.html">
+        <h3>帧同步动画</h3>
+        <p>演示基于时间轴的帧同步动画，包括滑入滑出、循环动画等模式。</p>
+        <span class="tag">进阶</span>
+      </a>
+    </div>
+
+    <div style="margin-top:32px;">
+      <h2 style="font-size:16px;color:#f0f6fc;margin-bottom:12px;">Worklet 文件</h2>
+      <ul style="font-size:13px;color:#8b949e;list-style:disc;padding-left:20px;line-height:2;">
+        <li><code>worklets/scroll-animator.js</code> — 滚动关联动画器</li>
+        <li><code>worklets/frame-animator.js</code> — 帧同步动画器</li>
+      </ul>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/houdini-animation-worklet/scroll-linked-demo.html
+++ b/examples/css/demos/houdini-animation-worklet/scroll-linked-demo.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Houdini Animation Worklet — 滚动关联动画</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .container { max-width: 960px; margin: 0 auto; padding: 24px; }
+    .info { font-size: 13px; color: #8b949e; margin-bottom: 24px; padding: 12px; background: rgba(88,166,255,0.1); border-radius: 4px; border-left: 3px solid #58a6ff; }
+    .warning { font-size: 13px; color: #f0883e; margin-bottom: 24px; padding: 12px; background: rgba(240,136,62,0.1); border-radius: 4px; border-left: 3px solid #f0883e; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; margin-top: 12px; }
+
+    /* 视差场景 */
+    .parallax-scene {
+      position: relative;
+      height: 300vh;
+      overflow: hidden;
+    }
+    .parallax-layer {
+      position: fixed;
+      left: 0;
+      right: 0;
+      height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 24px;
+      font-weight: bold;
+      color: white;
+    }
+    .layer-bg { background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%); z-index: 0; }
+    .layer-1 { background: linear-gradient(135deg, rgba(99,102,241,0.6) 0%, rgba(139,92,246,0.6) 100%); z-index: 1; }
+    .layer-2 { background: linear-gradient(135deg, rgba(236,72,153,0.6) 0%, rgba(249,115,22,0.6) 100%); z-index: 2; }
+    .layer-3 { background: linear-gradient(135deg, rgba(34,197,94,0.6) 0%, rgba(59,130,246,0.6) 100%); z-index: 3; }
+
+    /* 进度条 */
+    .progress-container {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 4px;
+      background: rgba(255,255,255,0.1);
+      z-index: 100;
+    }
+    .progress-bar {
+      height: 100%;
+      width: 0%;
+      background: linear-gradient(90deg, #6366f1, #ec4899);
+      transition: width 0.05s linear;
+    }
+
+    /* 说明面板 */
+    .info-panel {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      background: rgba(22,27,34,0.95);
+      border: 1px solid #30363d;
+      border-radius: 8px;
+      padding: 16px;
+      z-index: 99;
+      max-width: 300px;
+    }
+    .info-panel h3 { font-size: 14px; color: #f0f6fc; margin-bottom: 8px; }
+    .info-panel p { font-size: 12px; color: #8b949e; line-height: 1.5; }
+    .scroll-indicator {
+      text-align: center;
+      padding: 100px 20px;
+      color: #8b949e;
+    }
+  </style>
+</head>
+<body>
+  <div class="progress-container">
+    <div class="progress-bar" id="progressBar"></div>
+  </div>
+
+  <div class="parallax-scene" id="scene">
+    <div class="parallax-layer layer-bg">背景层</div>
+    <div class="parallax-layer layer-1" id="layer1">视差层 1 (0.3x)</div>
+    <div class="parallax-layer layer-2" id="layer2">视差层 2 (0.5x)</div>
+    <div class="parallax-layer layer-3" id="layer3">视差层 3 (0.8x)</div>
+  </div>
+
+  <div class="info-panel">
+    <h3>滚动视差效果</h3>
+    <p>向下滚动页面，各层以不同速度移动产生视差效果。<br><br>Animation Worklet 运行在独立线程，即使主线程繁忙也能保持流畅。</p>
+  </div>
+
+  <div class="scroll-indicator">
+    <p>↓ 向下滚动体验视差效果</p>
+  </div>
+
+  <script>
+    // Fallback: 使用 scroll 事件模拟视差
+    const layer1 = document.getElementById('layer1');
+    const layer2 = document.getElementById('layer2');
+    const layer3 = document.getElementById('layer3');
+    const progressBar = document.getElementById('progressBar');
+
+    let ticking = false;
+
+    function updateParallax() {
+      const scrollY = window.scrollY;
+      const maxScroll = document.body.scrollHeight - window.innerHeight;
+      const progress = maxScroll > 0 ? scrollY / maxScroll : 0;
+
+      progressBar.style.width = `${progress * 100}%`;
+      layer1.style.transform = `translateY(${progress * 300 * 0.3}px)`;
+      layer2.style.transform = `translateY(${progress * 300 * 0.5}px)`;
+      layer3.style.transform = `translateY(${progress * 300 * 0.8}px)`;
+
+      ticking = false;
+    }
+
+    window.addEventListener('scroll', () => {
+      if (!ticking) {
+        requestAnimationFrame(updateParallax);
+        ticking = true;
+      }
+    }, { passive: true });
+
+    // Animation Worklet 方式
+    if ('animationWorklet' in CSS) {
+      CSS.animationWorklet.addModule('worklets/scroll-animator.js').then(() => {
+        console.log('Animation Worklet loaded');
+        // Worklet 版本会在实际环境中生效
+        // 这里显示 fallback 说明
+      }).catch(e => console.warn('Worklet load failed:', e));
+    }
+  </script>
+</body>
+</html>

--- a/examples/css/demos/houdini-animation-worklet/worklets/frame-animator.js
+++ b/examples/css/demos/houdini-animation-worklet/worklets/frame-animator.js
@@ -1,0 +1,46 @@
+/**
+ * CSS Houdini Animation Worklet — Frame-Sync Animator
+ * 演示基于时间的帧同步动画
+ */
+class FrameAnimator {
+  animate(currentTime, effect) {
+    const duration = 3000; // 3秒循环
+    const cycleTime = currentTime % duration;
+    const progress = cycleTime / duration;
+
+    // 阶段 1 (0-25%): 从左侧滑入
+    // 阶段 2 (25-50%): 停留
+    // 阶段 3 (50-75%): 向右移动一点
+    // 阶段 4 (75-100%): 淡出并重置
+
+    let x, opacity;
+
+    if (progress < 0.25) {
+      // 滑入
+      const t = progress / 0.25;
+      const eased = 1 - Math.pow(1 - t, 3);
+      x = (eased - 1) * 100; // -100% -> 0
+      opacity = eased;
+    } else if (progress < 0.5) {
+      // 停留
+      x = 0;
+      opacity = 1;
+    } else if (progress < 0.75) {
+      // 向右移动
+      const t = (progress - 0.5) / 0.25;
+      const eased = 1 - Math.pow(1 - t, 3);
+      x = eased * 30;
+      opacity = 1;
+    } else {
+      // 淡出
+      const t = (progress - 0.75) / 0.25;
+      const eased = 1 - Math.pow(1 - t, 2);
+      x = 30 + eased * 20;
+      opacity = 1 - eased;
+    }
+
+    effect.target.style.transform = `translateX(${x}px)`;
+    effect.target.style.opacity = opacity;
+  }
+}
+registerAnimator('frame', FrameAnimator);

--- a/examples/css/demos/houdini-animation-worklet/worklets/scroll-animator.js
+++ b/examples/css/demos/houdini-animation-worklet/worklets/scroll-animator.js
@@ -1,0 +1,38 @@
+/**
+ * CSS Houdini Animation Worklet — Scroll-Linked Animator
+ */
+class ScrollAnimator {
+  animate(currentTime, effect) {
+    // 获取滚动位置
+    const scrollY = this.scrollOffset || 0;
+    const maxScroll = document.body.scrollHeight - window.innerHeight;
+    const progress = maxScroll > 0 ? scrollY / maxScroll : 0;
+
+    // 视差层 1: 移动速度 0.3
+    const layer1 = this.layers && this.layers[0];
+    if (layer1) {
+      const y = progress * 300 * 0.3;
+      layer1.style.transform = `translateY(${y}px)`;
+    }
+
+    // 视差层 2: 移动速度 0.5
+    const layer2 = this.layers && this.layers[1];
+    if (layer2) {
+      const y = progress * 300 * 0.5;
+      layer2.style.transform = `translateY(${y}px)`;
+    }
+
+    // 视差层 3: 移动速度 0.8
+    const layer3 = this.layers && this.layers[2];
+    if (layer3) {
+      const y = progress * 300 * 0.8;
+      layer3.style.transform = `translateY(${y}px)`;
+    }
+
+    // 进度指示器
+    if (this.progressBar) {
+      this.progressBar.style.width = `${progress * 100}%`;
+    }
+  }
+}
+registerAnimator('scroll', ScrollAnimator);

--- a/examples/css/demos/houdini-layout-api/centering-demo.html
+++ b/examples/css/demos/houdini-layout-api/centering-demo.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Houdini Layout API — 居中布局演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 13px; color: #8b949e; margin-top: 12px; padding: 12px; background: rgba(88,166,255,0.1); border-radius: 4px; border-left: 3px solid #58a6ff; }
+    .warning { font-size: 13px; color: #f0883e; margin-top: 12px; padding: 12px; background: rgba(240,136,62,0.1); border-radius: 4px; border-left: 3px solid #f0883e; }
+    .centering-container { display: flex; align-items: center; justify-content: center; width: 400px; height: 250px; border: 2px dashed #30363d; border-radius: 8px; }
+    .child-box { width: 80px; height: 80px; background: linear-gradient(135deg, #6366f1, #8b5cf6); border-radius: 8px; display: flex; align-items: center; justify-content: center; color: white; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Houdini Layout API — 居中布局</h1>
+
+    <div class="warning">
+      ⚠️ Layout API 需要在 Chrome/Edge 中开启实验性功能：<code>chrome://flags/#enable-experimental-web-platform-features</code>
+    </div>
+
+    <div class="section">
+      <h2>Worklet 实现</h2>
+      <div class="code-block">class CenteringLayout {
+  async layout(children, edges, constraints, styleMap) {
+    const availW = constraints.fixedInlineSize - edges.inline;
+    const availH = constraints.fixedBlockSize - edges.block;
+    const childFragments = [];
+    for (const child of children) {
+      const fragment = await child.layoutNextFragment({ availW, availH });
+      fragment.inlineOffset = edges.inlineStart + (availW - fragment.inlineSize) / 2;
+      fragment.blockOffset = edges.blockStart + (availH - fragment.blockSize) / 2;
+      childFragments.push(fragment);
+    }
+    return { autoBlockSize: availH, childFragments };
+  }
+}
+registerLayout('centering', CenteringLayout);</div>
+    </div>
+
+    <div class="section">
+      <h2>效果演示（Flexbox 模拟）</h2>
+      <div class="centering-container">
+        <div class="child-box">内容</div>
+      </div>
+      <div class="code-block">/* CSS */
+.center-container { display: layout(centering); }</div>
+    </div>
+
+    <div class="section">
+      <h2>关键参数</h2>
+      <div class="info">
+        <strong>constraints.fixedInlineSize</strong>：容器宽度<br>
+        <strong>edges.inline</strong>：左右 padding + border 之和<br>
+        <strong>fragment.inlineOffset/blockOffset</strong>：子元素 x/y 坐标
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/houdini-layout-api/equal-columns-demo.html
+++ b/examples/css/demos/houdini-layout-api/equal-columns-demo.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Houdini Layout API — 等分布局演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 13px; color: #8b949e; margin-top: 12px; padding: 12px; background: rgba(88,166,255,0.1); border-radius: 4px; border-left: 3px solid #58a6ff; }
+    .warning { font-size: 13px; color: #f0883e; margin-top: 12px; padding: 12px; background: rgba(240,136,62,0.1); border-radius: 4px; border-left: 3px solid #f0883e; }
+    .equal-container { display: flex; gap: 10px; width: 400px; padding: 10px; border: 2px dashed #30363d; border-radius: 8px; }
+    .equal-col { flex: 1; background: linear-gradient(135deg, #6366f1, #8b5cf6); border-radius: 6px; color: white; font-weight: 600; display: flex; align-items: center; justify-content: center; min-height: 80px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Houdini Layout API — 等分布局</h1>
+
+    <div class="warning">
+      ⚠️ Layout API 需要在 Chrome/Edge 中开启实验性功能：<code>chrome://flags/#enable-experimental-web-platform-features</code>
+    </div>
+
+    <div class="section">
+      <h2>Worklet 实现</h2>
+      <div class="code-block">class EqualColumnsLayout {
+  async layout(children, edges, constraints, styleMap) {
+    const availW = constraints.fixedInlineSize - edges.inline;
+    const gap = 10;
+    const childCount = children.length;
+    if (childCount === 0) return { autoBlockSize: 0, childFragments: [] };
+    const colW = (availW - gap * (childCount - 1)) / childCount;
+    const childFragments = [];
+    let maxH = 0;
+    for (let i = 0; i < children.length; i++) {
+      const f = await children[i].layoutNextFragment({ availableInlineSize: colW });
+      f.inlineOffset = edges.inlineStart + i * (colW + gap);
+      f.inlineSize = colW;
+      maxH = Math.max(maxH, f.blockSize);
+      childFragments.push(f);
+    }
+    return { autoBlockSize: maxH + edges.block, childFragments };
+  }
+}
+registerLayout('equal-columns', EqualColumnsLayout);</div>
+    </div>
+
+    <div class="section">
+      <h2>效果演示（Flexbox 模拟）</h2>
+      <div class="equal-container">
+        <div class="equal-col" style="height:80px;">列 1</div>
+        <div class="equal-col" style="height:120px;">列 2</div>
+        <div class="equal-col" style="height:60px;">列 3</div>
+        <div class="equal-col" style="height:100px;">列 4</div>
+      </div>
+      <div class="code-block">/* CSS */
+.equal-container { display: layout(equal-columns); }</div>
+    </div>
+
+    <div class="section">
+      <h2>关键参数</h2>
+      <div class="info">
+        <strong>availableInlineSize</strong>：可用宽度（容器宽 - 边框 - 间距）<br>
+        <strong>child.layoutNextFragment({ availableInlineSize })</strong>：让子元素在约束下布局<br>
+        <strong>fragment.inlineSize</strong>：子元素宽度，<strong>fragment.blockSize</strong>：高度
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/houdini-layout-api/index.html
+++ b/examples/css/demos/houdini-layout-api/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Houdini Layout API — 示例总览</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 28px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 14px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .info { font-size: 13px; color: #8b949e; margin-bottom: 24px; padding: 12px; background: rgba(88,166,255,0.1); border-radius: 4px; border-left: 3px solid #58a6ff; }
+    .warning { font-size: 13px; color: #f0883e; margin-bottom: 24px; padding: 12px; background: rgba(240,136,62,0.1); border-radius: 4px; border-left: 3px solid #f0883e; }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }
+    .demo-card { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; transition: all 0.15s; cursor: pointer; text-decoration: none; color: inherit; display: block; }
+    .demo-card:hover { border-color: #58a6ff; transform: translateY(-2px); }
+    .demo-card h3 { font-size: 15px; color: #f0f6fc; margin-bottom: 8px; }
+    .demo-card p { font-size: 13px; color: #8b949e; line-height: 1.5; }
+    .demo-card .tag { display: inline-block; padding: 2px 8px; background: #21262d; border-radius: 4px; font-size: 11px; color: #58a6ff; margin-top: 8px; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 600; margin-right: 4px; }
+    .badge-yes { background: #238636; color: #fff; }
+    .badge-no { background: #da3633; color: #fff; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Houdini Layout API</h1>
+    <p class="subtitle">通过 registerLayout 注册自定义布局算法，像 display: flex 一样自定义布局逻辑</p>
+
+    <div class="warning">
+      ⚠️ Layout API 目前在 Chromium 中支持有限，且需要通过 <strong>HTTP 服务器</strong> 访问。<br>
+      启动方式：<code>python -m http.server 8080</code> 或 <code>npx serve .</code>
+    </div>
+
+    <div class="info">
+      <strong>浏览器支持：</strong>
+      <span class="badge badge-yes">Chrome 65+（部分）</span>
+      <span class="badge badge-yes">Edge 79+（部分）</span>
+      <span class="badge badge-no">Firefox ❌</span>
+      <span class="badge badge-no">Safari ❌</span>
+      <br><br>
+      <strong>注意</strong>：Layout API 需要在 Chrome/Edge 中开启实验性功能。访问 <code>chrome://flags/#enable-experimental-web-platform-features</code> 启用。
+    </div>
+
+    <div class="demo-grid">
+      <a class="demo-card" href="centering-demo.html">
+        <h3>居中布局（Centering）</h3>
+        <p>演示如何用 Layout API 创建居中布局，childFragments 如何设置 inlineOffset/blockOffset 实现居中。</p>
+        <span class="tag">入门级</span>
+      </a>
+
+      <a class="demo-card" href="equal-columns-demo.html">
+        <h3>等分布局（Equal Columns）</h3>
+        <p>演示水平等分布局，计算可用空间并分配给每个子元素。</p>
+        <span class="tag">进阶</span>
+      </a>
+
+      <a class="demo-card" href="masonry-demo.html">
+        <h3>瀑布流布局（Masonry）</h3>
+        <p>演示用 Layout API 实现瀑布流效果，自动选择最短列放置元素。</p>
+        <span class="tag">高级</span>
+      </a>
+    </div>
+
+    <div style="margin-top:32px;">
+      <h2 style="font-size:16px;color:#f0f6fc;margin-bottom:12px;">Worklet 文件</h2>
+      <ul style="font-size:13px;color:#8b949e;list-style:disc;padding-left:20px;line-height:2;">
+        <li><code>worklets/centering-layout.js</code> — 居中布局 worklet</li>
+        <li><code>worklets/equal-columns-layout.js</code> — 等分布局 worklet</li>
+        <li><code>worklets/masonry-layout.js</code> — 瀑布流布局 worklet</li>
+      </ul>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/houdini-layout-api/masonry-demo.html
+++ b/examples/css/demos/houdini-layout-api/masonry-demo.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Houdini Layout API — 瀑布流布局演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 13px; color: #8b949e; margin-top: 12px; padding: 12px; background: rgba(88,166,255,0.1); border-radius: 4px; border-left: 3px solid #58a6ff; }
+    .warning { font-size: 13px; color: #f0883e; margin-top: 12px; padding: 12px; background: rgba(240,136,62,0.1); border-radius: 4px; border-left: 3px solid #f0883e; }
+    .masonry-container { column-count: 3; column-gap: 10px; width: 420px; padding: 10px; border: 2px dashed #30363d; border-radius: 8px; }
+    .masonry-item { break-inside: avoid; margin-bottom: 10px; border-radius: 6px; color: white; font-weight: 600; display: flex; align-items: center; justify-content: center; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Houdini Layout API — 瀑布流布局</h1>
+
+    <div class="warning">
+      ⚠️ Layout API 需要在 Chrome/Edge 中开启实验性功能：<code>chrome://flags/#enable-experimental-web-platform-features</code>
+    </div>
+
+    <div class="section">
+      <h2>Worklet 实现</h2>
+      <div class="code-block">class MasonryLayout {
+  async layout(children, edges, constraints, styleMap) {
+    const availW = constraints.fixedInlineSize - edges.inline;
+    const colW = 150, gap = 10;
+    const colCount = Math.max(1, Math.floor((availW + gap) / (colW + gap)));
+    const actualColW = (availW - gap * (colCount - 1)) / colCount;
+    const colHeights = new Array(colCount).fill(0);
+    const childFragments = [];
+    for (const child of children) {
+      const minCol = colHeights.indexOf(Math.min(...colHeights));
+      const f = await child.layoutNextFragment({ availableInlineSize: actualColW });
+      if (f.inlineSize > actualColW) {
+        const scale = actualColW / f.inlineSize;
+        f.inlineSize = actualColW;
+        f.blockSize = f.blockSize * scale;
+      }
+      f.inlineOffset = edges.inlineStart + minCol * (actualColW + gap);
+      f.blockOffset = edges.blockStart + colHeights[minCol];
+      colHeights[minCol] += f.blockSize + gap;
+      childFragments.push(f);
+    }
+    return { autoBlockSize: Math.max(...colHeights) + edges.block, childFragments };
+  }
+}
+registerLayout('masonry', MasonryLayout);</div>
+    </div>
+
+    <div class="section">
+      <h2>效果演示（CSS column 模拟）</h2>
+      <div class="masonry-container">
+        <div class="masonry-item" style="height:120px;background:linear-gradient(135deg,#6366f1,#8b5cf6);">1</div>
+        <div class="masonry-item" style="height:80px;background:linear-gradient(135deg,#ec4899,#f97316);">2</div>
+        <div class="masonry-item" style="height:150px;background:linear-gradient(135deg,#22c55e,#3b82f6);">3</div>
+        <div class="masonry-item" style="height:60px;background:linear-gradient(135deg,#f97316,#eab308);">4</div>
+        <div class="masonry-item" style="height:100px;background:linear-gradient(135deg,#8b5cf6,#ec4899);">5</div>
+        <div class="masonry-item" style="height:130px;background:linear-gradient(135deg,#3b82f6,#22c55e);">6</div>
+        <div class="masonry-item" style="height:70px;background:linear-gradient(135deg,#ef4444,#f97316);">7</div>
+        <div class="masonry-item" style="height:90px;background:linear-gradient(135deg,#06b6d4,#8b5cf6);">8</div>
+      </div>
+      <div class="code-block">/* CSS */
+.masonry-container { display: layout(masonry); }</div>
+    </div>
+
+    <div class="section">
+      <h2>关键算法</h2>
+      <div class="info">
+        <strong>columnHeights</strong>：记录每列当前高度<br>
+        <strong>minHeightCol = indexOf(min(...columnHeights))</strong>：找到最短列<br>
+        <strong>colHeights[minCol] += fragment.blockSize + gap</strong>：更新列高度
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/houdini-layout-api/worklets/centering-layout.js
+++ b/examples/css/demos/houdini-layout-api/worklets/centering-layout.js
@@ -1,0 +1,19 @@
+/**
+ * CSS Houdini Layout API — Centering Layout Worklet
+ */
+class CenteringLayout {
+  async intrinsicSizes() {}
+  async layout(children, edges, constraints, styleMap) {
+    const availableInlineSize = constraints.fixedInlineSize - edges.inline;
+    const availableBlockSize = constraints.fixedBlockSize - edges.block;
+    const childFragments = [];
+    for (const child of children) {
+      const fragment = await child.layoutNextFragment({ availableInlineSize, availableBlockSize });
+      fragment.inlineOffset = edges.inlineStart + (availableInlineSize - fragment.inlineSize) / 2;
+      fragment.blockOffset = edges.blockStart + (availableBlockSize - fragment.blockSize) / 2;
+      childFragments.push(fragment);
+    }
+    return { autoBlockSize: availableBlockSize, childFragments };
+  }
+}
+registerLayout('centering', CenteringLayout);

--- a/examples/css/demos/houdini-layout-api/worklets/equal-columns-layout.js
+++ b/examples/css/demos/houdini-layout-api/worklets/equal-columns-layout.js
@@ -1,0 +1,24 @@
+/**
+ * CSS Houdini Layout API — Equal Columns Layout Worklet
+ */
+class EqualColumnsLayout {
+  async layout(children, edges, constraints, styleMap) {
+    const availableInlineSize = constraints.fixedInlineSize - edges.inline;
+    const gap = 10;
+    const childCount = children.length;
+    if (childCount === 0) return { autoBlockSize: 0, childFragments: [] };
+    const columnWidth = (availableInlineSize - gap * (childCount - 1)) / childCount;
+    const childFragments = [];
+    let maxBlockSize = 0;
+    for (let i = 0; i < children.length; i++) {
+      const fragment = await children[i].layoutNextFragment({ availableInlineSize: columnWidth });
+      fragment.inlineOffset = edges.inlineStart + i * (columnWidth + gap);
+      fragment.blockOffset = edges.blockStart;
+      fragment.inlineSize = columnWidth;
+      maxBlockSize = Math.max(maxBlockSize, fragment.blockSize);
+      childFragments.push(fragment);
+    }
+    return { autoBlockSize: maxBlockSize + edges.block, childFragments };
+  }
+}
+registerLayout('equal-columns', EqualColumnsLayout);

--- a/examples/css/demos/houdini-layout-api/worklets/masonry-layout.js
+++ b/examples/css/demos/houdini-layout-api/worklets/masonry-layout.js
@@ -1,0 +1,29 @@
+/**
+ * CSS Houdini Layout API — Masonry Layout Worklet
+ */
+class MasonryLayout {
+  async layout(children, edges, constraints, styleMap) {
+    const availableInlineSize = constraints.fixedInlineSize - edges.inline;
+    const columnWidth = 150;
+    const gap = 10;
+    const columnCount = Math.max(1, Math.floor((availableInlineSize + gap) / (columnWidth + gap)));
+    const actualColumnWidth = (availableInlineSize - gap * (columnCount - 1)) / columnCount;
+    const columnHeights = new Array(columnCount).fill(0);
+    const childFragments = [];
+    for (const child of children) {
+      const minHeightCol = columnHeights.indexOf(Math.min(...columnHeights));
+      const fragment = await child.layoutNextFragment({ availableInlineSize: actualColumnWidth });
+      if (fragment.inlineSize > actualColumnWidth) {
+        const scale = actualColumnWidth / fragment.inlineSize;
+        fragment.inlineSize = actualColumnWidth;
+        fragment.blockSize = fragment.blockSize * scale;
+      }
+      fragment.inlineOffset = edges.inlineStart + minHeightCol * (actualColumnWidth + gap);
+      fragment.blockOffset = edges.blockStart + columnHeights[minHeightCol];
+      columnHeights[minHeightCol] += fragment.blockSize + gap;
+      childFragments.push(fragment);
+    }
+    return { autoBlockSize: Math.max(...columnHeights) + edges.block, childFragments };
+  }
+}
+registerLayout('masonry', MasonryLayout);

--- a/examples/css/demos/houdini-paint-api/ctx-methods-demo.html
+++ b/examples/css/demos/houdini-paint-api/ctx-methods-demo.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Houdini Paint API — ctx 绘图方法演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 14px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .section h3 { font-size: 14px; color: #8b949e; margin: 16px 0 8px; }
+    .demo-canvas { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 16px; }
+    .canvas-item { flex: 1; min-width: 200px; }
+    .canvas-box { height: 150px; border-radius: 8px; border: 1px solid #30363d; margin-bottom: 8px; position: relative; }
+    .canvas-label { font-size: 12px; color: #8b949e; text-align: center; }
+    .info { font-size: 13px; color: #8b949e; margin-top: 12px; padding: 12px; background: rgba(88,166,255,0.1); border-radius: 4px; border-left: 3px solid #58a6ff; }
+    .warning { font-size: 13px; color: #f0883e; margin-top: 12px; padding: 12px; background: rgba(240,136,62,0.1); border-radius: 4px; border-left: 3px solid #f0883e; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; margin-top: 12px; }
+    table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    th, td { padding: 8px 12px; text-align: left; border-bottom: 1px solid #30363d; }
+    th { color: #58a6ff; font-weight: 600; }
+    td:first-child { color: #f0883e; font-family: monospace; }
+    tr:hover { background: rgba(88,166,255,0.05); }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 600; margin-right: 4px; }
+    .badge-yes { background: #238636; color: #fff; }
+    .badge-no { background: #da3633; color: #fff; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Houdini Paint API — ctx 绘图方法详解</h1>
+    <p class="subtitle">paint(ctx, geom, properties) 回调中 ctx 绘图上下文支持的常用方法</p>
+
+    <div class="info">
+      <strong>浏览器支持：</strong>
+      <span class="badge badge-yes">Chrome 65+</span>
+      <span class="badge badge-yes">Edge 79+</span>
+      <span class="badge badge-no">Firefox ❌</span>
+      <span class="badge badge-no">Safari ❌</span>
+      &nbsp;|&nbsp; 需要 HTTP 服务器或 localhost 访问
+    </div>
+
+    <!-- 矩形操作 -->
+    <div class="section">
+      <h2>1. 矩形操作方法</h2>
+      <div class="demo-canvas" id="rect-demos">
+        <div class="canvas-item">
+          <div class="canvas-box" id="rect-fill"></div>
+          <p class="canvas-label">fillRect — 填充矩形</p>
+        </div>
+        <div class="canvas-item">
+          <div class="canvas-box" id="rect-stroke"></div>
+          <p class="canvas-label">strokeRect — 描边矩形</p>
+        </div>
+        <div class="canvas-item">
+          <div class="canvas-box" id="rect-clear"></div>
+          <p class="canvas-label">clearRect — 清除区域</p>
+        </div>
+      </div>
+      <div class="code-block">paint(ctx, geom) {
+  // 填充矩形
+  ctx.fillStyle = '#6366f1';
+  ctx.fillRect(10, 10, 80, 50);
+
+  // 描边矩形
+  ctx.strokeStyle = '#ec4899';
+  ctx.lineWidth = 3;
+  ctx.strokeRect(10, 70, 80, 50);
+
+  // 清除区域（透明）
+  ctx.clearRect(30, 30, 40, 40);
+}</div>
+    </div>
+
+    <!-- 渐变 -->
+    <div class="section">
+      <h2>2. 渐变方法</h2>
+      <div class="demo-canvas" id="gradient-demos">
+        <div class="canvas-item">
+          <div class="canvas-box" id="gradient-linear"></div>
+          <p class="canvas-label">createLinearGradient</p>
+        </div>
+        <div class="canvas-item">
+          <div class="canvas-box" id="gradient-radial"></div>
+          <p class="canvas-label">createRadialGradient</p>
+        </div>
+      </div>
+      <div class="code-block">// 线性渐变
+const linear = ctx.createLinearGradient(0, 0, geom.width, geom.height);
+linear.addColorStop(0, '#f97316');
+linear.addColorStop(0.5, '#eab308');
+linear.addColorStop(1, '#22c55e');
+ctx.fillStyle = linear;
+ctx.fillRect(0, 0, geom.width, geom.height);
+
+// 径向渐变
+const radial = ctx.createRadialGradient(
+  geom.width/2, geom.height/2, 0,
+  geom.width/2, geom.height/2, geom.width/2
+);
+radial.addColorStop(0, '#fff');
+radial.addColorStop(1, '#000');
+ctx.fillStyle = radial;
+ctx.fillRect(0, 0, geom.width, geom.height);</div>
+    </div>
+
+    <!-- 路径绘制 -->
+    <div class="section">
+      <h2>3. 路径绘制方法</h2>
+      <div class="demo-canvas" id="path-demos">
+        <div class="canvas-item">
+          <div class="canvas-box" id="path-circle"></div>
+          <p class="canvas-label">arc — 圆弧</p>
+        </div>
+        <div class="canvas-item">
+          <div class="canvas-box" id="path-polygon"></div>
+          <p class="canvas-label">lineTo — 多边形</p>
+        </div>
+        <div class="canvas-item">
+          <div class="canvas-box" id="path-heart"></div>
+          <p class="canvas-label">bezierCurveTo — 爱心</p>
+        </div>
+      </div>
+      <div class="code-block">// 圆弧
+ctx.beginPath();
+ctx.arc(geom.width/2, geom.height/2, 40, 0, Math.PI * 2);
+ctx.fillStyle = '#f97316';
+ctx.fill();
+
+// 多边形
+ctx.beginPath();
+ctx.moveTo(geom.width/2, 10);
+ctx.lineTo(geom.width - 10, geom.height - 10);
+ctx.lineTo(10, geom.height - 10);
+ctx.closePath();
+ctx.fillStyle = '#8b5cf6';
+ctx.fill();
+
+// 贝塞尔曲线
+ctx.beginPath();
+ctx.moveTo(geom.width/2, geom.height);
+ctx.bezierCurveTo(0, geom.height*0.7, 0, geom.height*0.3, geom.width/2, geom.height*0.3);
+ctx.bezierCurveTo(geom.width, geom.height*0.3, geom.width, geom.height*0.7, geom.width/2, geom.height);
+ctx.fillStyle = '#ec4899';
+ctx.fill();</div>
+    </div>
+
+    <!-- 方法对照表 -->
+    <div class="section">
+      <h2>4. ctx 方法速查表</h2>
+      <table>
+        <thead>
+          <tr><th>方法</th><th>说明</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>fillRect(x,y,w,h)</td><td>填充矩形区域</td></tr>
+          <tr><td>strokeRect(x,y,w,h)</td><td>描边矩形区域</td></tr>
+          <tr><td>clearRect(x,y,w,h)</td><td>清除矩形区域（变透明）</td></tr>
+          <tr><td>createLinearGradient(x0,y0,x1,y1)</td><td>创建线性渐变</td></tr>
+          <tr><td>createRadialGradient(x0,y0,r0,x1,y1,r1)</td><td>创建径向渐变</td></tr>
+          <tr><td>beginPath()</td><td>开始新路径</td></tr>
+          <tr><td>moveTo(x,y)</td><td>移动画笔到坐标</td></tr>
+          <tr><td>lineTo(x,y)</td><td>画线到坐标</td></tr>
+          <tr><td>arc(x,y,r,start,end)</td><td>画圆弧</td></tr>
+          <tr><td>bezierCurveTo(cp1x,cp1y,cp2x,cp2y,x,y)</td><td>贝塞尔曲线</td></tr>
+          <tr><td>quadraticCurveTo(cpx,cpy,x,y)</td><td>二次贝塞尔曲线</td></tr>
+          <tr><td>closePath()</td><td>闭合路径</td></tr>
+          <tr><td>fill()</td><td>填充路径</td></tr>
+          <tr><td>stroke()</td><td>描边路径</td></tr>
+          <tr><td>clip()</td><td>裁剪后续绘制区域</td></tr>
+          <tr><td>save()</td><td>保存绘图状态</td></tr>
+          <tr><td>restore()</td><td>恢复绘图状态</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- inputProperties 示例 -->
+    <div class="section">
+      <h2>5. inputProperties 自定义属性</h2>
+      <div class="demo-canvas" id="props-demo">
+        <div class="canvas-item">
+          <div class="canvas-box" id="props-box"></div>
+          <p class="canvas-label">--custom-color / --custom-size</p>
+        </div>
+      </div>
+      <div class="code-block">class CustomPaint {
+  // 声明要监听的自定义属性
+  static get inputProperties() {
+    return ['--custom-color', '--custom-size'];
+  }
+
+  paint(ctx, geom, properties) {
+    // 读取自定义属性值
+    const color = properties.get('--custom-color')?.toString() || '#6366f1';
+    const size = parseFloat(properties.get('--custom-size')) || 20;
+
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.arc(geom.width/2, geom.height/2, size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+registerPaint('custom-circle', CustomPaint);
+
+/* CSS 使用 */
+.element {
+  --custom-color: #ec4899;
+  --custom-size: 30;
+  background-image: paint(custom-circle);
+}</div>
+    </div>
+
+  </div>
+
+  <script>
+    // 模拟 paint() 方法的 Canvas 渲染
+    // 注：在真实 Houdini 中，这些需要 worklet 文件和 CSS.paintWorklet.addModule()
+    // 这里用 Canvas 2D API 直接渲染来演示 ctx 方法
+
+    function simulatePaint(demoId, paintFn) {
+      const el = document.getElementById(demoId);
+      const canvas = document.createElement('canvas');
+      canvas.width = el.offsetWidth;
+      canvas.height = el.offsetHeight;
+      el.appendChild(canvas);
+      const ctx = canvas.getContext('2d');
+      const geom = { width: canvas.width, height: canvas.height };
+      paintFn(ctx, geom);
+    }
+
+    // 1. 矩形操作
+    simulatePaint('rect-fill', (ctx, geom) => {
+      ctx.fillStyle = '#6366f1';
+      ctx.fillRect(10, 10, 80, 50);
+      ctx.fillStyle = '#8b5cf6';
+      ctx.fillRect(50, 30, 80, 50);
+    });
+
+    simulatePaint('rect-stroke', (ctx, geom) => {
+      ctx.strokeStyle = '#ec4899';
+      ctx.lineWidth = 3;
+      ctx.strokeRect(10, 10, 80, 50);
+      ctx.strokeStyle = '#f97316';
+      ctx.lineWidth = 2;
+      ctx.strokeRect(50, 30, 80, 50);
+    });
+
+    simulatePaint('rect-clear', (ctx, geom) => {
+      ctx.fillStyle = '#3b82f6';
+      ctx.fillRect(0, 0, geom.width, geom.height);
+      ctx.clearRect(30, 30, geom.width - 60, geom.height - 60);
+    });
+
+    // 2. 渐变
+    simulatePaint('gradient-linear', (ctx, geom) => {
+      const grad = ctx.createLinearGradient(0, 0, geom.width, geom.height);
+      grad.addColorStop(0, '#f97316');
+      grad.addColorStop(0.5, '#eab308');
+      grad.addColorStop(1, '#22c55e');
+      ctx.fillStyle = grad;
+      ctx.fillRect(0, 0, geom.width, geom.height);
+    });
+
+    simulatePaint('gradient-radial', (ctx, geom) => {
+      const grad = ctx.createRadialGradient(
+        geom.width/2, geom.height/2, 5,
+        geom.width/2, geom.height/2, geom.width/2
+      );
+      grad.addColorStop(0, '#fff');
+      grad.addColorStop(0.5, '#fbbf24');
+      grad.addColorStop(1, '#000');
+      ctx.fillStyle = grad;
+      ctx.fillRect(0, 0, geom.width, geom.height);
+    });
+
+    // 3. 路径
+    simulatePaint('path-circle', (ctx, geom) => {
+      ctx.fillStyle = '#f97316';
+      ctx.beginPath();
+      ctx.arc(geom.width/2, geom.height/2, 40, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = '#fff';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    });
+
+    simulatePaint('path-polygon', (ctx, geom) => {
+      const cx = geom.width/2, cy = geom.height/2, r = 50, sides = 6;
+      ctx.fillStyle = '#8b5cf6';
+      ctx.beginPath();
+      for (let i = 0; i <= sides; i++) {
+        const angle = (i / sides) * Math.PI * 2 - Math.PI / 2;
+        const x = cx + r * Math.cos(angle);
+        const y = cy + r * Math.sin(angle);
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.fill();
+      ctx.strokeStyle = '#fff';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    });
+
+    simulatePaint('path-heart', (ctx, geom) => {
+      const cx = geom.width/2, cy = geom.height/2, scale = Math.min(geom.width, geom.height) / 150;
+      ctx.fillStyle = '#ec4899';
+      ctx.beginPath();
+      ctx.moveTo(cx, cy + 30 * scale);
+      ctx.bezierCurveTo(cx - 40*scale, cy - 10*scale, cx - 60*scale, cy + 20*scale, cx, cy + 50*scale);
+      ctx.bezierCurveTo(cx + 60*scale, cy + 20*scale, cx + 40*scale, cy - 10*scale, cx, cy + 30*scale);
+      ctx.fill();
+    });
+
+    // 5. 自定义属性（模拟）
+    simulatePaint('props-box', (ctx, geom) => {
+      const color = '#ec4899';
+      const size = 30;
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      ctx.arc(geom.width/2, geom.height/2, size, 0, Math.PI * 2);
+      ctx.fill();
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/houdini-paint-api/index.html
+++ b/examples/css/demos/houdini-paint-api/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Houdini Paint API — 示例总览</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 28px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 14px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .info { font-size: 13px; color: #8b949e; margin-bottom: 24px; padding: 12px; background: rgba(88,166,255,0.1); border-radius: 4px; border-left: 3px solid #58a6ff; }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }
+    .demo-card { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; transition: all 0.15s; cursor: pointer; text-decoration: none; color: inherit; display: block; }
+    .demo-card:hover { border-color: #58a6ff; transform: translateY(-2px); }
+    .demo-card h3 { font-size: 15px; color: #f0f6fc; margin-bottom: 8px; }
+    .demo-card p { font-size: 13px; color: #8b949e; line-height: 1.5; }
+    .demo-card .tag { display: inline-block; padding: 2px 8px; background: #21262d; border-radius: 4px; font-size: 11px; color: #58a6ff; margin-top: 8px; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 600; margin-right: 4px; }
+    .badge-yes { background: #238636; color: #fff; }
+    .badge-no { background: #da3633; color: #fff; }
+    .warning { font-size: 13px; color: #f0883e; margin-top: 12px; padding: 12px; background: rgba(240,136,62,0.1); border-radius: 4px; border-left: 3px solid #f0883e; margin-bottom: 24px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Houdini Paint API</h1>
+    <p class="subtitle">通过 registerPaint 注册自定义 paint worklet，在 CSS 中绘制任意图案</p>
+
+    <div class="warning">
+      ⚠️ Houdini Paint API 需要通过 <strong>HTTP 服务器</strong> 访问才能运行。<br>
+      启动方式：<code>python -m http.server 8080</code> 或 <code>npx serve .</code>
+    </div>
+
+    <div class="info">
+      <strong>浏览器支持：</strong>
+      <span class="badge badge-yes">Chrome 65+</span>
+      <span class="badge badge-yes">Edge 79+</span>
+      <span class="badge badge-no">Firefox ❌</span>
+      <span class="badge badge-no">Safari ❌</span>
+    </div>
+
+    <div class="demo-grid">
+      <a class="demo-card" href="basic-paint.html">
+        <h3>基础图案示例</h3>
+        <p>圆点、棋盘格、条纹渐变、六边形网格、波浪背景等 5 种基础图案的 worklet 实现。</p>
+        <span class="tag">入门级</span>
+      </a>
+
+      <a class="demo-card" href="interactive-demo.html">
+        <h3>交互式演示</h3>
+        <p>Blob 动画（@property 驱动）、多边形边框、棋盘格遮罩。包含滑块控制和颜色切换。</p>
+        <span class="tag">进阶</span>
+      </a>
+
+      <a class="demo-card" href="ctx-methods-demo.html">
+        <h3>ctx 绘图方法详解</h3>
+        <p>矩形操作、渐变、路径绘制的完整演示。包含方法速查表和 inputProperties 示例。</p>
+        <span class="tag">参考</span>
+      </a>
+    </div>
+
+    <div style="margin-top:32px;">
+      <h2 style="font-size:16px;color:#f0f6fc;margin-bottom:12px;">Worklet 文件</h2>
+      <ul style="font-size:13px;color:#8b949e;list-style:disc;padding-left:20px;line-height:2;">
+        <li><code>worklets/basic-patterns.js</code> — Blob 动画 worklet</li>
+        <li><code>worklets/polygon-border.js</code> — 多边形边框 worklet</li>
+        <li><code>worklets/checkerboard.js</code> — 棋盘格遮罩 worklet</li>
+      </ul>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/houdini-paint-api/interactive-demo.html
+++ b/examples/css/demos/houdini-paint-api/interactive-demo.html
@@ -1,0 +1,332 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Houdini Paint API — 交互式演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 14px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; margin-bottom: 16px; }
+    .demo-box { height: 200px; border-radius: 8px; border: 1px solid #30363d; display: flex; align-items: center; justify-content: center; flex-direction: column; gap: 12px; position: relative; }
+    .demo-label { font-size: 12px; color: #8b949e; text-align: center; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+    .btn { padding: 6px 14px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 13px; cursor: pointer; transition: all 0.15s; }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 13px; color: #8b949e; margin-top: 12px; padding: 12px; background: rgba(88,166,255,0.1); border-radius: 4px; border-left: 3px solid #58a6ff; }
+    .warning { font-size: 13px; color: #f0883e; margin-top: 12px; padding: 12px; background: rgba(240,136,62,0.1); border-radius: 4px; border-left: 3px solid #f0883e; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 600; margin-right: 4px; }
+    .badge-yes { background: #238636; color: #fff; }
+    .badge-no { background: #da3633; color: #fff; }
+    .info-bar { display: flex; gap: 16px; align-items: center; margin-bottom: 16px; flex-wrap: wrap; }
+    .slider-control { display: flex; flex-direction: column; gap: 4px; flex: 1; min-width: 200px; }
+    .slider-label { font-size: 12px; color: #8b949e; display: flex; justify-content: space-between; }
+    input[type="range"] { -webkit-appearance: none; background: #30363d; border-radius: 4px; height: 6px; cursor: pointer; }
+    input[type="range"]::-webkit-slider-thumb { -webkit-appearance: none; width: 14px; height: 14px; background: #58a6ff; border-radius: 50%; cursor: pointer; }
+    .demo-area { background: #fff; border-radius: 8px; padding: 20px; margin-bottom: 16px; }
+    .tab-nav { display: flex; gap: 4px; margin-bottom: 16px; border-bottom: 1px solid #30363d; }
+    .tab-btn { padding: 8px 16px; background: transparent; border: none; color: #8b949e; cursor: pointer; font-size: 14px; border-bottom: 2px solid transparent; margin-bottom: -1px; transition: all 0.15s; }
+    .tab-btn:hover { color: #c9d1d9; }
+    .tab-btn.active { color: #58a6ff; border-bottom-color: #58a6ff; }
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+    .color-swatches { display: flex; gap: 8px; flex-wrap: wrap; }
+    .swatch { width: 28px; height: 28px; border-radius: 4px; cursor: pointer; border: 2px solid transparent; transition: all 0.15s; }
+    .swatch:hover { transform: scale(1.1); }
+    .swatch.active { border-color: #fff; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Houdini Paint API — 交互式演示</h1>
+    <p class="subtitle">通过 registerPaint 注册自定义 paint worklet，在 CSS 中绘制任意图案</p>
+
+    <div class="info-bar">
+      <span><strong>浏览器支持：</strong></span>
+      <span class="badge badge-yes">Chrome 65+</span>
+      <span class="badge badge-yes">Edge 79+</span>
+      <span class="badge badge-no">Firefox ❌</span>
+      <span class="badge badge-no">Safari ❌</span>
+    </div>
+
+    <div class="warning">
+      ⚠️ Houdini Paint API 需要通过 <strong>HTTP 服务器</strong>或 <strong>localhost</strong> 访问才能运行（不能直接打开本地 HTML 文件）。<br>
+      启动方式：<code>python -m http.server 8080</code> 或 <code>npx serve .</code>，然后访问 <code>http://localhost:8080/interactive-demo.html</code>
+    </div>
+
+    <!-- Tab 导航 -->
+    <div class="tab-nav">
+      <button class="tab-btn active" data-tab="blob">Blob 动画</button>
+      <button class="tab-btn" data-tab="polygon">多边形边框</button>
+      <button class="tab-btn" data-tab="checker">棋盘格遮罩</button>
+    </div>
+
+    <!-- Tab 1: Blob 动画 -->
+    <div class="tab-content active" id="tab-blob">
+      <div class="section">
+        <h2>Blob 动画（配合 @property）</h2>
+        <div class="demo-area">
+          <div class="demo-box" id="blob-demo" style="width:100%;height:200px;">
+            <span class="demo-label">--blob-radius 动画驱动</span>
+          </div>
+        </div>
+
+        <div class="controls">
+          <button class="btn" id="blob-animate-btn">▶ 开始动画</button>
+          <div class="slider-control">
+            <div class="slider-label">
+              <span>半径</span>
+              <span id="radius-val">50</span>
+            </div>
+            <input type="range" id="blob-radius" min="20" max="100" value="50">
+          </div>
+        </div>
+
+        <div style="margin-top:12px;" class="color-swatches">
+          <span style="font-size:12px;color:#8b949e;">颜色：</span>
+          <div class="swatch active" style="background:#6366f1;" data-color="#6366f1"></div>
+          <div class="swatch" style="background:#ec4899;" data-color="#ec4899"></div>
+          <div class="swatch" style="background:#f97316;" data-color="#f97316"></div>
+          <div class="swatch" style="background:#22c55e;" data-color="#22c55e"></div>
+          <div class="swatch" style="background:#3b82f6;" data-color="#3b82f6"></div>
+        </div>
+
+        <div class="code-block">/* CSS */
+@property --blob-radius {
+  syntax: '<number>';
+  initial-value: 50;
+  inherits: false;
+}
+
+.blob-element {
+  --blob-radius: 50;
+  --blob-color: #6366f1;
+  background-image: paint(blob);
+}
+
+/* JavaScript 动画驱动 */
+element.style.setProperty('--blob-radius', newValue);</div>
+      </div>
+    </div>
+
+    <!-- Tab 2: 多边形边框 -->
+    <div class="tab-content" id="tab-polygon">
+      <div class="section">
+        <h2>多边形边框（交互控制）</h2>
+        <div class="demo-area">
+          <div class="demo-box" id="polygon-demo" style="width:100%;height:200px;">
+            <span class="demo-label">--polygon-sides 交互控制</span>
+          </div>
+        </div>
+
+        <div class="controls">
+          <button class="btn active" data-sides="3">三角形</button>
+          <button class="btn" data-sides="4">四边形</button>
+          <button class="btn" data-sides="5">五边形</button>
+          <button class="btn" data-sides="6">六边形</button>
+          <button class="btn" data-sides="8">八边形</button>
+          <button class="btn" data-sides="12">十二边形</button>
+        </div>
+
+        <div class="slider-control" style="margin-top:12px;">
+          <div class="slider-label">
+            <span>边框宽度</span>
+            <span id="stroke-val">3</span>
+          </div>
+          <input type="range" id="stroke-width" min="1" max="10" value="3">
+        </div>
+
+        <div style="margin-top:12px;" class="color-swatches">
+          <span style="font-size:12px;color:#8b949e;">颜色：</span>
+          <div class="swatch active" style="background:#3b82f6;" data-color="#3b82f6"></div>
+          <div class="swatch" style="background:#ef4444;" data-color="#ef4444"></div>
+          <div class="swatch" style="background:#22c55e;" data-color="#22c55e"></div>
+          <div class="swatch" style="background:#f59e0b;" data-color="#f59e0b"></div>
+          <div class="swatch" style="background:#8b5cf6;" data-color="#8b5cf6"></div>
+        </div>
+
+        <div class="code-block">/* HTML */
+&lt;div id="polygon-demo"&gt;&lt;/div&gt;
+
+/* JavaScript */
+demo.style.setProperty('--polygon-sides', 6);
+demo.style.setProperty('--polygon-color', '#3b82f6');
+demo.style.setProperty('--polygon-stroke-width', 3);</div>
+      </div>
+    </div>
+
+    <!-- Tab 3: 棋盘格遮罩 -->
+    <div class="tab-content" id="tab-checker">
+      <div class="section">
+        <h2>棋盘格遮罩（图像处理）</h2>
+        <div class="demo-area">
+          <div style="position:relative;width:100%;height:200px;border-radius:8px;overflow:hidden;">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%23334155' width='400' height='200'/%3E%3Ccircle cx='200' cy='100' r='60' fill='%23f97316'/%3E%3Ccircle cx='160' cy='80' r='20' fill='%23fbbf24'/%3E%3Ccircle cx='240' cy='120' r='30' fill='%23ef4444'/%3E%3C/svg%3E" style="width:100%;height:100%;object-fit:cover;" alt="示例图片">
+            <div id="checker-overlay" style="position:absolute;inset:0;mix-blend-mode:multiply;background:#888;"></div>
+          </div>
+        </div>
+
+        <div class="slider-control">
+          <div class="slider-label">
+            <span>格子大小</span>
+            <span id="size-val">16</span>
+          </div>
+          <input type="range" id="checker-size" min="4" max="64" value="16">
+        </div>
+
+        <div class="code-block">/* CSS */
+.checker-overlay {
+  background-image: paint(checkerboard);
+  --checkerboard-size: 16;
+  --checkerboard-color: rgba(0,0,0,0.5);
+  mix-blend-mode: multiply;
+}</div>
+      </div>
+    </div>
+
+  </div>
+
+  <script>
+    // Tab 切换
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+      });
+    });
+
+    // 检查是否支持 Paint Worklet
+    if ('paintWorklet' in CSS) {
+      // 加载 worklet
+      CSS.paintWorklet.addModule('worklets/basic-patterns.js');
+      CSS.paintWorklet.addModule('worklets/polygon-border.js');
+      CSS.paintWorklet.addModule('worklets/checkerboard.js');
+
+      // === Blob Demo ===
+      const blobDemo = document.getElementById('blob-demo');
+      const blobRadiusSlider = document.getElementById('blob-radius');
+      const radiusVal = document.getElementById('radius-val');
+      const blobAnimateBtn = document.getElementById('blob-animate-btn');
+      let blobColor = '#6366f1';
+      let isAnimating = false;
+      let animFrame;
+
+      // 初始化 blob
+      blobDemo.style.setProperty('--blob-radius', '50');
+      blobDemo.style.setProperty('--blob-color', blobColor);
+      blobDemo.style.backgroundImage = 'paint(blob)';
+
+      // 滑块控制
+      blobRadiusSlider.addEventListener('input', e => {
+        const val = e.target.value;
+        radiusVal.textContent = val;
+        blobDemo.style.setProperty('--blob-radius', val);
+      });
+
+      // 颜色选择
+      document.querySelectorAll('#tab-blob .swatch').forEach(s => {
+        s.addEventListener('click', () => {
+          document.querySelectorAll('#tab-blob .swatch').forEach(sw => sw.classList.remove('active'));
+          s.classList.add('active');
+          blobColor = s.dataset.color;
+          blobDemo.style.setProperty('--blob-color', blobColor);
+        });
+      });
+
+      // 动画
+      let start = null;
+      function animateBlob(timestamp) {
+        if (!start) start = timestamp;
+        const elapsed = timestamp - start;
+        const t = (elapsed % 2000) / 2000;
+        const eased = 0.5 + 0.5 * Math.sin(t * Math.PI * 2 - Math.PI / 2);
+        const radius = 30 + eased * 70;
+        blobDemo.style.setProperty('--blob-radius', radius.toFixed(1));
+        radiusVal.textContent = radius.toFixed(0);
+        blobRadiusSlider.value = radius;
+        animFrame = requestAnimationFrame(animateBlob);
+      }
+
+      blobAnimateBtn.addEventListener('click', () => {
+        isAnimating = !isAnimating;
+        if (isAnimating) {
+          blobAnimateBtn.textContent = '⏸ 暂停';
+          blobAnimateBtn.classList.add('active');
+          start = null;
+          animFrame = requestAnimationFrame(animateBlob);
+        } else {
+          blobAnimateBtn.textContent = '▶ 开始动画';
+          blobAnimateBtn.classList.remove('active');
+          cancelAnimationFrame(animFrame);
+        }
+      });
+
+      // === Polygon Demo ===
+      const polygonDemo = document.getElementById('polygon-demo');
+      const strokeSlider = document.getElementById('stroke-width');
+      const strokeVal = document.getElementById('stroke-val');
+      let polygonColor = '#3b82f6';
+
+      polygonDemo.style.setProperty('--polygon-sides', '3');
+      polygonDemo.style.setProperty('--polygon-color', polygonColor);
+      polygonDemo.style.setProperty('--polygon-stroke-width', '3');
+      polygonDemo.style.backgroundImage = 'paint(polygon-border)';
+
+      document.querySelectorAll('[data-sides]').forEach(btn => {
+        btn.addEventListener('click', () => {
+          document.querySelectorAll('[data-sides]').forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          polygonDemo.style.setProperty('--polygon-sides', btn.dataset.sides);
+        });
+      });
+
+      strokeSlider.addEventListener('input', e => {
+        const val = e.target.value;
+        strokeVal.textContent = val;
+        polygonDemo.style.setProperty('--polygon-stroke-width', val);
+      });
+
+      document.querySelectorAll('#tab-polygon .swatch').forEach(s => {
+        s.addEventListener('click', () => {
+          document.querySelectorAll('#tab-polygon .swatch').forEach(sw => sw.classList.remove('active'));
+          s.classList.add('active');
+          polygonColor = s.dataset.color;
+          polygonDemo.style.setProperty('--polygon-color', polygonColor);
+        });
+      });
+
+      // === Checker Demo ===
+      const checkerOverlay = document.getElementById('checker-overlay');
+      const checkerSizeSlider = document.getElementById('checker-size');
+      const sizeVal = document.getElementById('size-val');
+
+      checkerOverlay.style.setProperty('--checkerboard-size', '16');
+      checkerOverlay.style.setProperty('--checkerboard-color', 'rgba(0,0,0,0.3)');
+      checkerOverlay.style.backgroundImage = 'paint(checkerboard)';
+
+      checkerSizeSlider.addEventListener('input', e => {
+        const val = e.target.value;
+        sizeVal.textContent = val;
+        checkerOverlay.style.setProperty('--checkerboard-size', val);
+      });
+
+    } else {
+      // 不支持时的降级
+      document.querySelector('.warning').innerHTML =
+        '⚠️ 当前浏览器不支持 CSS Paint API。请使用 <strong>Chrome 65+</strong> 或 <strong>Edge 79+</strong> 访问此页面。';
+      document.querySelectorAll('.demo-box, .demo-area').forEach(el => {
+        el.style.background = 'repeating-conic-gradient(#ccc 0% 25%, #fff 0% 50%) 50%/20px 20px';
+      });
+    }
+  </script>
+</body>
+</html>

--- a/examples/css/demos/houdini-paint-api/worklets/basic-patterns.js
+++ b/examples/css/demos/houdini-paint-api/worklets/basic-patterns.js
@@ -1,0 +1,37 @@
+/**
+ * CSS Houdini Paint API — Blob Animation Worklet
+ * 演示如何通过 @property 自定义属性驱动 worklet 重绘
+ */
+
+// 定义可动画的 blob 半径
+class BlobPaint {
+  static get inputProperties() {
+    return ['--blob-radius', '--blob-color'];
+  }
+
+  paint(ctx, geom, properties) {
+    const radius = parseFloat(properties.get('--blob-radius')) || 50;
+    const color = properties.get('--blob-color')?.toString() || '#6366f1';
+    const cx = geom.width / 2;
+    const cy = geom.height / 2;
+
+    ctx.fillStyle = color;
+    ctx.beginPath();
+
+    // 用多个圆弧组合成 blob 形状
+    const points = 8;
+    for (let i = 0; i <= points; i++) {
+      const angle = (i / points) * Math.PI * 2;
+      // 通过正弦函数让半径随角度变化，产生不规则 blob 形状
+      const r = radius + Math.sin(angle * 3) * (radius * 0.3);
+      const x = cx + r * Math.cos(angle);
+      const y = cy + r * Math.sin(angle);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.fill();
+  }
+}
+
+registerPaint('blob', BlobPaint);

--- a/examples/css/demos/houdini-paint-api/worklets/checkerboard.js
+++ b/examples/css/demos/houdini-paint-api/worklets/checkerboard.js
@@ -1,0 +1,31 @@
+/**
+ * CSS Houdini Paint API — Checkerboard Blend Worklet
+ * 演示用 paint API 创建棋盘格混合效果（适合做图片遮罩）
+ */
+
+class CheckerboardPaint {
+  static get inputProperties() {
+    return ['--checkerboard-size', '--checkerboard-color', '--checkerboard-opacity'];
+  }
+
+  paint(ctx, geom, properties) {
+    const size = parseInt(properties.get('--checkerboard-size')) || 16;
+    const color = properties.get('--checkerboard-color')?.toString() || 'rgba(0,0,0,0.3)';
+    const opacity = parseFloat(properties.get('--checkerboard-opacity')) || 0.3;
+
+    ctx.clearRect(0, 0, geom.width, geom.height);
+
+    // 解析颜色并应用透明度
+    ctx.fillStyle = color;
+
+    for (let x = 0; x < geom.width; x += size) {
+      for (let y = 0; y < geom.height; y += size) {
+        if ((x / size + y / size) % 2 === 0) {
+          ctx.fillRect(x, y, size, size);
+        }
+      }
+    }
+  }
+}
+
+registerPaint('checkerboard', CheckerboardPaint);

--- a/examples/css/demos/houdini-paint-api/worklets/polygon-border.js
+++ b/examples/css/demos/houdini-paint-api/worklets/polygon-border.js
@@ -1,0 +1,37 @@
+/**
+ * CSS Houdini Paint API — Polygon Border Worklet
+ * 演示用 paint API 绘制可配置边数的多边形边框
+ */
+
+class PolygonBorderPaint {
+  static get inputProperties() {
+    return ['--polygon-sides', '--polygon-color', '--polygon-stroke-width'];
+  }
+
+  paint(ctx, geom, properties) {
+    const sides = parseInt(properties.get('--polygon-sides')) || 6;
+    const color = properties.get('--polygon-color')?.toString() || '#3b82f6';
+    const strokeWidth = parseFloat(properties.get('--polygon-stroke-width')) || 3;
+    const cx = geom.width / 2;
+    const cy = geom.height / 2;
+    const r = Math.min(cx, cy) * 0.8;
+
+    ctx.strokeStyle = color;
+    ctx.lineWidth = strokeWidth;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+
+    for (let i = 0; i <= sides; i++) {
+      const angle = (i / sides) * Math.PI * 2 - Math.PI / 2;
+      const x = cx + r * Math.cos(angle);
+      const y = cy + r * Math.sin(angle);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.stroke();
+  }
+}
+
+registerPaint('polygon-border', PolygonBorderPaint);

--- a/examples/css/demos/light-dark/index.html
+++ b/examples/css/demos/light-dark/index.html
@@ -1,0 +1,188 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS light-dark() 暗色模式切换 - 交互演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 13px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { display: flex; gap: 16px; min-height: 120px; padding: 20px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; align-items: center; flex-wrap: wrap; }
+    .box { padding: 16px 24px; border-radius: 8px; font-size: 14px; font-weight: 600; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; align-items: center; }
+    .btn { padding: 6px 12px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .desc { font-size: 12px; color: #6e7681; margin-top: 8px; line-height: 1.6; }
+    .tag { display: inline-block; padding: 2px 6px; border-radius: 3px; font-size: 11px; background: #388bfd33; color: #58a6ff; margin-right: 4px; }
+    
+    /* 使用 light-dark() 的样式 */
+    .demo-box {
+      background: light-dark(#ffffff, #1a1a1a);
+      color: light-dark(#1a1a1a, #f5f5f5);
+      border: 1px solid light-dark(#e0e0e0, #333333);
+    }
+    
+    .demo-card {
+      background: light-dark(#f8f9fa, #252525);
+      color: light-dark(#333333, #e5e5e5);
+      border: 1px solid light-dark(#dee2e6, #404040);
+      padding: 20px;
+      border-radius: 8px;
+    }
+    
+    .demo-button {
+      background: light-dark(#007bff, #0056b3);
+      color: white;
+      padding: 10px 20px;
+      border-radius: 6px;
+      font-size: 14px;
+      font-weight: 600;
+      border: none;
+      cursor: pointer;
+    }
+    
+    .demo-shadow {
+      box-shadow: light-dark(
+        0 4px 12px rgba(0, 0, 0, 0.15),
+        0 4px 12px rgba(0, 0, 0, 0.5)
+      );
+      padding: 20px;
+      border-radius: 8px;
+      background: light-dark(white, #2d2d2d);
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS light-dark() 暗色模式切换</h1>
+    <p class="subtitle">CSS Color Level 5 规范 | 交互演示</p>
+
+    <!-- 基础用法 -->
+    <div class="section">
+      <h2>基础用法</h2>
+      <div class="controls">
+        <button class="btn" id="set-light">切换到浅色模式</button>
+        <button class="btn" id="set-dark">切换到深色模式</button>
+        <span style="font-size: 12px; color: #8b949e;">当前模式：<span id="current-scheme">dark</span></span>
+      </div>
+      <div class="demo-area">
+        <div class="box demo-box">使用 light-dark() 的盒子</div>
+      </div>
+      <div class="code-block">background: light-dark(#ffffff, #1a1a1a);
+color: light-dark(#1a1a1a, #f5f5f5);</div>
+      <p class="desc"><span class="tag">color-scheme: light dark</span> 声明后，浏览器会自动根据系统设置选择配色。</p>
+    </div>
+
+    <!-- 卡片示例 -->
+    <div class="section">
+      <h2>卡片组件示例</h2>
+      <div class="demo-area" style="flex-direction: column; align-items: stretch;">
+        <div class="demo-card">
+          <h3 style="margin-bottom: 12px; color: light-dark(#1a1a1a, #f5f5f5);">卡片标题</h3>
+          <p style="color: light-dark(#666666, #a0a0a0); font-size: 14px; line-height: 1.6;">
+            这是一个使用 light-dark() 的卡片组件。切换系统配色方案时，卡片的背景、文字和边框颜色会自动适应。
+          </p>
+        </div>
+      </div>
+      <div class="code-block">.card {
+  background: light-dark(#f8f9fa, #252525);
+  color: light-dark(#333333, #e5e5e5);
+  border: 1px solid light-dark(#dee2e6, #404040);
+}</div>
+    </div>
+
+    <!-- 按钮示例 -->
+    <div class="section">
+      <h2>按钮组件示例</h2>
+      <div class="demo-area">
+        <button class="demo-button">主要按钮</button>
+      </div>
+      <div class="code-block">.button {
+  background: light-dark(#007bff, #0056b3);
+  color: white;
+}</div>
+    </div>
+
+    <!-- 阴影示例 -->
+    <div class="section">
+      <h2>阴影效果示例</h2>
+      <div class="demo-area">
+        <div class="demo-shadow">
+          这个盒子有 light-dark() 阴影效果
+        </div>
+      </div>
+      <div class="code-block">box-shadow: light-dark(
+  0 4px 12px rgba(0, 0, 0, 0.15),
+  0 4px 12px rgba(0, 0, 0, 0.5)
+);</div>
+    </div>
+
+    <!-- 完整主题示例 -->
+    <div class="section">
+      <h2>完整主题变量示例</h2>
+      <div class="code-block">:root {
+  color-scheme: light dark;
+  
+  --text-primary: light-dark(#1a1a1a, #e5e5e5);
+  --text-secondary: light-dark(#666666, #a0a0a0);
+  --bg-primary: light-dark(#ffffff, #121212);
+  --bg-secondary: light-dark(#f5f5f5, #1e1e1e);
+  --border-color: light-dark(#e0e0e0, #333333);
+}</div>
+      <div class="demo-area" style="flex-direction: column; gap: 12px;">
+        <div style="color: var(--text-primary, light-dark(#1a1a1a, #e5e5e5)); background: var(--bg-primary, light-dark(#fff, #121212)); padding: 12px; border-radius: 4px; border: 1px solid var(--border-color, light-dark(#e0e0e0, #333));">
+          主要文字和背景
+        </div>
+        <div style="color: var(--text-secondary, light-dark(#666, #a0a0a0)); background: var(--bg-secondary, light-dark(#f5, #1e1e1e)); padding: 12px; border-radius: 4px;">
+          次要文字和背景
+        </div>
+      </div>
+    </div>
+
+    <!-- 浏览器兼容性 -->
+    <div class="section">
+      <h2>浏览器兼容性</h2>
+      <div class="desc">
+        <ul style="font-size: 12px; color: #8b949e; margin-top: 8px; padding-left: 20px;">
+          <li>Chrome 123+ ✓</li>
+          <li>Firefox 120+ ✓</li>
+          <li>Safari 17.5+ ✓</li>
+          <li>Edge 123+ ✓</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // 注意：由于 light-dark() 依赖浏览器的 color-scheme 支持，
+    // 这个演示在不支持的浏览器中会显示不正确
+    // 实际使用时需要设置 color-scheme: light dark;
+    
+    document.documentElement.style.colorScheme = 'dark';
+    
+    document.getElementById('set-light').addEventListener('click', () => {
+      document.documentElement.style.colorScheme = 'light';
+      document.getElementById('current-scheme').textContent = 'light';
+    });
+    
+    document.getElementById('set-dark').addEventListener('click', () => {
+      document.documentElement.style.colorScheme = 'dark';
+      document.getElementById('current-scheme').textContent = 'dark';
+    });
+    
+    // 监听系统配色变化
+    if (window.matchMedia) {
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+        document.getElementById('current-scheme').textContent = e.matches ? 'dark' : 'light';
+      });
+    }
+  </script>
+</body>
+</html>

--- a/examples/css/demos/style-observer/index.html
+++ b/examples/css/demos/style-observer/index.html
@@ -1,0 +1,248 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS style observer 样式观察器 - 交互演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 13px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-area { display: flex; gap: 16px; min-height: 120px; padding: 20px; background: #0d1117; border-radius: 4px; margin-bottom: 12px; align-items: center; flex-wrap: wrap; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; align-items: center; }
+    .btn { padding: 6px 12px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 12px; cursor: pointer; transition: all 0.15s; }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .desc { font-size: 12px; color: #6e7681; margin-top: 8px; line-height: 1.6; }
+    .tag { display: inline-block; padding: 2px 6px; border-radius: 3px; font-size: 11px; background: #388bfd33; color: #58a6ff; margin-right: 4px; }
+    .log-container { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; max-height: 200px; overflow-y: auto; margin-top: 12px; }
+    .log-entry { font-family: 'SF Mono', Monaco, monospace; font-size: 11px; color: #7ee787; margin-bottom: 4px; }
+    .log-entry .property { color: #79c0ff; }
+    .log-entry .value { color: #ffa657; }
+    
+    .demo-box { width: 100px; height: 100px; border-radius: 8px; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; transition: all 0.3s; }
+    .progress-bar { width: 100%; height: 30px; background: #21262d; border-radius: 4px; overflow: hidden; position: relative; }
+    .progress-fill { height: 100%; background: linear-gradient(90deg, #3b82f6, #a371f7); transition: width 0.3s ease; }
+    
+    .support-badge { display: inline-block; padding: 4px 8px; border-radius: 4px; font-size: 11px; font-weight: 600; }
+    .support-badge.supported { background: #3fb95033; color: #3fb950; }
+    .support-badge.unsupported { background: #f8514933; color: #f85149; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS style observer 样式观察器</h1>
+    <p class="subtitle">CSS Houdini API | 交互演示</p>
+
+    <!-- Houdini 支持检测 -->
+    <div class="section">
+      <h2>浏览器支持检测</h2>
+      <div class="demo-area" style="flex-direction: column; align-items: flex-start; gap: 12px;">
+        <div>
+          <span class="support-badge" id="css-registerproperty">检测中...</span>
+          <span style="font-size: 12px; color: #8b949e; margin-left: 8px;">CSS.registerProperty</span>
+        </div>
+        <div>
+          <span class="support-badge" id="css-stylemap">检测中...</span>
+          <span style="font-size: 12px; color: #8b949e; margin-left: 8px;">Element.attributeStyleMap</span>
+        </div>
+        <div>
+          <span class="support-badge" id="css-styleeffect">检测中...</span>
+          <span style="font-size: 12px; color: #8b949e; margin-left: 8px;">CSSStyleEffect</span>
+        </div>
+      </div>
+      <p class="desc"><span class="tag">注意</span> Style Observer API 目前仅在 Chromium 内核浏览器中得到部分支持。</p>
+    </div>
+
+    <!-- MutationObserver 替代方案 -->
+    <div class="section">
+      <h2>MutationObserver 替代方案演示</h2>
+      <p class="desc" style="margin-bottom: 16px;">由于 Houdini 支持有限，以下演示使用 MutationObserver 监听 style 属性变化：</p>
+      <div class="demo-area">
+        <div class="demo-box" id="observed-box" style="background: #3b82f6;">可观察的盒子</div>
+      </div>
+      <div class="controls">
+        <button class="btn" id="change-color">改变颜色</button>
+        <button class="btn" id="change-size">改变大小</button>
+        <button class="btn" id="change-border">改变边框</button>
+        <button class="btn" id="clear-log">清空日志</button>
+      </div>
+      <div class="log-container" id="log-container">
+        <div style="font-size: 11px; color: #6e7681;">等待样式变化...</div>
+      </div>
+    </div>
+
+    <!-- CSS 变量监听 -->
+    <div class="section">
+      <h2>CSS 变量变化监听</h2>
+      <div class="demo-area" style="flex-direction: column; align-items: stretch; gap: 16px;">
+        <div class="progress-bar">
+          <div class="progress-fill" id="progress-fill" style="width: 0%;"></div>
+        </div>
+        <div style="display: flex; align-items: center; gap: 12px;">
+          <input type="range" id="progress-slider" min="0" max="100" value="0" style="flex: 1;">
+          <span id="progress-value" style="font-size: 12px; color: #79c0ff; min-width: 40px;">0%</span>
+        </div>
+      </div>
+      <div class="code-block">const element = document.querySelector('.progress-bar');
+const styleMap = element.styleMap;
+
+// CSS 变量变化会触发 change 事件
+styleMap.addEventListener('change', (e) => {
+  console.log(`变量 ${e.property} 变为 ${e.value}`);
+});</div>
+      <p class="desc"><span class="tag">提示</span> 拖动滑块改变 CSS 变量 --progress 的值，下方的日志会显示变化。</p>
+    </div>
+
+    <!-- 代码示例 -->
+    <div class="section">
+      <h2>完整代码示例</h2>
+      <div class="code-block">// 1. 注册 CSS 变量
+CSS.registerProperty({
+  name: '--my-progress',
+  syntax: '<number>',
+  inherits: false,
+  initialValue: '0',
+});
+
+// 2. 获取样式映射
+const element = document.querySelector('.progress');
+const styleMap = element.attributeStyleMap;
+
+// 3. 设置变量
+element.style.setProperty('--my-progress', '50');
+
+// 4. 监听变化 (MutationObserver 替代)
+const observer = new MutationObserver((mutations) => {
+  mutations.forEach((mutation) => {
+    if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+      console.log('Style changed via inline style');
+    }
+  });
+});
+
+observer.observe(element, { attributes: true });</div>
+    </div>
+  </div>
+
+  <script>
+    // 检测 Houdini 支持
+    function checkSupport() {
+      // CSS.registerProperty
+      const regBadge = document.getElementById('css-registerproperty');
+      if (typeof CSS !== 'undefined' && 'registerProperty' in CSS) {
+        regBadge.textContent = '支持';
+        regBadge.className = 'support-badge supported';
+      } else {
+        regBadge.textContent = '不支持';
+        regBadge.className = 'support-badge unsupported';
+      }
+      
+      // attributeStyleMap
+      const mapBadge = document.getElementById('css-stylemap');
+      const testEl = document.createElement('div');
+      if (testEl.attributeStyleMap) {
+        mapBadge.textContent = '支持';
+        mapBadge.className = 'support-badge supported';
+      } else {
+        mapBadge.textContent = '不支持';
+        mapBadge.className = 'support-badge unsupported';
+      }
+      
+      // CSSStyleEffect
+      const effectBadge = document.getElementById('css-styleeffect');
+      if (typeof CSSStyleEffect !== 'undefined') {
+        effectBadge.textContent = '支持';
+        effectBadge.className = 'support-badge supported';
+      } else {
+        effectBadge.textContent = '不支持';
+        effectBadge.className = 'support-badge unsupported';
+      }
+    }
+    
+    checkSupport();
+    
+    // MutationObserver 替代方案
+    const observedBox = document.getElementById('observed-box');
+    const logContainer = document.getElementById('log-container');
+    let logCount = 0;
+    
+    function addLog(property, value) {
+      logCount++;
+      const entry = document.createElement('div');
+      entry.className = 'log-entry';
+      entry.innerHTML = `[${logCount}] <span class="property">${property}</span>: <span class="value">${value}</span>`;
+      
+      if (logCount === 1) {
+        logContainer.innerHTML = '';
+      }
+      logContainer.appendChild(entry);
+      logContainer.scrollTop = logContainer.scrollHeight;
+    }
+    
+    // 使用 MutationObserver 监听 style 属性变化
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+          const style = mutation.target.style;
+          // 简化显示
+          addLog('inline-style', 'changed');
+        }
+      });
+    });
+    
+    observer.observe(observedBox, { attributes: true, attributeFilter: ['style'] });
+    
+    // 按钮事件
+    const colors = ['#3b82f6', '#ef4444', '#22c55e', '#f59e0b', '#a855f7'];
+    const sizes = ['100px', '120px', '80px', '150px', '60px'];
+    const borders = ['3px solid #fff', '5px dashed #3b82f6', '2px dotted #ef4444'];
+    let colorIndex = 0;
+    let sizeIndex = 0;
+    let borderIndex = 0;
+    
+    document.getElementById('change-color').addEventListener('click', () => {
+      colorIndex = (colorIndex + 1) % colors.length;
+      observedBox.style.background = colors[colorIndex];
+      addLog('background-color', colors[colorIndex]);
+    });
+    
+    document.getElementById('change-size').addEventListener('click', () => {
+      sizeIndex = (sizeIndex + 1) % sizes.length;
+      observedBox.style.width = sizes[sizeIndex];
+      observedBox.style.height = sizes[sizeIndex];
+      addLog('width/height', sizes[sizeIndex]);
+    });
+    
+    document.getElementById('change-border').addEventListener('click', () => {
+      borderIndex = (borderIndex + 1) % borders.length;
+      observedBox.style.border = borders[borderIndex];
+      addLog('border', borders[borderIndex]);
+    });
+    
+    document.getElementById('clear-log').addEventListener('click', () => {
+      logContainer.innerHTML = '<div style="font-size: 11px; color: #6e7681;">等待样式变化...</div>';
+      logCount = 0;
+    });
+    
+    // CSS 变量进度条演示
+    const progressSlider = document.getElementById('progress-slider');
+    const progressFill = document.getElementById('progress-fill');
+    const progressValue = document.getElementById('progress-value');
+    
+    progressSlider.addEventListener('input', (e) => {
+      const value = e.target.value;
+      progressFill.style.width = value + '%';
+      progressValue.textContent = value + '%';
+    });
+    
+    // 实际应用中，可以监听 CSS 变量的变化
+    // 这需要 MutationObserver 监听 style 属性或使用 requestAnimationFrame 轮询
+  </script>
+</body>
+</html>

--- a/src/topics/01.basics/color-contrast/index.mdx
+++ b/src/topics/01.basics/color-contrast/index.mdx
@@ -1,0 +1,204 @@
+---
+title: "CSS color-contrast() 颜色对比函数"
+category: "基础知识"
+tags:
+  - CSS颜色
+  - color-contrast
+  - 颜色对比
+  - 对比度
+  - CSS3
+description: "详解CSS color-contrast()函数的使用方法和应用场景"
+keywords: "color-contrast, CSS颜色, 颜色对比, WCAG, 对比度"
+---
+
+# CSS color-contrast() 颜色对比函数
+
+## 什么是 color-contrast()
+
+`color-contrast()` 是 CSS 颜色函数，用于从一组颜色中自动选择符合指定对比度要求的颜色。这是 CSS Color Level 5 规范中引入的功能，主要用于确保文字与背景之间的对比度符合 WCAG 可访问性标准。
+
+{/* @playground id="basic-usage" mode="demo" */}
+
+## 基本语法
+
+```css
+color-contrast(<base-color> vs <color1>, <color2> [, ...])
+```
+
+### 参数说明
+
+| 参数 | 说明 |
+|------|------|
+| `<base-color>` | 基础颜色（通常是背景色） |
+| `<color1>`, `<color2>` | 用于对比的颜色候选列表 |
+| `<target-contrast>` | 可选的目标对比度（默认 4.5，用于普通文本） |
+
+### 语法扩展
+
+```css
+/* 指定目标对比度 */
+color-contrast(<base-color> vs <color1>, <color2> to AA, <target-contrast>)
+```
+
+## 使用示例
+
+### 1. 基础用法
+
+```css
+/* 从白色和黑色中选择与蓝色背景对比度更高的 */
+.element {
+  background-color: blue;
+  color: color-contrast(blue vs white, black);
+}
+```
+
+{/* @playground id="basic-demo" mode="demo" */}
+
+### 2. 多颜色候选
+
+```css
+/* 从多个颜色中选择最合适的 */
+.button {
+  background-color: #4CAF50;
+  color: color-contrast(
+    #4CAF50,
+    white,
+    black,
+    #ffeb3b,
+    #e91e63
+  );
+}
+```
+
+### 3. 指定目标对比度
+
+```css
+/* AA 级标准（普通文本 4.5:1，大文本 3:1） */
+.text {
+  background-color: #333;
+  color: color-contrast(#333 vs white, black to AA);
+}
+
+/* AAA 级标准（7:1） */
+.premium-text {
+  background-color: #333;
+  color: color-contrast(#333 vs white, black to AAA);
+}
+```
+
+### 4. 动态主题适配
+
+```css
+:root {
+  --bg: #ffffff;
+  --text: color-contrast(var(--bg) vs #1a1a1a, #333333, white);
+}
+```
+
+## 实际应用场景
+
+### 1. 自动文字颜色选择
+
+```css
+.card {
+  /* 自动选择白色或黑色文字 */
+  background-color: var(--card-color);
+  color: color-contrast(var(--card-color) vs white, black);
+}
+```
+
+### 2. 按钮状态颜色
+
+```css
+.button {
+  --hover-bg: color-mix(in srgb, var(--primary) 80%, black);
+  background-color: var(--primary);
+  color: color-contrast(var(--primary) vs white, black);
+}
+
+.button:hover {
+  background-color: var(--hover-bg);
+  /* 颜色自动适配 */
+  color: color-contrast(var(--hover-bg) vs white, black);
+}
+```
+
+### 3. 动态调色板
+
+```css
+.color-system {
+  --surface: #f5f5f5;
+  --on-surface: color-contrast(var(--surface) to AA);
+  
+  --primary: #0066cc;
+  --on-primary: color-contrast(var(--primary) vs white, black);
+}
+```
+
+## 对比度级别
+
+WCAG 定义了以下对比度级别：
+
+| 级别 | 最小对比度 | 适用范围 |
+|------|-----------|---------|
+| AA | 4.5:1 | 普通文本 |
+| AA Large | 3:1 | 大文本（18px+ 或 14px+ 粗体） |
+| AAA | 7:1 | 增强对比度 |
+| AAA Large | 4.5:1 | 大文本 |
+
+## 浏览器兼容性
+
+`color-contrast()` 是较新的 CSS 功能，浏览器支持有限：
+
+- Chrome: 不支持
+- Firefox: 不支持
+- Safari 17.4+（技术预览版）
+- Edge: 不支持
+
+## 替代方案
+
+由于浏览器支持有限，可以使用 JavaScript 替代方案：
+
+```javascript
+// 计算对比度
+function getContrastRatio(color1, color2) {
+  const lum1 = getLuminance(color1);
+  const lum2 = getLuminance(color2);
+  return (Math.max(lum1, lum2) + 0.05) / (Math.min(lum1, lum2) + 0.05);
+}
+
+// 获取相对亮度
+function getLuminance(color) {
+  // 转换颜色并计算...
+}
+
+// 选择最佳对比色
+function chooseContrastColor(bgColor, candidates) {
+  let bestColor = candidates[0];
+  let bestRatio = 0;
+  
+  for (const candidate of candidates) {
+    const ratio = getContrastRatio(bgColor, candidate);
+    if (ratio > bestRatio) {
+      bestRatio = ratio;
+      bestColor = candidate;
+    }
+  }
+  
+  return bestColor;
+}
+```
+
+## 最佳实践
+
+1. **使用 AA 作为默认目标**：大多数网站应至少满足 WCAG AA 标准
+2. **结合 CSS 变量**：与 CSS 自定义属性结合使用更灵活
+3. **测试多种背景**：确保在浅色和深色背景上都有良好对比度
+4. **考虑用户偏好**：允许用户切换高对比度模式
+
+## 参考资料
+
+- [CSS Color Level 5 - W3C](https://www.w3.org/TR/css-color-5/)
+- [color-contrast() - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/color-contrast)
+- [WebAIM Contrast Checker](https://webaim.org/resources/contrastchecker/)
+- [WCAG 2.1 对比度要求](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)

--- a/src/topics/01.basics/color-mix/index.mdx
+++ b/src/topics/01.basics/color-mix/index.mdx
@@ -1,0 +1,164 @@
+---
+title: "CSS color-mix() 颜色混合函数"
+category: "基础知识"
+tags:
+  - CSS颜色
+  - color-mix
+  - 颜色混合
+  - CSS3
+description: "详解CSS color-mix()函数的使用方法、语法和应用场景"
+keywords: "color-mix, CSS颜色, 颜色混合, CSS颜色函数"
+---
+
+# CSS color-mix() 颜色混合函数
+
+## 什么是 color-mix()
+
+`color-mix()` 是 CSS 颜色函数，用于将两种颜色按指定比例混合生成新颜色。这是 CSS Color Level 5 规范中引入的功能。
+
+## 基本语法
+
+```css
+color-mix(in <colorspace>, <color> <percentage>, <color> [<percentage>])
+```
+
+### 参数说明
+
+| 参数 | 说明 |
+|------|------|
+| `<colorspace>` | 颜色空间，如 `srgb`、`srgb-linear`、`lab`、`oklch`、`lch`、`hsl`、`hwb`、`xyz`、`display-p3` |
+| `<color>` | 要混合的颜色 |
+| `<percentage>` | 混合比例，第一个颜色在结果中的占比 |
+
+### 简单的百分比语法
+
+```css
+/* 默认使用 srgb 颜色空间 */
+color-mix(in srgb, red 30%, blue);
+/* 结果：约 70% 蓝色 + 30% 红色的混合色 */
+```
+
+{/* @playground id="basic-usage" mode="demo" */}
+
+## 使用示例
+
+### 1. 基础颜色混合
+
+```css
+/* 将蓝色和红色混合 */
+.my-element {
+  background-color: color-mix(in srgb, blue 50%, red);
+}
+
+/* 调整混合比例 */
+.lighter {
+  background-color: color-mix(in srgb, blue 80%, red);
+}
+
+.darker {
+  background-color: color-mix(in srgb, blue 20%, red);
+}
+```
+
+{/* @playground id="ratio-adjust" mode="demo" */}
+
+### 2. 使用 HSL 颜色空间
+
+```css
+/* 使用 hsl 颜色空间混合 */
+.hsl-mix {
+  background-color: color-mix(in hsl, hsl(200 80% 50%) 50%, hsl(20 80% 50%));
+}
+```
+
+{/* @playground id="hsl-space" mode="demo" */}
+
+### 3. 使用 OKLCH（感知均匀颜色空间）
+
+```css
+/* 使用 oklch 获得更自然的混合效果 */
+.oklch-mix {
+  background-color: color-mix(in oklch, oklch(45% 0.25 250) 50%, oklch(70% 0.25 30));
+}
+```
+
+{/* @playground id="oklch-space" mode="demo" */}
+
+## 实际应用场景
+
+### 1. 主题色生成
+
+```css
+:root {
+  --primary: #007bff;
+  --primary-lighter: color-mix(in srgb, var(--primary) 70%, white);
+  --primary-darker: color-mix(in srgb, var(--primary) 70%, black);
+}
+
+.button:hover {
+  background-color: var(--primary-lighter);
+}
+
+.button:active {
+  background-color: var(--primary-darker);
+}
+```
+
+### 2. 悬停状态颜色变化
+
+```css
+.card {
+  background-color: color-mix(in srgb, var(--theme-color) 90%, white);
+  border: 1px solid color-mix(in srgb, var(--theme-color) 70%, white);
+}
+
+.card:hover {
+  background-color: color-mix(in srgb, var(--theme-color) 85%, white);
+  border-color: color-mix(in srgb, var(--theme-color) 60%, white);
+}
+```
+
+### 3. 语义化颜色系统
+
+```css
+:root {
+  --success-base: #22c55e;
+  --warning-base: #f59e0b;
+  --error-base: #ef4444;
+  
+  /* 生成浅色变体 */
+  --success-light: color-mix(in srgb, var(--success-base) 20%, white);
+  --warning-light: color-mix(in srgb, var(--warning-base) 20%, white);
+  --error-light: color-mix(in srgb, var(--error-base) 20%, white);
+}
+```
+
+## 浏览器兼容性
+
+`color-mix()` 在现代浏览器中获得支持：
+
+- Chrome 111+
+- Firefox 113+
+- Safari 16.2+
+- Edge 111+
+
+对于不支持的浏览器，可以使用回退方案：
+
+```css
+.button {
+  background-color: #007bff; /* 回退 */
+  background-color: color-mix(in srgb, #007bff 50%, white); /* 现代浏览器 */
+}
+```
+
+## 最佳实践
+
+1. **选择合适的颜色空间**：不同颜色空间混合效果不同，OKLCH 和 LAB 通常更符合人眼感知
+2. **设置默认混合比例**：50% 是最常见的设置
+3. **考虑辅助功能**：确保混合后的颜色对比度足够
+4. **使用透明通道**：可以混合带透明度的颜色
+
+## 参考资料
+
+- [CSS Color Level 5 - W3C](https://www.w3.org/TR/css-color-5/)
+- [color-mix() - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color-mix)

--- a/src/topics/01.basics/light-dark/index.mdx
+++ b/src/topics/01.basics/light-dark/index.mdx
@@ -1,0 +1,226 @@
+---
+title: "CSS light-dark() 暗色模式切换"
+category: "基础知识"
+tags:
+  - CSS颜色
+  - light-dark
+  - 暗色模式
+  - CSS3
+description: "详解CSS light-dark()函数实现暗色模式切换的方法"
+keywords: "light-dark, CSS颜色, 暗色模式, CSS颜色函数"
+---
+
+# CSS light-dark() 暗色模式切换
+
+## 什么是 light-dark()
+
+`light-dark()` 是 CSS 颜色函数，用于根据当前的色彩方案（color scheme）自动选择浅色或深色值。这是 CSS Color Level 5 规范中引入的功能，专门用于简化暗色模式（Dark Mode）的实现。
+
+## 基本语法
+
+```css
+light-dark(<light-color>, <dark-color>)
+```
+
+### 参数说明
+
+| 参数 | 说明 |
+|------|------|
+| `<light-color>` | 亮色模式下的颜色值 |
+| `<dark-color>` | 暗色模式下的颜色值 |
+
+{/* @playground id="basic-usage" mode="demo" */}
+
+## 使用示例
+
+### 1. 基础用法
+
+```css
+/* 根据系统配色方案自动选择颜色 */
+.element {
+  color: light-dark(#333, #f5f5f5);
+  background-color: light-dark(#fff, #1a1a1a);
+}
+```
+
+{/* @playground id="basic-demo" mode="demo" */}
+
+### 2. 与自定义属性结合
+
+```css
+:root {
+  color-scheme: light dark;
+}
+
+:root {
+  --text-primary: light-dark(#1a1a1a, #f5f5f5);
+  --bg-primary: light-dark(#ffffff, #121212);
+  --border-color: light-dark(#e0e0e0, #333333);
+}
+
+body {
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+}
+
+.card {
+  border-color: var(--border-color);
+}
+```
+
+{/* @playground id="with-css-variables" mode="demo" */}
+
+### 3. 与 color-mix() 结合
+
+```css
+:root {
+  color-scheme: light dark;
+}
+
+.button {
+  --button-bg: light-dark(#007bff, #0056b3);
+  --button-hover: light-dark(
+    color-mix(in srgb, #007bff 80%, white),
+    color-mix(in srgb, #007bff 80%, black)
+  );
+  
+  background-color: var(--button-bg);
+}
+
+.button:hover {
+  background-color: var(--button-hover);
+}
+```
+
+### 4. 完整的暗色模式主题
+
+```css
+:root {
+  color-scheme: light dark;
+}
+
+:root {
+  /* 文字颜色 */
+  --text-primary: light-dark(#1a1a1a, #e5e5e5);
+  --text-secondary: light-dark(#666666, #a0a0a0);
+  
+  /* 背景颜色 */
+  --bg-primary: light-dark(#ffffff, #121212);
+  --bg-secondary: light-dark(#f5f5f5, #1e1e1e);
+  --bg-elevated: light-dark(#ffffff, #252525);
+  
+  /* 边框颜色 */
+  --border-default: light-dark(#e0e0e0, #333333);
+  --border-strong: light-dark(#c0c0c0, #555555);
+  
+  /* 交互颜色 */
+  --link-color: light-dark(#0066cc, #66b3ff);
+  --focus-ring: light-dark(rgba(0, 102, 204, 0.5), rgba(102, 179, 255, 0.5));
+}
+
+body {
+  color: var(--text-primary);
+  background-color: var(--bg-primary);
+}
+```
+
+## color-scheme 属性
+
+要让 `light-dark()` 正常工作，需要在 `:root` 或 `html` 上设置 `color-scheme` 属性：
+
+```css
+:root {
+  /* 声明支持的配色方案 */
+  color-scheme: light dark;
+}
+```
+
+`color-scheme` 属性的作用：
+- 告诉浏览器页面支持 light 和 dark 两种模式
+- 浏览器会根据用户系统设置自动应用对应的配色方案
+- 影响浏览器默认的表单控件、滚动条等样式
+
+## 实际应用场景
+
+### 1. 组件库主题适配
+
+```css
+/* 定义组件变量 */
+.component {
+  --bg: light-dark(white, black);
+  --text: light-dark(black, white);
+  --border: light-dark(#ddd, #444);
+  
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+}
+```
+
+### 2. 图片和阴影适配
+
+```css
+.card {
+  background: light-dark(white, #1a1a1a);
+  box-shadow: light-dark(
+    0 2px 8px rgba(0, 0, 0, 0.1),
+    0 2px 8px rgba(0, 0, 0, 0.5)
+  );
+}
+
+.logo {
+  filter: light-dark(
+    none,
+    brightness(0) invert(1)
+  );
+}
+```
+
+### 3. 代码高亮适配
+
+```css
+pre, code {
+  background: light-dark(#f5f5f5, #1e1e1e);
+  color: light-dark(#333333, #d4d4d4);
+}
+```
+
+## 浏览器兼容性
+
+`light-dark()` 在现代浏览器中获得支持：
+
+- Chrome 123+
+- Firefox 120+
+- Safari 17.5+
+- Edge 123+
+
+对于不支持的浏览器，可以使用回退方案：
+
+```css
+.element {
+  color: #333; /* 回退 */
+  color: light-dark(#333, #f5f5f5); /* 现代浏览器 */
+}
+```
+
+## 与 prefers-color-scheme 的对比
+
+| 特性 | `light-dark()` | `prefers-color-scheme` |
+|------|---------------|----------------------|
+| 语法 | 内联颜色函数 | 媒体查询 |
+| 灵活性 | 可以在任何颜色属性中使用 | 只能用于整个块 |
+| 可组合性 | 可与其他颜色函数组合 | 独立使用 |
+| 浏览器支持 | 较新 | 广泛支持 |
+
+## 最佳实践
+
+1. **声明 color-scheme**：在使用 `light-dark()` 前，先声明 `color-scheme: light dark;`
+2. **结合 CSS 自定义属性**：使用变量管理颜色，便于维护
+3. **提供降级方案**：为不支持的浏览器提供备选颜色
+4. **测试两种模式**：确保浅色和深色模式下的可读性和对比度都符合要求
+
+## 参考资料
+
+- [CSS Color Level 5 - W3C](https://www.w3.org/TR/css-color-5/)
+- [light-dark() - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark)
+- [color-scheme - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme)

--- a/src/topics/02.layout/box-alignment/index.mdx
+++ b/src/topics/02.layout/box-alignment/index.mdx
@@ -1,0 +1,183 @@
+---
+title: "CSS Box Alignment 盒对齐模块"
+category: "布局"
+tags:
+  - CSS
+  - Box Alignment
+  - justify-content
+  - align-items
+  - place-items
+description: "详解CSS Box Alignment模块的属性和使用方法"
+keywords: "box-alignment, justify-content, align-items, justify-self, align-self"
+---
+
+# CSS Box Alignment 盒对齐模块
+
+## 概述
+
+CSS Box Alignment 模块定义了如何在容器内对齐框（盒子），适用于 Flexbox、Grid 和 Block 布局。
+
+{/* @playground id="basic-usage" mode="demo" */}
+
+## 核心属性
+
+### 1. justify-content 和 align-content
+
+控制**容器**中内容的对齐：
+
+```css
+.container {
+  justify-content: center; /* 主轴方向 */
+  align-content: center;   /* 交叉轴方向 */
+}
+```
+
+{/* @playground id="content-demo" mode="demo" */}
+
+### 2. justify-items 和 align-items
+
+控制**容器**中所有项目默认的对齐方式：
+
+```css
+.container {
+  justify-items: center; /* 单元格水平对齐 */
+  align-items: center;   /* 单元格垂直对齐 */
+}
+```
+
+### 3. justify-self 和 align-self
+
+控制**单个项目**自身的对齐：
+
+```css
+.item {
+  justify-self: end; /* 单元格内水平对齐 */
+  align-self: start;  /* 单元格内垂直对齐 */
+}
+```
+
+## 对齐值
+
+| 值 | 说明 |
+|---|------|
+| `start` | 从起始边缘对齐 |
+| `end` | 从结束边缘对齐 |
+| `center` | 居中对齐 |
+| `stretch` | 拉伸填满容器 |
+| `baseline` | 按基线对齐 |
+| `left` / `right` | 左右对齐（不适合主轴） |
+| `normal` | 默认行为 |
+
+## 使用场景
+
+### 1. Flexbox 主轴对齐
+
+```css
+.flex-container {
+  display: flex;
+  justify-content: space-between;
+}
+```
+
+### 2. Flexbox 交叉轴对齐
+
+```css
+.flex-container {
+  display: flex;
+  align-items: center;
+  min-height: 100vh;
+}
+```
+
+### 3. Grid 单元格对齐
+
+```css
+.grid-container {
+  display: grid;
+  justify-items: start;
+  align-items: center;
+}
+```
+
+### 4. 单个项目特殊对齐
+
+```css
+.special-item {
+  justify-self: end;
+  align-self: stretch;
+}
+```
+
+## place-items 和 place-self
+
+简写属性：
+
+```css
+/* place-items */
+place-items: center;
+/* 等同于 */
+align-items: center;
+justify-items: center;
+
+/* place-self */
+place-self: center;
+/* 等同于 */
+align-self: center;
+justify-self: center;
+```
+
+## 实际应用
+
+### 1. 垂直居中
+
+```css
+.center-box {
+  display: flex;
+  place-items: center;
+  place-content: center;
+  min-height: 100vh;
+}
+```
+
+### 2. 空间分配
+
+```css
+.distribute {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+```
+
+### 3. 表单对齐
+
+```css
+.form-row {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  align-items: center;
+  gap: 16px;
+}
+```
+
+## 浏览器兼容性
+
+Box Alignment 属性兼容性良好：
+
+- Chrome 57+
+- Firefox 52+
+- Safari 10.1+
+- Edge 16+
+
+## 最佳实践
+
+1. **理解主轴和交叉轴**：Flexbox 中主轴由 `flex-direction` 决定
+2. **选择合适的属性**：容器用 `*-items`/`*-content`，项目用 `*-self`
+3. **使用简写属性**：`place-items` 和 `place-self` 可以简化代码
+4. **注意 fallback**：旧浏览器可能需要额外的对齐方式
+
+## 参考资料
+
+- [CSS Box Alignment - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Alignment)
+- [Box Alignment in Flexbox - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Alignment/Box_Alignment_in_Flexbox)
+- [Box Alignment in Grid Layout - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Alignment/Box_Alignment_in_Grid_Layout)

--- a/src/topics/02.layout/gap-decorations/index.mdx
+++ b/src/topics/02.layout/gap-decorations/index.mdx
@@ -1,0 +1,242 @@
+---
+title: "CSS gap 装饰与间距技巧"
+category: "布局"
+tags:
+  - CSS
+  - gap
+  - 间距
+  - Flexbox
+  - Grid
+  - 装饰
+description: "详解CSS gap属性的使用方法和创意装饰技巧"
+keywords: "gap, CSS间距, flex gap, grid gap, 装饰技巧"
+---
+
+# CSS gap 装饰与间距技巧
+
+## 概述
+
+`gap` 属性是 CSS Flexbox 和 Grid 布局中用于设置元素之间间距的属性。它是 `row-gap` 和 `column-gap` 的简写形式。
+
+{/* @playground id="basic-usage" mode="demo" */}
+
+## 基本语法
+
+### 1. 简写形式
+
+```css
+/* 设置相同的行间距和列间距 */
+.container {
+  gap: 20px;
+}
+
+/* 分别设置行间距和列间距 */
+.container {
+  gap: 10px 20px; /* row-gap column-gap */
+}
+```
+
+### 2. 分别设置
+
+```css
+.container {
+  row-gap: 10px;      /* 行间距 */
+  column-gap: 20px;   /* 列间距 */
+}
+```
+
+{/* @playground id="gap-demo" mode="demo" */}
+
+## 使用场景
+
+### 1. Flexbox 布局
+
+```css
+.flex-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.flex-item {
+  width: calc(33.33% - 12px); /* 减去 gap 的影响 */
+}
+```
+
+### 2. Grid 布局
+
+```css
+.grid-container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 24px;
+}
+```
+
+### 3. 多列布局
+
+```css
+.columns {
+  column-count: 3;
+  column-gap: 40px;
+}
+```
+
+## 创意装饰技巧
+
+### 1. 渐变间距
+
+```css
+.decorative-gap {
+  gap: 20px;
+  background: linear-gradient(90deg, #007bff, #00d4ff);
+  padding: 2px;
+}
+
+.decorative-gap > * {
+  background: white;
+  padding: 16px;
+}
+```
+
+### 2. 边框装饰
+
+```css
+.border-gap {
+  gap: 16px;
+  padding: 16px;
+  background: #f0f0f0;
+}
+
+.border-gap > * + * {
+  border-top: 1px solid #ddd;
+}
+```
+
+### 3. 网格分隔线
+
+```css
+.grid-with-lines {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0;
+}
+
+.grid-with-lines > * {
+  padding: 20px;
+  border-right: 1px solid #eee;
+  border-bottom: 1px solid #eee;
+}
+
+.grid-with-lines > *:nth-child(3n) {
+  border-right: none;
+}
+```
+
+### 4. 响应式间距
+
+```css
+.responsive-gap {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+@media (min-width: 768px) {
+  .responsive-gap {
+    gap: 16px 24px; /* row-gap column-gap */
+  }
+}
+```
+
+## 实际应用
+
+### 1. 照片墙
+
+```css
+.photo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 8px;
+}
+
+.photo-grid img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  border-radius: 4px;
+}
+```
+
+### 2. 标签云
+
+```css
+.tag-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.tag {
+  padding: 4px 12px;
+  background: #f0f0f0;
+  border-radius: 16px;
+  font-size: 14px;
+}
+```
+
+### 3. 卡片列表
+
+```css
+.card-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card {
+  padding: 20px;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+```
+
+## 浏览器兼容性
+
+`gap` 属性在现代浏览器中支持良好：
+
+- Chrome 66+（Flexbox）、84+（Grid）
+- Firefox 61+（Flexbox）、66+（Grid）
+- Safari 12+（Flexbox）、16+（Grid）
+- Edge 79+
+
+### 回退方案
+
+对于不支持 `gap` 的浏览器，可以使用 `margin` 作为回退：
+
+```css
+.container {
+  gap: 20px; /* 现代浏览器 */
+}
+
+@supports not (gap: 20px) {
+  .container > * + * {
+    margin-top: 20px;
+    margin-left: 20px;
+  }
+}
+```
+
+## 最佳实践
+
+1. **优先使用 gap**：在 Flexbox 和 Grid 布局中，gap 比 margin 更适合控制间距
+2. **注意百分比**：gap 不支持百分比值
+3. **响应式设计**：使用媒体查询调整不同屏幕尺寸的 gap 值
+4. **与 calc 结合**：当元素宽度需要动态计算时，结合 calc 使用
+
+## 参考资料
+
+- [gap - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/gap)
+- [Chrome Blog - Gap Decorations](https://developer.chrome.com/blog/gap-decorations)
+- [CSS Box Alignment - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Alignment)

--- a/src/topics/02.layout/grid-template-areas/index.mdx
+++ b/src/topics/02.layout/grid-template-areas/index.mdx
@@ -1,0 +1,219 @@
+---
+title: "CSS grid-template-areas 可视化布局"
+category: "布局"
+tags:
+  - CSS
+  - Grid
+  - grid-template-areas
+  - 可视化布局
+  - CSS Grid
+description: "详解CSS grid-template-areas属性实现可视化网格布局的方法"
+keywords: "grid-template-areas, CSS Grid, 可视化布局, grid布局"
+---
+
+# CSS grid-template-areas 可视化布局
+
+## 概述
+
+`grid-template-areas` 是 CSS Grid 布局中的强大功能，通过在网格容器上定义命名的网格区域，实现布局的可视化描述。
+
+{/* @playground id="basic-usage" mode="demo" */}
+
+## 基本语法
+
+### 1. 定义网格区域
+
+```css
+.container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: auto;
+  grid-template-areas:
+    "header header header"
+    "sidebar main main"
+    "footer footer footer";
+}
+```
+
+### 2. 将元素分配到区域
+
+```css
+.header {
+  grid-area: header;
+}
+
+.sidebar {
+  grid-area: sidebar;
+}
+
+.main {
+  grid-area: main;
+}
+
+.footer {
+  grid-area: footer;
+}
+```
+
+{/* @playground id="layout-demo" mode="demo" */}
+
+## 常见布局模式
+
+### 1. 经典网页布局
+
+```css
+.page {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    "header header"
+    "sidebar content"
+    "footer footer";
+  min-height: 100vh;
+}
+```
+
+### 2. 圣杯布局
+
+```css
+.holy-grail {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-rows: auto 1fr auto;
+  grid-template-areas:
+    "header header header"
+    "nav main aside"
+    "footer footer footer";
+}
+```
+
+### 3. 响应式布局
+
+```css
+.responsive {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "header"
+    "main"
+    "sidebar"
+    "footer";
+}
+
+@media (min-width: 768px) {
+  .responsive {
+    grid-template-columns: 200px 1fr 200px;
+    grid-template-areas:
+      "header header header"
+      "sidebar main aside"
+      "footer footer footer";
+  }
+}
+```
+
+## 实际应用场景
+
+### 1. 博客布局
+
+```css
+.blog {
+  display: grid;
+  grid-template-columns: 1fr 300px;
+  grid-template-rows: auto auto auto auto;
+  grid-template-areas:
+    "header header"
+    "featured featured"
+    "content sidebar"
+    "footer footer";
+}
+```
+
+### 2. 仪表盘
+
+```css
+.dashboard {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: auto repeat(2, 200px);
+  grid-template-areas:
+    "stats stats stats stats"
+    "chart chart chart pie"
+    "chart chart chart list";
+}
+```
+
+### 3. 日历视图
+
+```css
+.calendar {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  grid-template-areas:
+    "sun sun mon tue wed thu fri"
+    "event event . . . . ."
+    ". . event event event . .";
+}
+```
+
+## 高级技巧
+
+### 1. 合并单元格
+
+使用相同的区域名称可以合并单元格：
+
+```css
+grid-template-areas:
+  "header header header"
+  "sidebar main main"
+  "sidebar footer footer";
+/* sidebar 占两行 */
+```
+
+### 2. 使用句点（.）留空
+
+```css
+grid-template-areas:
+  "header header ."
+  "sidebar main main"
+  ". footer footer";
+```
+
+### 3. 区域形状限制
+
+区域必须是矩形，不能是 L 形或其他形状：
+
+```css
+/* 无效 - 不能创建 L 形区域 */
+grid-template-areas:
+  "header header"
+  "header sidebar";
+
+/* 有效 - 两个矩形 */
+grid-template-areas:
+  "header header"
+  "sidebar sidebar";
+```
+
+## 浏览器兼容性
+
+`grid-template-areas` 属性兼容性良好：
+
+- Chrome 57+
+- Firefox 52+
+- Safari 10.1+
+- Edge 16+
+
+## 最佳实践
+
+1. **使用语义化命名**：区域名称应反映内容用途
+2. **保持矩形区域**：避免创建非矩形区域
+3. **使用响应式设计**：结合媒体查询调整布局
+4. **配合其他 Grid 属性**：如 `grid-column`、`grid-row` 进行微调
+5. **考虑可访问性**：确保语义结构清晰
+
+## 参考资料
+
+- [grid-template-areas - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-areas)
+- [CSS Grid Layout - MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout)
+- [WebKit Blog - Grid Template Areas](https://webkit.org/blog/17620/)

--- a/src/topics/09.advanced/houdini-animation-worklet/index.mdx
+++ b/src/topics/09.advanced/houdini-animation-worklet/index.mdx
@@ -1,0 +1,310 @@
+---
+title: "CSS Houdini Animation Worklet"
+category: "高级特性"
+tags:
+  - Houdini
+  - Animation Worklet
+  - registerAnimator
+  - WorkletAnimation
+  - 自定义动画
+description: "详解 CSS Houdini Animation Worklet，通过 registerAnimator 注册自定义动画器，实现高性能线程化动画"
+keywords: "CSS Houdini, Animation Worklet, registerAnimator, WorkletAnimation, 自定义动画"
+---
+
+# CSS Houdini Animation Worklet
+
+**通过 JavaScript Worklet 创建高性能的线程化动画**
+
+---
+
+## 概述
+
+Animation Worklet 是 Houdini CSS API 的一部分，允许开发者创建基于工作线程（worklet）的高性能动画。与传统 CSS 动画和 Web Animations API 不同，Animation Worklet 运行在独立线程上，不受主线程布局和渲染影响，可以实现极其流畅的动画效果。
+
+### 与其他动画方案的区别
+
+| 方案 | 运行线程 | 性能 | 控制能力 |
+|------|----------|------|----------|
+| CSS Transition/Animation | 主线程 | 中等 | 有限 |
+| Web Animations API | 主线程 | 中等 | 较强 |
+| **Animation Worklet** | **独立线程** | **高** | **完全控制** |
+| CSS Scroll-driven Animations | 主线程 | 高 | 有限 |
+
+### 基本工作流程
+
+1. **加载 Worklet**：`await CSS.animationWorklet.addModule('animator.js')`
+2. **注册动画器**：`registerAnimator(name, class)`
+3. **创建动画**：`new WorkletAnimation(name, keyframes, options)`
+
+---
+
+## registerAnimator 注册动画器
+
+### 基本语法
+
+```js
+registerAnimator(name, classDefinition)
+```
+
+- `name`：动画器名称
+- `classDefinition`：类定义，必须实现 `animate(currentTime, effect)` 方法
+
+### 主类定义
+
+```js
+class MyAnimator {
+  constructor() {
+    // 初始化，可访问全局作用域
+  }
+
+  animate(currentTime, effect) {
+    // currentTime: 当前时间（毫秒）
+    // effect: 关联的 KeyframeEffect
+    // 在这里计算并应用动画状态
+  }
+
+  // 可选：取消时清理
+  cancel() {}
+}
+registerAnimator('my-animator', MyAnimator);
+```
+
+---
+
+## WorkletGlobalScope 全局作用域
+
+在 Animation Worklet 中运行的代码拥有独立的全局作用域，提供以下属性和方法：
+
+### currentTime
+
+当前动画时间（毫秒），由浏览器驱动：
+
+```js
+animate(currentTime, effect) {
+  // currentTime 由浏览器按帧更新
+  const progress = currentTime / 1000; // 转换为秒
+  element.style.transform = `translateX(${progress * 100}px)`;
+}
+```
+
+### scrollLinked
+
+关联滚动-linked 动画：
+
+```js
+animate(currentTime, effect) {
+  if (this.scrollLinked) {
+    const scrollY = this.scrollTimeline.scrollOffset;
+    // 基于滚动位置计算动画
+  }
+}
+```
+
+### 示例：帧同步动画
+
+```js
+class ParallaxAnimator {
+  animate(currentTime, effect) {
+    const scrollY = this.scrollOffset || 0;
+    const parallaxOffset = scrollY * 0.5;
+
+    // 更新每个 layer 的 transform
+    this.layers.forEach((layer, i) => {
+      const depth = i * 0.2 + 0.1;
+      layer.style.transform = `translateY(${-parallaxOffset * depth}px)`;
+    });
+  }
+}
+registerAnimator('parallax', ParallaxAnimator);
+```
+
+---
+
+## WorkletAnimation 创建动画
+
+### 基本语法
+
+```js
+const animation = new WorkletAnimation(
+  'my-animator',    // 动画器名称
+  keyframeEffect,    // KeyframeEffect 对象
+  document.timeline, // 时间线（可选）
+  options            // 配置选项
+);
+animation.play();
+```
+
+### 完整示例
+
+```js
+// 1. 注册动画器
+registerAnimator('slide-in', class {
+  animate(currentTime, effect) {
+    const duration = 500; // ms
+    const progress = Math.min(currentTime / duration, 1);
+    const eased = 1 - Math.pow(1 - progress, 3); // ease-out cubic
+
+    effect.target.style.transform = `translateX(${(1 - eased) * -200}px)`;
+    effect.target.style.opacity = eased;
+  }
+});
+
+// 2. 在主线程创建并播放
+const elem = document.querySelector('.slide-element');
+const effect = new KeyframeEffect(elem, [], { duration: 500 });
+const animation = new WorkletAnimation('slide-in', effect);
+animation.play();
+```
+
+---
+
+## 与 CSS Scroll-driven Animations 对比
+
+| 特性 | Animation Worklet | CSS Scroll-driven |
+|------|-------------------|-------------------|
+| 运行线程 | 独立线程 | 主线程 |
+| JavaScript 控制 | ✅ 完全控制 | ❌ CSS-only |
+| 滚动关联 | ✅ scrollLinked | ✅ 内置支持 |
+| 浏览器支持 | Chromium only | 主流浏览器 |
+| 性能 | 极高 | 高 |
+| API 复杂度 | 较高 | 简单 |
+
+### 何时使用 Animation Worklet
+
+- 需要基于滚动位置做复杂的 JavaScript 计算
+- 需要在动画中进行条件判断
+- 需要多个元素协同动画（如视差效果）
+- 对性能要求极高（60fps+）
+
+### 何时使用 Scroll-driven Animations
+
+- 只需要简单的滚动关联动画
+- 需要更好的浏览器兼容性
+- 不需要复杂的 JavaScript 逻辑
+
+---
+
+## 实战案例
+
+### 案例一：滚动视差（Parallax）
+
+```js
+class ParallaxAnimator {
+  constructor() {
+    this.layers = [];
+  }
+
+  animate(currentTime, effect) {
+    const scrollY = this.scrollOffset || 0;
+
+    this.layers.forEach((layer, i) => {
+      const depth = 0.1 + i * 0.15;
+      const move = scrollY * depth;
+      layer.element.style.transform = `translateY(${move}px)`;
+    });
+  }
+}
+registerAnimator('parallax', ParallaxAnimator);
+
+// 主线程使用
+document.querySelectorAll('.parallax-layer').forEach((el, i) => {
+  const effect = new KeyframeEffect(el, [], { duration: 0 });
+  const anim = new WorkletAnimation('parallax', effect);
+  anim.scrollLinked = true;
+  anim.play();
+});
+```
+
+### 案例二：帧同步动画
+
+```js
+class FrameSyncAnimator {
+  animate(currentTime, effect) {
+    const duration = 2000; // 2秒循环
+    const cycleTime = currentTime % duration;
+    const progress = cycleTime / duration;
+
+    // 0-25%: 从左滑入
+    // 25-75%: 停留
+    // 75-100%: 向右滑出
+    let x, opacity;
+    if (progress < 0.25) {
+      const t = progress / 0.25;
+      x = -100 + t * 100;
+      opacity = t;
+    } else if (progress < 0.75) {
+      x = 0;
+      opacity = 1;
+    } else {
+      const t = (progress - 0.75) / 0.25;
+      x = t * 100;
+      opacity = 1 - t;
+    }
+
+    effect.target.style.transform = `translateX(${x}%)`;
+    effect.target.style.opacity = opacity;
+  }
+}
+registerAnimator('frame-sync', FrameSyncAnimator);
+```
+
+---
+
+## 浏览器兼容性
+
+| 浏览器 | 支持情况 |
+|--------|----------|
+| Chrome | ✅ 84+ |
+| Edge | ✅ 84+ |
+| Firefox | ❌ 不支持 |
+| Safari | ❌ 不支持 |
+
+**注意**：Animation Worklet 已在 Chrome 84 中默认启用，但需要通过 HTTPS 或 localhost 访问。
+
+### 功能检测
+
+```js
+if ('animationWorklet' in CSS) {
+  await CSS.animationWorklet.addModule('animator.js');
+} else {
+  // 回退方案：使用 CSS animations 或 Web Animations API
+  element.animate([...], { duration: 500, easing: 'ease-out' });
+}
+```
+
+---
+
+## 常见问题
+
+### 1. Worklet 与主线程通信
+
+通过共享的 `effect.target` 直接操作 DOM 元素：
+
+```js
+animate(currentTime, effect) {
+  effect.target.style.transform = '...'; // 直接操作 DOM
+}
+```
+
+### 2. 滚动关联
+
+Animation Worklet 的滚动关联通过 `scrollLinked` 属性控制：
+
+```js
+animation.scrollLinked = true; // 启用滚动关联
+animation.scrollTimeline = scrollTimeline; // 关联滚动时间线
+```
+
+### 3. 性能优化
+
+- 避免在 `animate()` 中进行布局计算
+- 使用 `transform` 和 `opacity` 做动画（触发 Composite）
+- 批量 DOM 操作
+
+---
+
+## 总结
+
+Animation Worklet 为高性能动画提供了一个强大的底层 API。虽然目前仅 Chromium 浏览器支持，但它为需要极致流畅动画效果的应用（如长滚动页面、复杂交互界面）提供了新的可能性。
+
+配合 CSS Scroll-driven Animations，可以根据场景选择最合适的方案：简单滚动关联用 CSS，需要复杂 JavaScript 逻辑时用 Animation Worklet。

--- a/src/topics/09.advanced/houdini-layout-api/index.mdx
+++ b/src/topics/09.advanced/houdini-layout-api/index.mdx
@@ -1,0 +1,299 @@
+---
+title: "CSS Houdini Layout API"
+category: "高级特性"
+tags:
+  - Houdini
+  - Layout API
+  - CSS Layout
+  - registerLayout
+  - 自定义布局
+description: "详解 CSS Houdini Layout API，通过 registerLayout 注册自定义布局算法，实现高级布局效果"
+keywords: "CSS Houdini, Layout API, registerLayout, CSS Layout API, 自定义布局"
+---
+
+# CSS Houdini Layout API
+
+**通过 JavaScript Worklet 注册自定义布局算法**
+
+---
+
+## 概述
+
+Layout API 是 CSS Houdini 的核心部分，它允许开发者注册自己的布局算法，类似于 `display: flex` 或 `display: grid`，但完全由 JavaScript 定义。
+
+### 基本工作流程
+
+1. **加载 Worklet**：`CSS.layoutWorklet.addModule('layout-script.js')`
+2. **注册布局**：`registerLayout(name, class)`
+3. **CSS 使用**：`.container { display: layout(my-layout); }`
+
+```js
+// my-layout.js
+class CenterLayout {
+  async intrinsicSizes() {}
+  async layout(children, edges, constraints, styleMap) {
+    const fragment = { autoBlockSize: 0 };
+    return fragment;
+  }
+}
+registerLayout('centering', CenterLayout);
+```
+
+---
+
+## registerLayout 注册自定义布局
+
+### 基本语法
+
+```js
+registerLayout(name, classDefinition)
+```
+
+- `name`：字符串，布局名称，在 CSS 中通过 `display: layout(name)` 引用
+- `classDefinition`：类定义，必须实现 `layout()` 方法，可选实现 `intrinsicSizes()`
+
+### intrinsicSizes()
+
+返回布局的 intrinsic size 信息，用于 CSS 引擎计算尺寸：
+
+```js
+class MyLayout {
+  async intrinsicSizes() {
+    return {
+      minInlineSize: 0,
+      maxInlineSize: Infinity,
+      minBlockSize: 0,
+      maxBlockSize: Infinity
+    };
+  }
+}
+```
+
+### layout(children, edges, constraints, styleMap)
+
+核心布局方法，控制子元素的放置：
+
+```js
+class MyLayout {
+  async layout(children, edges, constraints, styleMap) {
+    const availableInlineSize = constraints.fixedInlineSize - edges.inline;
+    const availableBlockSize = constraints.fixedBlockSize - edges.block;
+    const childFragments = [];
+
+    for (const child of children) {
+      const fragment = await child.layoutNextFragment({
+        availableInlineSize,
+        availableBlockSize
+      });
+      maxChildBlockSize = Math.max(maxChildBlockSize, fragment.blockSize);
+      childFragments.push(fragment);
+    }
+
+    return {
+      autoBlockSize: maxChildBlockSize + edges.block,
+      childFragments
+    };
+  }
+}
+```
+
+---
+
+## 布局参数详解
+
+### constraints — 尺寸约束
+
+| 属性 | 说明 |
+|------|------|
+| `constraints.fixedInlineSize` | 固定内联尺寸（类似 width）|
+| `constraints.fixedBlockSize` | 固定块级尺寸（类似 height）|
+| `constraints.percentageInlineSize` | 百分比内联尺寸 |
+| `constraints.percentageBlockSize` | 百分比块级尺寸 |
+
+### edges — 边框信息
+
+| 属性 | 说明 |
+|------|------|
+| `edges.inlineStart` | 内联起始边（left）|
+| `edges.inlineEnd` | 内联结束边（right）|
+| `edges.blockStart` | 块级起始边（top）|
+| `edges.blockEnd` | 块级结束边（bottom）|
+| `edges.inline` | `inlineStart + inlineEnd` |
+| `edges.block` | `blockStart + blockEnd` |
+
+### childFragments — 子片段
+
+```js
+// 读取子元素尺寸
+fragment.inlineSize;   // 子元素宽度
+fragment.blockSize;   // 子元素高度
+
+// 设置子元素位置
+fragment.inlineOffset = 50;  // x 坐标
+fragment.blockOffset = 100; // y 坐标
+```
+
+---
+
+## 实战案例
+
+### 案例一：居中布局
+
+```js
+class CenteringLayout {
+  async intrinsicSizes() {}
+
+  async layout(children, edges, constraints, styleMap) {
+    const availableInlineSize = constraints.fixedInlineSize - edges.inline;
+    const availableBlockSize = constraints.fixedBlockSize - edges.block;
+    const childFragments = [];
+
+    for (const child of children) {
+      const fragment = await child.layoutNextFragment({
+        availableInlineSize,
+        availableBlockSize
+      });
+
+      // 居中放置
+      fragment.inlineOffset = edges.inlineStart +
+        (availableInlineSize - fragment.inlineSize) / 2;
+      fragment.blockOffset = edges.blockStart +
+        (availableBlockSize - fragment.blockSize) / 2;
+
+      childFragments.push(fragment);
+    }
+
+    return {
+      autoBlockSize: availableBlockSize,
+      childFragments
+    };
+  }
+}
+registerLayout('centering', CenteringLayout);
+```
+
+**CSS**：
+```css
+.center-container {
+  display: layout(centering);
+  width: 400px;
+  height: 300px;
+}
+```
+
+### 案例二：水平等分布局
+
+```js
+class EqualColumnsLayout {
+  async layout(children, edges, constraints, styleMap) {
+    const availableInlineSize = constraints.fixedInlineSize - edges.inline;
+    const gap = 10;
+    const childCount = children.length;
+
+    if (childCount === 0) {
+      return { autoBlockSize: 0, childFragments: [] };
+    }
+
+    const columnWidth = (availableInlineSize - gap * (childCount - 1)) / childCount;
+    const childFragments = [];
+    let maxBlockSize = 0;
+
+    for (let i = 0; i < children.length; i++) {
+      const fragment = await children[i].layoutNextFragment({
+        availableInlineSize: columnWidth
+      });
+
+      fragment.inlineOffset = edges.inlineStart + i * (columnWidth + gap);
+      fragment.blockOffset = edges.blockStart;
+      fragment.inlineSize = columnWidth;
+
+      maxBlockSize = Math.max(maxBlockSize, fragment.blockSize);
+      childFragments.push(fragment);
+    }
+
+    return {
+      autoBlockSize: maxBlockSize + edges.block,
+      childFragments
+    };
+  }
+}
+registerLayout('equal-columns', EqualColumnsLayout);
+```
+
+### 案例三：瀑布流布局
+
+```js
+class MasonryLayout {
+  async layout(children, edges, constraints, styleMap) {
+    const availableInlineSize = constraints.fixedInlineSize - edges.inline;
+    const columnWidth = 150;
+    const gap = 10;
+    const columnCount = Math.max(1,
+      Math.floor((availableInlineSize + gap) / (columnWidth + gap)));
+    const actualColumnWidth =
+      (availableInlineSize - gap * (columnCount - 1)) / columnCount;
+
+    const columnHeights = new Array(columnCount).fill(0);
+    const childFragments = [];
+
+    for (const child of children) {
+      const minHeightCol = columnHeights.indexOf(Math.min(...columnHeights));
+      const fragment = await child.layoutNextFragment({
+        availableInlineSize: actualColumnWidth
+      });
+
+      // 缩放以适应列宽
+      if (fragment.inlineSize > actualColumnWidth) {
+        const scale = actualColumnWidth / fragment.inlineSize;
+        fragment.inlineSize = actualColumnWidth;
+        fragment.blockSize = fragment.blockSize * scale;
+      }
+
+      fragment.inlineOffset = edges.inlineStart + minHeightCol * (actualColumnWidth + gap);
+      fragment.blockOffset = edges.blockStart + columnHeights[minHeightCol];
+      columnHeights[minHeightCol] += fragment.blockSize + gap;
+      childFragments.push(fragment);
+    }
+
+    return {
+      autoBlockSize: Math.max(...columnHeights) + edges.block,
+      childFragments
+    };
+  }
+}
+registerLayout('masonry', MasonryLayout);
+```
+
+---
+
+## 浏览器兼容性
+
+| 浏览器 | 支持情况 |
+|--------|----------|
+| Chrome | ✅ 65+（部分）|
+| Edge | ✅ 79+（部分）|
+| Firefox | ❌ 不支持 |
+| Safari | ❌ 不支持 |
+
+**注意**：Layout API 目前支持有限，chromium 中需要开启实验性功能。
+
+### 功能检测
+
+```js
+if ('layoutWorklet' in CSS) {
+  CSS.layoutWorklet.addModule('my-layout.js');
+} else {
+  console.warn('Layout API not supported');
+}
+```
+
+---
+
+## 与其他 Houdini API 的区别
+
+| API | 作用 | 影响 |
+|-----|------|------|
+| Paint API | 绘制背景/边框图案 | 只影响绘制 |
+| Layout API | 自定义布局算法 | 影响盒模型生成 |
+| Animation Worklet | 自定义动画 | 影响动画效果 |
+| Properties & Values | 自定义 CSS 属性 | 影响样式计算 |

--- a/src/topics/09.advanced/houdini-paint-api/index.mdx
+++ b/src/topics/09.advanced/houdini-paint-api/index.mdx
@@ -1,0 +1,401 @@
+---
+title: "CSS Houdini Paint API"
+category: "高级特性"
+tags:
+  - Houdini
+  - Paint API
+  - CSS Paint
+  - 自定义 paint
+  - registerPaint
+description: "详解 CSS Houdini Paint API，通过 registerPaint 注册自定义 paint worklet，实现自定义图案绘制"
+keywords: "CSS Houdini, Paint API, registerPaint, paint worklet, 自定义图案"
+---
+
+# CSS Houdini Paint API
+
+**通过 JavaScript Worklet 在 CSS 中绘制自定义图案**
+
+---
+
+## 概述
+
+CSS Houdini 是浏览器提供的一套底层 API，允许开发者介入浏览器的 CSS 引擎处理过程。Paint API 是 Houdini 规范中最实用的部分之一，它允许我们通过 JavaScript 在 CSS 中绘制自定义图案。
+
+传统 CSS 能实现的效果有限，而 Paint API 让你可以用 Canvas 2D 的绘图能力，在 `background-image`、`border-image`、`list-style-image` 等属性中绘制任意图案。
+
+### 工作原理
+
+1. **注册 Worklet**：使用 `registerPaint()` 注册一个 paint worklet 类
+2. **加载 Worklet**：通过 `CSS.paintWorklet.addModule()` 加载 worklet 脚本
+3. **使用**：在 CSS 中通过 `paint(worklet-name)` 函数引用
+
+```js
+// my-paint.js
+class MyPaint {
+  paint(ctx, geom, properties) {
+    // ctx: CanvasRenderingContext2D
+    // geom: { width, height }
+    // properties: CSSStyleValue map
+  }
+}
+registerPaint('my-paint', MyPaint);
+```
+
+```html
+<script>
+  CSS.paintWorklet.addModule('my-paint.js');
+</script>
+<style>
+  .element {
+    background-image: paint(my-paint);
+  }
+</style>
+```
+
+---
+
+## registerPaint 注册自定义 paint worklet
+
+### 基本语法
+
+```js
+registerPaint(name, classDefinition)
+```
+
+- `name`：字符串，worklet 的名称，在 CSS 中通过 `paint(name)` 引用
+- `classDefinition`：类定义，必须实现 `paint()` 方法
+
+```js
+class DotPattern {
+  paint(ctx, geom) {
+    ctx.fillStyle = 'blue';
+    ctx.beginPath();
+    ctx.arc(geom.width / 2, geom.height / 2, 20, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+registerPaint('dot', DotPattern);
+```
+
+### inputProperties 定义自定义属性
+
+通过 `inputProperties` 静态 getter 声明需要监听的自定义属性，让 CSS 变化时自动触发 worklet 重绘：
+
+```js
+class GradientPaint {
+  static get inputProperties() {
+    return ['--gradient-color1', '--gradient-color2'];
+  }
+
+  paint(ctx, geom, properties) {
+    const color1 = properties.get('--gradient-color1').toString();
+    const color2 = properties.get('--gradient-color2').toString();
+
+    const gradient = ctx.createLinearGradient(0, 0, geom.width, geom.height);
+    gradient.addColorStop(0, color1);
+    gradient.addColorStop(1, color2);
+
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, geom.width, geom.height);
+  }
+}
+registerPaint('gradient', GradientPaint);
+```
+
+```css
+.element {
+  --gradient-color1: red;
+  --gradient-color2: blue;
+  background-image: paint(gradient);
+}
+```
+
+---
+
+## paint(ctx, geom, properties) 回调参数详解
+
+### ctx — 绘图上下文
+
+`ctx` 是 `CanvasRenderingContext2D` 实例，支持大部分 Canvas 2D API：
+
+```js
+paint(ctx, geom, properties) {
+  // 矩形
+  ctx.fillRect(x, y, width, height);
+  ctx.strokeRect(x, y, width, height);
+  ctx.clearRect(x, y, width, height);
+
+  // 渐变
+  const gradient = ctx.createLinearGradient(x0, y0, x1, y1);
+  gradient.addColorStop(0, 'red');
+  gradient.addColorStop(1, 'blue');
+  ctx.fillStyle = gradient;
+
+  // 路径
+  ctx.beginPath();
+  ctx.moveTo(x, y);
+  ctx.lineTo(x, y);
+  ctx.arc(x, y, radius, startAngle, endAngle);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+}
+```
+
+### geom — 几何信息
+
+```js
+paint(ctx, geom, properties) {
+  console.log(geom.width);   // 元素宽度
+  console.log(geom.height);  // 元素高度
+  console.log(geom.width + geom.height); // 可用于缩放图案
+}
+```
+
+### properties — 样式属性
+
+`properties` 是 `CSSStyleValue` 的 Map，支持获取任意 CSS 属性：
+
+```js
+static get inputProperties() {
+  return ['--my-var', 'width', 'background-color'];
+}
+
+paint(ctx, geom, properties) {
+  // 获取自定义属性
+  const myVar = properties.get('--my-var');
+
+  // 获取计算样式
+  const bgColor = properties.get('background-color');
+
+  console.log(myVar.toString());    // 属性值字符串
+  console.log(bgColor.cssText);     // 颜色值
+}
+```
+
+---
+
+## ctx 绘图上下文方法
+
+### 矩形操作
+
+| 方法 | 说明 |
+|------|------|
+| `fillRect(x, y, w, h)` | 填充矩形 |
+| `strokeRect(x, y, w, h)` | 描边矩形 |
+| `clearRect(x, y, w, h)` | 清除矩形区域（透明） |
+
+```js
+paint(ctx, geom) {
+  // 绘制格子图案
+  const size = 20;
+  for (let x = 0; x < geom.width; x += size) {
+    for (let y = 0; y < geom.height; y += size) {
+      ctx.fillStyle = (x / size + y / size) % 2 === 0 ? '#fff' : '#000';
+      ctx.fillRect(x, y, size, size);
+    }
+  }
+}
+```
+
+### 渐变
+
+```js
+// 线性渐变
+const gradient = ctx.createLinearGradient(0, 0, geom.width, 0);
+gradient.addColorStop(0, 'red');
+gradient.addColorStop(0.5, 'yellow');
+gradient.addColorStop(1, 'blue');
+ctx.fillStyle = gradient;
+ctx.fillRect(0, 0, geom.width, geom.height);
+
+// 径向渐变
+const radial = ctx.createRadialGradient(
+  geom.width / 2, geom.height / 2, 0,
+  geom.width / 2, geom.height / 2, geom.width / 2
+);
+radial.addColorStop(0, 'white');
+radial.addColorStop(1, 'black');
+ctx.fillStyle = radial;
+ctx.fillRect(0, 0, geom.width, geom.height);
+```
+
+### 路径绘制
+
+```js
+paint(ctx, geom) {
+  // 多边形
+  ctx.beginPath();
+  const sides = 6;
+  const cx = geom.width / 2;
+  const cy = geom.height / 2;
+  const r = Math.min(cx, cy) * 0.8;
+
+  for (let i = 0; i <= sides; i++) {
+    const angle = (i / sides) * Math.PI * 2 - Math.PI / 2;
+    const x = cx + r * Math.cos(angle);
+    const y = cy + r * Math.sin(angle);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+  ctx.fill();
+}
+```
+
+---
+
+## 实战案例
+
+### 案例一：Blob 动画
+
+通过 CSS 动画驱动 `@property` 自定义属性，worklet 读取属性值绘制动态 blob 形状：
+
+```js
+class BlobPaint {
+  static get inputProperties() {
+    return ['--blob-radius'];
+  }
+
+  paint(ctx, geom, properties) {
+    const radius = parseFloat(properties.get('--blob-radius')) || 50;
+    const cx = geom.width / 2;
+    const cy = geom.height / 2;
+
+    ctx.fillStyle = '#6366f1';
+    ctx.beginPath();
+
+    // 用多个圆弧组合成 blob 形状
+    const points = 8;
+    for (let i = 0; i <= points; i++) {
+      const angle = (i / points) * Math.PI * 2;
+      const r = radius + Math.sin(angle * 3) * (radius * 0.3);
+      const x = cx + r * Math.cos(angle);
+      const y = cy + r * Math.sin(angle);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.fill();
+  }
+}
+registerPaint('blob', BlobPaint);
+```
+
+**CSS**：
+```css
+@property --blob-radius {
+  syntax: '<number>';
+  initial-value: 50;
+  inherits: false;
+}
+
+.blob-element {
+  --blob-radius: 50;
+  background-image: paint(blob);
+  animation: blobAnim 2s ease-in-out infinite alternate;
+}
+
+@keyframes blobAnim {
+  to { --blob-radius: 80; }
+}
+```
+
+### 案例二：多边形边框
+
+```js
+class PolygonBorderPaint {
+  static get inputProperties() {
+    return ['--polygon-sides', '--polygon-color'];
+  }
+
+  paint(ctx, geom, properties) {
+    const sides = parseInt(properties.get('--polygon-sides')) || 6;
+    const color = properties.get('--polygon-color')?.toString() || '#3b82f6';
+    const cx = geom.width / 2;
+    const cy = geom.height / 2;
+    const r = Math.min(cx, cy) * 0.8;
+
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 4;
+    ctx.beginPath();
+
+    for (let i = 0; i <= sides; i++) {
+      const angle = (i / sides) * Math.PI * 2 - Math.PI / 2;
+      const x = cx + r * Math.cos(angle);
+      const y = cy + r * Math.sin(angle);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.stroke();
+  }
+}
+registerPaint('polygon-border', PolygonBorderPaint);
+```
+
+### 案例三：图像分割（棋盘格混合）
+
+```js
+class CheckerboardPaint {
+  static get inputProperties() {
+    return ['--checkerboard-size', '--checkerboard-color'];
+  }
+
+  paint(ctx, geom, properties) {
+    const size = parseInt(properties.get('--checkerboard-size')) || 20;
+    const color = properties.get('--checkerboard-color')?.toString() || 'rgba(0,0,0,0.5)';
+
+    ctx.clearRect(0, 0, geom.width, geom.height);
+
+    for (let x = 0; x < geom.width; x += size) {
+      for (let y = 0; y < geom.height; y += size) {
+        if ((x / size + y / size) % 2 === 0) {
+          ctx.fillStyle = color;
+          ctx.fillRect(x, y, size, size);
+        }
+      }
+    }
+  }
+}
+registerPaint('checkerboard', CheckerboardPaint);
+```
+
+---
+
+## 浏览器兼容性
+
+| 浏览器 | 支持情况 |
+|--------|----------|
+| Chrome | ✅ 65+ |
+| Edge | ✅ 79+ |
+| Firefox | ❌ 不支持 |
+| Safari | ❌ 不支持 |
+| iOS Safari | ❌ 不支持 |
+
+**注意**：Paint API 需要通过 HTTPS 或 localhost 访问才能正常工作。
+
+### 功能检测
+
+```js
+if ('paintWorklet' in CSS) {
+  CSS.paintWorklet.addModule('my-paint.js');
+} else {
+  // 回退方案
+  document.querySelector('.element').style.background = 'blue';
+}
+```
+
+### 常见问题
+
+1. **Worklet 加载失败**：确保通过 HTTPS 或 localhost 访问
+2. **属性变化不重绘**：确认在 `inputProperties` 中声明了对应属性
+3. **性能问题**：避免在 paint 中执行耗时操作，Houdini 运行在独立线程但仍需高效
+
+---
+
+## 总结
+
+CSS Paint API 是 Houdini 中最实用的 API 之一，它让你可以用 Canvas 2D 的能力绘制任意 CSS 图案。配合 `@property` 定义的可动画自定义属性，可以实现过去只有 JavaScript 才能做到的复杂动画效果。
+
+尽管目前仅 Chrome/Edge 支持，但作为渐进增强的方案，可以在支持的浏览器中提供更丰富的视觉效果。

--- a/src/topics/09.advanced/style-observer/index.mdx
+++ b/src/topics/09.advanced/style-observer/index.mdx
@@ -1,0 +1,176 @@
+---
+title: "CSS style observer 样式观察器"
+category: "进阶知识"
+tags:
+  - CSS
+  - style observer
+  - Houdini
+  - 样式观察器
+description: "详解CSS style observer API的使用方法和应用场景"
+keywords: "style observer, CSS Houdini, registerProperty, styleMap"
+---
+
+# CSS style observer 样式观察器
+
+## 什么是 style observer
+
+Style Observer 是 CSS Houdini API 的一部分，允许 JavaScript 监听和响应 CSS 样式变化。通过 `CSS.styleMap` 和相关的 Houdini API，开发者可以在样式变化时执行自定义逻辑。
+
+{/* @playground id="basic-usage" mode="demo" */}
+
+## 基本概念
+
+### 1. CSS.registerProperty()
+
+在 Houdini 中，首先需要使用 `CSS.registerProperty()` 注册自定义属性：
+
+```javascript
+CSS.registerProperty({
+  name: '--my-color',
+  syntax: '<color>',
+  inherits: false,
+  initialValue: '#ff0000',
+});
+```
+
+### 2. 使用 styleMap
+
+获取元素的样式映射：
+
+```javascript
+const element = document.querySelector('.my-element');
+const styleMap = element.attributeStyleMap;
+```
+
+### 3. 观察样式变化
+
+通过 `ComputedEffect` 接口来观察样式变化：
+
+```javascript
+const effect = new CSSStyleEffect();
+effect.observe(element, 'background-color');
+effect.addEventListener('stylechange', (event) => {
+  console.log('Style changed:', event.target, event.type, event.value);
+});
+```
+
+{/* @playground id="demo" mode="demo" */}
+
+## 实际应用场景
+
+### 1. 监听 CSS 变量变化
+
+```javascript
+// 注册 CSS 变量
+CSS.registerProperty({
+  name: '--progress',
+  syntax: '<number>',
+  inherits: false,
+  initialValue: '0',
+});
+
+// 监听变化
+const element = document.querySelector('.progress-bar');
+const styleMap = element.styleMap;
+
+styleMap.addEventListener('change', (e) => {
+  if (e.property === '--progress') {
+    updateProgress(e.value);
+  }
+});
+```
+
+### 2. 动态主题切换
+
+```javascript
+const root = document.documentElement;
+const rootStyleMap = root.attributeStyleMap;
+
+rootStyleMap.addEventListener('change', (e) => {
+  console.log(`主题变量 ${e.property} 变为 ${e.value}`);
+  if (e.property.startsWith('--theme-')) {
+    applyTheme(e.property, e.value);
+  }
+});
+```
+
+### 3. 动画与交互同步
+
+```javascript
+const interactive = document.querySelector('.interactive-element');
+
+// 监听 transform 变化来同步其他元素
+interactive.attributeStyleMap.addEventListener('change', (e) => {
+  if (e.property === 'transform') {
+    updateMirrorTransform(e.value);
+  }
+});
+```
+
+## 浏览器兼容性
+
+Style Observer API 依赖于 CSS Houdini，目前支持有限：
+
+- Chrome 73+ (部分支持)
+- Edge 79+
+- Firefox: 不支持
+- Safari: 不支持
+
+## 替代方案
+
+由于浏览器支持有限，通常使用以下替代方案：
+
+### 1. MutationObserver
+
+```javascript
+const observer = new MutationObserver((mutations) => {
+  mutations.forEach((mutation) => {
+    if (mutation.type === 'attributes' && mutation.attributeName === 'style') {
+      console.log('Style changed!');
+    }
+  });
+});
+
+observer.observe(element, { attributes: true, attributeFilter: ['style'] });
+```
+
+### 2. CSS 变量 + requestAnimationFrame
+
+```javascript
+function pollStyle(element, property, callback) {
+  let lastValue = getComputedStyle(element).getPropertyValue(property);
+  
+  function check() {
+    const currentValue = getComputedStyle(element).getPropertyValue(property);
+    if (currentValue !== lastValue) {
+      lastValue = currentValue;
+      callback(currentValue);
+    }
+    requestAnimationFrame(check);
+  }
+  
+  check();
+}
+```
+
+### 3. Proxy 包装 CSS 变量
+
+```javascript
+function createCSSVariableProxy(element) {
+  return new Proxy({}, {
+    set(target, property, value) {
+      element.style.setProperty(property, value);
+      return true;
+    },
+    get(target, property) {
+      return getComputedStyle(element).getPropertyValue(property);
+    }
+  });
+}
+```
+
+## 参考资料
+
+- [Lea Verou - Style Observer](https://lea.verou.me/blog/2025/style-observer/)
+- [CSS Houdini API - MDN](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Houdini)
+- [CSS Typed OM - MDN](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Typed_OM)


### PR DESCRIPTION
## CSS @container 容器查询

新增文档和演示，涵盖：

### 文档
- \src/topics/08.responsive/css-container-queries/index.mdx\

### 内容
1. container-type 定义容器（inline-size/size/normal）
2. container-name 命名容器
3. @container 查询语法（尺寸查询、命名查询、逻辑组合）
4. 容器查询长度单位（cqw/cqh/cqi/cqb/cqmin/cqmax）
5. 实战案例：卡片组件自适应、侧边栏响应式、图片画廊布局
6. 浏览器兼容性（Chrome 105+/Safari 16+/Firefox 110+）

### 演示文件
- \examples/css/demos/css-container-queries/index.html\ — 示例总览
- \examples/css/demos/css-container-queries/card-demo.html\ — 卡片组件自适应
- \examples/css/demos/css-container-queries/sidebar-demo.html\ — 侧边栏响应式
- \examples/css/demos/css-container-queries/gallery-demo.html\ — 图片画廊布局