### PR TITLE
feat: add font-display and font-variation-settings docs and demos

### DIFF
--- a/examples/css/demos/css-font-display/index.html
+++ b/examples/css/demos/css-font-display/index.html
@@ -1,0 +1,483 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>font-display 字体显示策略演示</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f5f5f5;
+    }
+
+    h1 {
+      text-align: center;
+      color: #333;
+    }
+
+    .demo-section {
+      background: white;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .demo-section h2 {
+      margin-top: 0;
+      color: #2563eb;
+      font-size: 1.2em;
+    }
+
+    /* 字体卡片样式 */
+    .font-card {
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 15px;
+      background: #fafafa;
+    }
+
+    .font-card h3 {
+      margin: 0 0 10px 0;
+      color: #1f2937;
+      font-size: 1rem;
+    }
+
+    .font-display-value {
+      display: inline-block;
+      padding: 4px 12px;
+      background: #dbeafe;
+      color: #1e40af;
+      border-radius: 4px;
+      font-size: 0.85em;
+      font-family: monospace;
+      margin-bottom: 15px;
+    }
+
+    .font-sample {
+      font-size: 24px;
+      padding: 15px;
+      background: white;
+      border-radius: 6px;
+      border: 1px solid #e5e7eb;
+      min-height: 80px;
+      display: flex;
+      align-items: center;
+    }
+
+    .font-description {
+      margin-top: 10px;
+      font-size: 0.9em;
+      color: #6b7280;
+    }
+
+    pre {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 15px;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.9em;
+      margin-top: 15px;
+    }
+
+    code {
+      font-family: "Fira Code", Consolas, monospace;
+    }
+
+    .info-box {
+      background: #eff6ff;
+      border: 1px solid #bfdbfe;
+      border-radius: 6px;
+      padding: 15px;
+      margin-bottom: 20px;
+    }
+
+    .info-box strong {
+      color: #1e40af;
+    }
+
+    /* 自定义字体加载 */
+    @font-face {
+      font-family: 'CustomFont';
+      src: url('https://fonts.gstatic.com/s/roboto/v30/Roboto-Light.woff2') format('woff2');
+      font-weight: 300;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: 'CustomFontOptional';
+      src: url('https://fonts.gstatic.com/s/roboto/v30/Roboto-Light.woff2') format('woff2');
+      font-weight: 300;
+      font-display: optional;
+    }
+
+    @font-face {
+      font-family: 'CustomFontBlock';
+      src: url('https://fonts.gstatic.com/s/roboto/v30/Roboto-Light.woff2') format('woff2');
+      font-weight: 300;
+      font-display: block;
+    }
+
+    @font-face {
+      font-family: 'CustomFontAuto';
+      src: url('https://fonts.gstatic.com/s/roboto/v30/Roboto-Light.woff2') format('woff2');
+      font-weight: 300;
+      font-display: auto;
+    }
+
+    .font-swap {
+      font-family: 'CustomFont', sans-serif;
+    }
+
+    .font-optional {
+      font-family: 'CustomFontOptional', sans-serif;
+    }
+
+    .font-block {
+      font-family: 'CustomFontBlock', sans-serif;
+    }
+
+    .font-auto {
+      font-family: 'CustomFontAuto', sans-serif;
+    }
+
+    /* 模拟加载状态 */
+    .loading-indicator {
+      display: inline-block;
+      width: 12px;
+      height: 12px;
+      border: 2px solid #e5e7eb;
+      border-top-color: #2563eb;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+      margin-right: 8px;
+      vertical-align: middle;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    .font-card.loading .font-sample {
+      position: relative;
+    }
+
+    .font-card.loading .font-sample::after {
+      content: '字体加载中...';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: #fef3c7;
+      padding: 5px 10px;
+      border-radius: 4px;
+      font-size: 14px;
+      color: #92400e;
+    }
+
+    /* 表格样式 */
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 15px;
+    }
+
+    th, td {
+      border: 1px solid #e5e7eb;
+      padding: 12px;
+      text-align: left;
+    }
+
+    th {
+      background: #f9fafb;
+      font-weight: 600;
+    }
+
+    .behavior-tag {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    .behavior-foit { background: #fee2e2; color: #991b1b; }
+    .behavior-fout { background: #d1fae5; color: #065f46; }
+    .behavior-hidden { background: #e0e7ff; color: #3730a3; }
+
+    /* 控制面板 */
+    .control-panel {
+      background: #1f2937;
+      color: #f9fafb;
+      padding: 20px;
+      border-radius: 8px;
+      margin-bottom: 20px;
+    }
+
+    .control-panel h3 {
+      margin-top: 0;
+      color: #60a5fa;
+    }
+
+    .control-row {
+      display: flex;
+      align-items: center;
+      margin-bottom: 15px;
+    }
+
+    .control-row label {
+      width: 120px;
+      font-size: 0.9em;
+    }
+
+    .control-row input[type="range"] {
+      flex: 1;
+      margin: 0 15px;
+    }
+
+    .control-row span {
+      width: 60px;
+      text-align: right;
+      font-family: monospace;
+    }
+
+    /* 可变字体演示 */
+    .vf-container {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 20px;
+      margin-top: 15px;
+    }
+
+    .vf-card {
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 15px;
+      background: white;
+    }
+
+    .vf-card h4 {
+      margin: 0 0 10px 0;
+      color: #374151;
+      font-size: 0.95em;
+    }
+
+    .vf-sample {
+      font-size: 32px;
+      text-align: center;
+      padding: 20px;
+      background: #f9fafb;
+      border-radius: 6px;
+      margin-bottom: 10px;
+    }
+
+    .vf-value {
+      font-family: monospace;
+      font-size: 0.85em;
+      color: #6b7280;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <h1>font-display 字体显示策略演示</h1>
+
+  <div class="info-box">
+    <strong>💡 什么是 FOIT 和 FOUT？</strong>
+    <ul style="margin: 10px 0 0 0; padding-left: 20px;">
+      <li><strong>FOIT</strong> (Flash of Invisible Text)：字体加载期间文本不可见，可能造成闪烁</li>
+      <li><strong>FOUT</strong> (Flash of Unstyled Text)：先用后备字体显示，加载后切换到自定义字体</li>
+    </ul>
+  </div>
+
+  <div class="demo-section">
+    <h2>font-display 取值对比</h2>
+    <p>每种 <code>font-display</code> 策略在字体加载过程中的表现：</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>值</th>
+          <th>阻塞时间</th>
+          <th>后备字体</th>
+          <th>行为</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>auto</code></td>
+          <td>浏览器决定</td>
+          <td>由浏览器决定</td>
+          <td><span class="behavior-tag behavior-foit">FOIT</span></td>
+        </tr>
+        <tr>
+          <td><code>block</code></td>
+          <td>短暂（约 3s）</td>
+          <td>使用</td>
+          <td><span class="behavior-tag behavior-foit">FOIT → FOUT</span></td>
+        </tr>
+        <tr>
+          <td><code>swap</code></td>
+          <td>无</td>
+          <td>使用</td>
+          <td><span class="behavior-tag behavior-fout">FOUT</span></td>
+        </tr>
+        <tr>
+          <td><code>fallback</code></td>
+          <td>极短（约 0.1s）</td>
+          <td>使用</td>
+          <td><span class="behavior-tag behavior-foit">FOIT → 放弃</span></td>
+        </tr>
+        <tr>
+          <td><code>optional</code></td>
+          <td>无或极短</td>
+          <td>使用</td>
+          <td><span class="behavior-tag behavior-hidden">由浏览器决定</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="demo-section">
+    <h2>swap - 立即显示后备字体</h2>
+    <div class="font-card">
+      <div class="font-display-value">font-display: swap</div>
+      <p class="font-description">
+        <strong>特点：</strong>字体加载前立即显示后备字体，加载完成后立即切换。适合图标字体或重要文本。
+      </p>
+      <div class="font-sample font-swap">
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <pre><code>@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: swap;
+}</code></pre>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>optional - 优先使用缓存</h2>
+    <div class="font-card">
+      <div class="font-display-value">font-display: optional</div>
+      <p class="font-description">
+        <strong>特点：</strong>如果字体已在缓存中则使用，否则使用后备字体。适合正文文本，追求整体体验。
+      </p>
+      <div class="font-sample font-optional">
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <pre><code>@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: optional;
+}</code></pre>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>block - 短暂阻塞后显示后备字体</h2>
+    <div class="font-card">
+      <div class="font-display-value">font-display: block</div>
+      <p class="font-description">
+        <strong>特点：</strong>阻塞较短时间（约 3 秒）等待字体加载，超时后显示后备字体。
+      </p>
+      <div class="font-sample font-block">
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <pre><code>@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: block;
+}</code></pre>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>auto - 浏览器默认行为</h2>
+    <div class="font-card">
+      <div class="font-display-value">font-display: auto</div>
+      <p class="font-description">
+        <strong>特点：</strong>使用浏览器的默认字体加载策略，通常表现为 FOIT。
+      </p>
+      <div class="font-sample font-auto">
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <pre><code>@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: auto;
+}</code></pre>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>fallback - 快速超时</h2>
+    <div class="font-card">
+      <div class="font-display-value">font-display: fallback</div>
+      <p class="font-description">
+        <strong>特点：</strong>阻塞极短时间（约 100ms），超时后使用后备字体。如果字体未加载，下次访问时可能使用。
+      </p>
+      <pre><code>@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: fallback;
+}</code></pre>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>实际应用建议</h2>
+    <ul>
+      <li><strong>图标字体：</strong>使用 <code>swap</code> - 图标需要立即显示</li>
+      <li><strong>正文文本：</strong>使用 <code>optional</code> 或 <code>fallback</code> - 避免文字跳动影响阅读</li>
+      <li><strong>标题文字：</strong>使用 <code>swap</code> - 允许轻微跳动但保证及时显示</li>
+      <li><strong>不重要装饰：</strong>使用 <code>optional</code> - 只在网络条件好时加载</li>
+    </ul>
+  </div>
+
+  <div class="demo-section">
+    <h2>性能优化技巧</h2>
+    <pre><code>/* 1. 使用 font-display 的同时，结合预加载 */
+&lt;link rel="preload" href="font.woff2" as="font" type="font/woff2" crossorigin&gt;
+
+/* 2. 使用 woff2 格式，兼容性最好且压缩率高 */
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: swap;
+}
+
+/* 3. 为不同字符集定义不同字体 */
+@font-face {
+  font-family: 'MyFont';
+  src: url('latin.woff2') format('woff2');
+  unicode-range: U+0000-00FF;
+  font-display: swap;
+}</code></pre>
+  </div>
+
+  <script>
+    // 检测字体加载状态
+    document.fonts.ready.then(function() {
+      console.log('所有字体加载完成');
+    });
+
+    // 监听特定字体加载
+    const font = new FontFace('CustomFont', 'url(https://fonts.gstatic.com/s/roboto/v30/Roboto-Light.woff2) format("woff2")');
+    font.load().then(function(loadedFont) {
+      document.fonts.add(loadedFont);
+      console.log('CustomFont 加载成功');
+    }).catch(function(error) {
+      console.log('CustomFont 加载失败:', error);
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/css-font-variation-settings/index.html
+++ b/examples/css/demos/css-font-variation-settings/index.html
@@ -1,0 +1,662 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>font-variation-settings 可变字体演示</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f5f5f5;
+    }
+
+    h1 {
+      text-align: center;
+      color: #333;
+    }
+
+    .demo-section {
+      background: white;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .demo-section h2 {
+      margin-top: 0;
+      color: #2563eb;
+      font-size: 1.2em;
+    }
+
+    pre {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 15px;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.9em;
+    }
+
+    code {
+      font-family: "Fira Code", Consolas, monospace;
+    }
+
+    .info-box {
+      background: #eff6ff;
+      border: 1px solid #bfdbfe;
+      border-radius: 6px;
+      padding: 15px;
+      margin-bottom: 20px;
+    }
+
+    .info-box strong {
+      color: #1e40af;
+    }
+
+    /* 可变字体特性轴表格 */
+    .axis-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 15px;
+    }
+
+    .axis-table th, .axis-table td {
+      border: 1px solid #e5e7eb;
+      padding: 12px;
+      text-align: left;
+    }
+
+    .axis-table th {
+      background: #f9fafb;
+      font-weight: 600;
+    }
+
+    .axis-tag {
+      display: inline-block;
+      padding: 2px 8px;
+      background: #dbeafe;
+      color: #1e40af;
+      border-radius: 4px;
+      font-size: 0.85em;
+      font-family: monospace;
+    }
+
+    /* 可变字体演示卡片 */
+    .vf-demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
+      margin-top: 15px;
+    }
+
+    .vf-card {
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 20px;
+      background: white;
+    }
+
+    .vf-card h3 {
+      margin: 0 0 15px 0;
+      color: #1f2937;
+      font-size: 1em;
+    }
+
+    .vf-sample {
+      font-size: 48px;
+      text-align: center;
+      padding: 30px;
+      background: #f9fafb;
+      border-radius: 6px;
+      margin-bottom: 15px;
+      min-height: 120px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .vf-controls {
+      margin-top: 15px;
+    }
+
+    .vf-controls label {
+      display: block;
+      font-size: 0.85em;
+      color: #6b7280;
+      margin-bottom: 5px;
+    }
+
+    .vf-controls input[type="range"] {
+      width: 100%;
+    }
+
+    .vf-controls .value-display {
+      font-family: monospace;
+      font-size: 0.85em;
+      color: #2563eb;
+      margin-top: 5px;
+    }
+
+    /* 字重渐变演示 */
+    .weight-gradient {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+
+    .weight-item {
+      padding: 15px 20px;
+      background: white;
+      border-bottom: 1px solid #e5e7eb;
+    }
+
+    .weight-item:last-child {
+      border-bottom: none;
+    }
+
+    .weight-label {
+      font-size: 0.8em;
+      color: #6b7280;
+      margin-bottom: 5px;
+    }
+
+    /* 宽度渐变 */
+    .width-gradient {
+      display: flex;
+      gap: 10px;
+      align-items: flex-end;
+    }
+
+    .width-item {
+      flex: 1;
+      text-align: center;
+      padding: 20px 10px;
+      background: #f9fafb;
+      border-radius: 6px;
+    }
+
+    .width-item span {
+      display: block;
+      font-size: 0.75em;
+      color: #6b7280;
+      margin-top: 10px;
+    }
+
+    /* 斜体演示 */
+    .ital-demo {
+      display: flex;
+      gap: 20px;
+    }
+
+    .ital-item {
+      flex: 1;
+      padding: 20px;
+      background: #f9fafb;
+      border-radius: 6px;
+    }
+
+    .ital-item h4 {
+      margin: 0 0 10px 0;
+      color: #374151;
+      font-size: 0.9em;
+    }
+
+    /* 倾斜演示 */
+    .slnt-demo {
+      display: flex;
+      gap: 20px;
+      align-items: center;
+    }
+
+    .slnt-item {
+      flex: 1;
+      text-align: center;
+    }
+
+    .slnt-item span {
+      display: block;
+      font-size: 0.8em;
+      color: #6b7280;
+      margin-top: 8px;
+    }
+
+    /* 使用 Google Fonts 可变字体 */
+    @import url('https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,slnt,wdth,wght@8..144,-10..0,75..125,100..1000&display=swap');
+
+    .roboto-flex {
+      font-family: 'Roboto Flex', sans-serif;
+    }
+
+    /* 使用 Inter 可变字体（通过 CDN） */
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
+
+    .inter-variable {
+      font-family: 'Inter', sans-serif;
+    }
+
+    /* 自定义可变字体示例 */
+    .custom-vf-sample {
+      font-family: 'Roboto Flex', sans-serif;
+    }
+
+    /* 交互式控制面板 */
+    .control-panel {
+      background: #1f2937;
+      color: #f9fafb;
+      padding: 20px;
+      border-radius: 8px;
+      margin-bottom: 20px;
+    }
+
+    .control-panel h3 {
+      margin-top: 0;
+      color: #60a5fa;
+    }
+
+    .slider-group {
+      margin-bottom: 20px;
+    }
+
+    .slider-group label {
+      display: block;
+      margin-bottom: 8px;
+      font-size: 0.9em;
+      color: #d1d5db;
+    }
+
+    .slider-row {
+      display: flex;
+      align-items: center;
+      gap: 15px;
+    }
+
+    .slider-row input[type="range"] {
+      flex: 1;
+    }
+
+    .slider-row .axis-name {
+      width: 50px;
+      font-family: monospace;
+      font-size: 0.85em;
+      color: #9ca3af;
+    }
+
+    .slider-row .axis-value {
+      width: 60px;
+      text-align: right;
+      font-family: monospace;
+      color: #60a5fa;
+    }
+
+    /* 预设按钮 */
+    .preset-buttons {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      margin-top: 15px;
+    }
+
+    .preset-btn {
+      padding: 8px 16px;
+      background: #374151;
+      color: #f9fafb;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.85em;
+      transition: background 0.2s;
+    }
+
+    .preset-btn:hover {
+      background: #4b5563;
+    }
+
+    .preset-btn.active {
+      background: #2563eb;
+    }
+
+    /* 动画效果 */
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.6; }
+    }
+
+    .loading {
+      animation: pulse 1.5s ease-in-out infinite;
+    }
+  </style>
+</head>
+<body>
+  <h1>font-variation-settings 可变字体演示</h1>
+
+  <div class="info-box">
+    <strong>💡 什么是可变字体？</strong>
+    <p style="margin: 10px 0 0 0;">
+      可变字体（Variable Fonts）是 OpenType 字体规范的发展，它允许在单个字体文件中包含多个变体，
+      通过轴（axis）来控制字体的外观。相比传统字体，可变字体文件更小，功能更强大。
+    </p>
+  </div>
+
+  <div class="demo-section">
+    <h2>常用特性轴</h2>
+    <table class="axis-table">
+      <thead>
+        <tr>
+          <th>轴名</th>
+          <th>全称</th>
+          <th>说明</th>
+          <th>典型范围</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="axis-tag">wght</span></td>
+          <td>Weight</td>
+          <td>字重（粗细）</td>
+          <td>100 - 900</td>
+        </tr>
+        <tr>
+          <td><span class="axis-tag">wdth</span></td>
+          <td>Width</td>
+          <td>字宽（压缩/扩展）</td>
+          <td>75 - 125</td>
+        </tr>
+        <tr>
+          <td><span class="axis-tag">ital</span></td>
+          <td>Italic</td>
+          <td>斜体（0=正体，1=斜体）</td>
+          <td>0 - 1</td>
+        </tr>
+        <tr>
+          <td><span class="axis-tag">slnt</span></td>
+          <td>Slant</td>
+          <td>倾斜角度</td>
+          <td>-10 - 0</td>
+        </tr>
+        <tr>
+          <td><span class="axis-tag">opsz</span></td>
+          <td>Optical Size</td>
+          <td>光学尺寸（字号相关）</td>
+          <td>6 - 144</td>
+        </tr>
+        <tr>
+          <td><span class="axis-tag">GRAD</span></td>
+          <td>Grade</td>
+          <td>字重等级（不影响布局）</td>
+          <td>-50 - 150</td>
+        </tr>
+        <tr>
+          <td><span class="axis-tag">XTRA</span></td>
+          <td>Contrast</td>
+          <td>轮廓对比度</td>
+          <td>63 - 1000</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="demo-section">
+    <h2>字重轴 (wght) 演示</h2>
+    <p>使用 Roboto Flex 可变字体展示不同字重：</p>
+
+    <div class="weight-gradient roboto-flex">
+      <div class="weight-item" style="font-variation-settings: 'wght' 100;">
+        <div class="weight-label">100 - Thin (极细)</div>
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <div class="weight-item" style="font-variation-settings: 'wght' 300;">
+        <div class="weight-label">300 - Light (细体)</div>
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <div class="weight-item" style="font-variation-settings: 'wght' 400;">
+        <div class="weight-label">400 - Regular (常规)</div>
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <div class="weight-item" style="font-variation-settings: 'wght' 500;">
+        <div class="weight-label">500 - Medium (中等)</div>
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <div class="weight-item" style="font-variation-settings: 'wght' 700;">
+        <div class="weight-label">700 - Bold (粗体)</div>
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <div class="weight-item" style="font-variation-settings: 'wght' 900;">
+        <div class="weight-label">900 - Black (黑体)</div>
+        The quick brown fox jumps over the lazy dog
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>宽度轴 (wdth) 演示</h2>
+    <p>同一个字体，不同宽度：</p>
+
+    <div class="width-gradient roboto-flex">
+      <div class="width-item" style="font-variation-settings: 'wght' 400, 'wdth' 75;">
+        <div style="font-size: 32px;">Aa</div>
+        <span>wdth: 75</span>
+      </div>
+      <div class="width-item" style="font-variation-settings: 'wght' 400, 'wdth' 87;">
+        <div style="font-size: 32px;">Aa</div>
+        <span>wdth: 87</span>
+      </div>
+      <div class="width-item" style="font-variation-settings: 'wght' 400, 'wdth' 100;">
+        <div style="font-size: 32px;">Aa</div>
+        <span>wdth: 100</span>
+      </div>
+      <div class="width-item" style="font-variation-settings: 'wght' 400, 'wdth' 112;">
+        <div style="font-size: 32px;">Aa</div>
+        <span>wdth: 112</span>
+      </div>
+      <div class="width-item" style="font-variation-settings: 'wght' 400, 'wdth' 125;">
+        <div style="font-size: 32px;">Aa</div>
+        <span>wdth: 125</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>倾斜轴 (slnt) 演示</h2>
+
+    <div class="slnt-demo roboto-flex">
+      <div class="slnt-item">
+        <div class="vf-sample" style="font-variation-settings: 'slnt' 0; font-size: 36px;">
+          Normal
+        </div>
+        <span>slnt: 0</span>
+      </div>
+      <div class="slnt-item">
+        <div class="vf-sample" style="font-variation-settings: 'slnt' -6; font-size: 36px;">
+          Slanted
+        </div>
+        <span>slnt: -6</span>
+      </div>
+      <div class="slnt-item">
+        <div class="vf-sample" style="font-variation-settings: 'slnt' -12; font-size: 36px;">
+          More Slant
+        </div>
+        <span>slnt: -12</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>交互式演示</h2>
+    <p>拖动滑块实时调整可变字体的各个轴：</p>
+
+    <div class="control-panel">
+      <h3>Roboto Flex 可变字体控制</h3>
+
+      <div class="slider-group">
+        <label>字重 (wght): <span id="wghtValue">400</span></label>
+        <div class="slider-row">
+          <span class="axis-name">wght</span>
+          <input type="range" id="wghtSlider" min="100" max="900" value="400" step="1">
+          <span class="axis-value" id="wghtDisplay">400</span>
+        </div>
+      </div>
+
+      <div class="slider-group">
+        <label>字宽 (wdth): <span id="wdthValue">100</span></label>
+        <div class="slider-row">
+          <span class="axis-name">wdth</span>
+          <input type="range" id="wdthSlider" min="75" max="125" value="100" step="1">
+          <span class="axis-value" id="wdthDisplay">100</span>
+        </div>
+      </div>
+
+      <div class="slider-group">
+        <label>倾斜 (slnt): <span id="slntValue">0</span></label>
+        <div class="slider-row">
+          <span class="axis-name">slnt</span>
+          <input type="range" id="slntSlider" min="-10" max="0" value="0" step="0.5">
+          <span class="axis-value" id="slntDisplay">0</span>
+        </div>
+      </div>
+
+      <div class="slider-group">
+        <label>光学尺寸 (opsz): <span id="opszValue">14</span></label>
+        <div class="slider-row">
+          <span class="axis-name">opsz</span>
+          <input type="range" id="opszSlider" min="6" max="144" value="14" step="1">
+          <span class="axis-value" id="opszDisplay">14</span>
+        </div>
+      </div>
+
+      <div class="preset-buttons">
+        <button class="preset-btn" data-wght="100" data-wdth="100" data-slnt="0" data-opsz="14">Thin</button>
+        <button class="preset-btn" data-wght="300" data-wdth="100" data-slnt="0" data-opsz="14">Light</button>
+        <button class="preset-btn" data-wght="400" data-wdth="100" data-slnt="0" data-opsz="14">Regular</button>
+        <button class="preset-btn" data-wght="700" data-wdth="100" data-slnt="0" data-opsz="14">Bold</button>
+        <button class="preset-btn" data-wght="900" data-wdth="100" data-slnt="0" data-opsz="14">Black</button>
+        <button class="preset-btn" data-wght="400" data-wdth="75" data-slnt="0" data-opsz="14">Condensed</button>
+        <button class="preset-btn" data-wght="400" data-wdth="125" data-slnt="0" data-opsz="14">Expanded</button>
+      </div>
+    </div>
+
+    <div class="vf-card" style="margin-top: 20px;">
+      <div class="vf-sample roboto-flex" id="vfSample">
+        可变字体
+      </div>
+      <p style="font-family: monospace; font-size: 0.85em; color: #6b7280; margin-top: 10px;" id="vfSettings">
+        font-variation-settings: 'wght' 400, 'wdth' 100, 'slnt' 0, 'opsz' 14
+      </p>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>CSS 语法</h2>
+    <pre><code>/* 基本语法 */
+.element {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 400;
+}
+
+/* 多个轴同时设置 */
+.heading {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 700, 'wdth' 100;
+  font-size: 48px;
+}
+
+/* 与普通字体属性配合使用 */
+.text {
+  font-family: 'Roboto Flex', sans-serif;
+  font-weight: 500;        /* 标准属性 */
+  font-variation-settings: 'wght' 500, 'wdth' 95;  /* 可变字体轴 */
+}</code></pre>
+  </div>
+
+  <div class="demo-section">
+    <h2>注意事项</h2>
+    <ul>
+      <li><strong>兼容性：</strong>现代浏览器都支持可变字体，但需要使用支持可变字体的字体文件</li>
+      <li><strong>性能：</strong>使用 <code>font-display: optional</code> 可在网络不佳时跳过字体加载</li>
+      <li><strong>回退：</strong>为不支持可变字体的浏览器提供 fallback 字体</li>
+      <li><strong>Google Fonts：</strong>Google Fonts 上的可变字体 URL 包含完整的轴范围</li>
+    </ul>
+  </div>
+
+  <div class="demo-section">
+    <h2>常用可变字体推荐</h2>
+    <ul>
+      <li><strong>Roboto Flex</strong> - Google Fonts，支持 wght, wdth, slnt, opsz</li>
+      <li><strong>Inter</strong> - Google Fonts，支持 wght</li>
+      <li><strong>Recursive</strong> - Google Fonts，支持 wght, slnt, MONO, CASL, CRSV</li>
+      <li><strong>Source Sans 3</strong> - Google Fonts，支持 wght, wdth, ital, slnt, SOFT, ZERO</li>
+      <li><strong>Amstelvar</strong> - Google Fonts，支持 wght, opsz, XTRA, YOPQ 等</li>
+    </ul>
+  </div>
+
+  <script>
+    const wghtSlider = document.getElementById('wghtSlider');
+    const wdthSlider = document.getElementById('wdthSlider');
+    const slntSlider = document.getElementById('slntSlider');
+    const opszSlider = document.getElementById('opszSlider');
+
+    const wghtValue = document.getElementById('wghtValue');
+    const wdthValue = document.getElementById('wdthValue');
+    const slntValue = document.getElementById('slntValue');
+    const opszValue = document.getElementById('opszValue');
+
+    const wghtDisplay = document.getElementById('wghtDisplay');
+    const wdthDisplay = document.getElementById('wdthDisplay');
+    const slntDisplay = document.getElementById('slntDisplay');
+    const opszDisplay = document.getElementById('opszDisplay');
+
+    const vfSample = document.getElementById('vfSample');
+    const vfSettings = document.getElementById('vfSettings');
+
+    function updateFontVariation() {
+      const wght = wghtSlider.value;
+      const wdth = wdthSlider.value;
+      const slnt = slntSlider.value;
+      const opsz = opszSlider.value;
+
+      wghtValue.textContent = wght;
+      wdthValue.textContent = wdth;
+      slntValue.textContent = slnt;
+      opszValue.textContent = opsz;
+
+      wghtDisplay.textContent = wght;
+      wdthDisplay.textContent = wdth;
+      slntDisplay.textContent = slnt;
+      opszDisplay.textContent = opsz;
+
+      const settings = `'wght' ${wght}, 'wdth' ${wdth}, 'slnt' ${slnt}, 'opsz' ${opsz}`;
+      vfSample.style.fontVariationSettings = settings;
+      vfSettings.textContent = `font-variation-settings: ${settings}`;
+    }
+
+    wghtSlider.addEventListener('input', updateFontVariation);
+    wdthSlider.addEventListener('input', updateFontVariation);
+    slntSlider.addEventListener('input', updateFontVariation);
+    opszSlider.addEventListener('input', updateFontVariation);
+
+    // 预设按钮
+    document.querySelectorAll('.preset-btn').forEach(btn => {
+      btn.addEventListener('click', function() {
+        wghtSlider.value = this.dataset.wght;
+        wdthSlider.value = this.dataset.wdth;
+        slntSlider.value = this.dataset.slnt;
+        opszSlider.value = this.dataset.opsz;
+        updateFontVariation();
+
+        document.querySelectorAll('.preset-btn').forEach(b => b.classList.remove('active'));
+        this.classList.add('active');
+      });
+    });
+
+    // 初始化
+    updateFontVariation();
+  </script>
+</body>
+</html>

--- a/examples/css/demos/css-prefers-reduced-motion/index.html
+++ b/examples/css/demos/css-prefers-reduced-motion/index.html
@@ -1,0 +1,424 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>prefers-reduced-motion 减少动效演示</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f5f5f5;
+    }
+
+    h1 {
+      text-align: center;
+      color: #333;
+    }
+
+    .demo-section {
+      background: white;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .demo-section h2 {
+      margin-top: 0;
+      color: #2563eb;
+      font-size: 1.2em;
+    }
+
+    .demo-box {
+      padding: 15px;
+      border: 2px dashed #ccc;
+      border-radius: 6px;
+      margin: 10px 0;
+      background: #fafafa;
+    }
+
+    pre {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 15px;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.9em;
+    }
+
+    code {
+      font-family: "Fira Code", Consolas, monospace;
+    }
+
+    /* 状态指示器 */
+    .motion-indicator {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      padding: 10px 20px;
+      border-radius: 20px;
+      font-size: 14px;
+      font-weight: bold;
+      z-index: 1000;
+    }
+
+    .motion-indicator.reduce {
+      background: #fef3c7;
+      color: #92400e;
+    }
+
+    .motion-indicator.no-preference {
+      background: #e0e7ff;
+      color: #3730a3;
+    }
+
+    /* ========== 动画示例 ========== */
+
+    /* 1. 旋转动画 */
+    .spinner {
+      width: 50px;
+      height: 50px;
+      border: 4px solid #e5e7eb;
+      border-top-color: #2563eb;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    /* 2. 弹跳动画 */
+    .bounce {
+      width: 50px;
+      height: 50px;
+      background: #dc2626;
+      border-radius: 50%;
+      animation: bounce 0.6s ease-in-out infinite alternate;
+    }
+
+    @keyframes bounce {
+      from { transform: translateY(0); }
+      to { transform: translateY(-50px); }
+    }
+
+    /* 3. 淡入动画 */
+    .fade-in {
+      opacity: 0;
+      animation: fadeIn 1s ease-out forwards;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(20px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* 4. 脉冲动画 */
+    .pulse {
+      width: 50px;
+      height: 50px;
+      background: #059669;
+      border-radius: 50%;
+      animation: pulse 1.5s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { transform: scale(1); opacity: 1; }
+      50% { transform: scale(1.2); opacity: 0.7; }
+    }
+
+    /* 5. 滑动动画 */
+    .slide {
+      width: 50px;
+      height: 50px;
+      background: #7c3aed;
+      animation: slide 2s ease-in-out infinite;
+    }
+
+    @keyframes slide {
+      0%, 100% { transform: translateX(0); }
+      50% { transform: translateX(100px); }
+    }
+
+    /* 动画容器 */
+    .animation-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 20px;
+      margin-top: 20px;
+    }
+
+    .animation-item {
+      text-align: center;
+      padding: 20px;
+      background: #f9fafb;
+      border-radius: 8px;
+    }
+
+    .animation-item span {
+      display: block;
+      margin-top: 10px;
+      font-size: 14px;
+      color: #666;
+    }
+
+    /* ========== 减少动效覆盖 ========== */
+    @media (prefers-reduced-motion: reduce) {
+      /* 禁用旋转 */
+      .spinner {
+        animation: none;
+        border-top-color: #2563eb;
+        background: transparent;
+      }
+
+      /* 禁用弹跳 */
+      .bounce {
+        animation: none;
+        transform: translateY(0);
+      }
+
+      /* 禁用淡入 */
+      .fade-in {
+        animation: none;
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      /* 禁用脉冲 */
+      .pulse {
+        animation: none;
+        transform: scale(1);
+        opacity: 1;
+      }
+
+      /* 禁用滑动 */
+      .slide {
+        animation: none;
+        transform: translateX(0);
+      }
+
+      /* 禁用平滑滚动 */
+      html {
+        scroll-behavior: auto;
+      }
+    }
+
+    /* 说明文字 */
+    .info-box {
+      background: #eff6ff;
+      border: 1px solid #bfdbfe;
+      border-radius: 6px;
+      padding: 15px;
+      margin-bottom: 20px;
+    }
+
+    .info-box strong {
+      color: #1e40af;
+    }
+
+    .warning-box {
+      background: #fef3c7;
+      border: 1px solid #fcd34d;
+      border-radius: 6px;
+      padding: 15px;
+      margin-bottom: 20px;
+    }
+
+    .warning-box strong {
+      color: #92400e;
+    }
+  </style>
+</head>
+<body>
+  <div class="motion-indicator no-preference" id="motionIndicator">
+    动效偏好：未设置
+  </div>
+
+  <h1>prefers-reduced-motion 减少动效演示</h1>
+
+  <div class="info-box">
+    <strong>💡 提示：</strong>本页面演示了各种 CSS 动画效果，以及它们在启用「减少动效」时的行为。
+  </div>
+
+  <div class="warning-box">
+    <strong>⚠️ 如何启用减少动效：</strong>
+    <ul style="margin: 10px 0 0 0; padding-left: 20px;">
+      <li>macOS: 系统设置 → 辅助功能 → 显示 → 减弱动态效果</li>
+      <li>Windows: 设置 → 轻松使用 → 显示 → 在 Windows 中显示动画</li>
+      <li>iOS: 设置 → 辅助功能 → 减弱动态效果</li>
+    </ul>
+  </div>
+
+  <div class="demo-section">
+    <h2>动画示例</h2>
+    <p>以下动画在启用了「减少动效」后将停止或变成静态：</p>
+
+    <div class="animation-grid">
+      <div class="animation-item">
+        <div class="spinner"></div>
+        <span>旋转动画</span>
+      </div>
+      <div class="animation-item">
+        <div class="bounce"></div>
+        <span>弹跳动画</span>
+      </div>
+      <div class="animation-item">
+        <div class="fade-in" style="background: #059669; width: 50px; height: 50px; border-radius: 4px;"></div>
+        <span>淡入动画</span>
+      </div>
+      <div class="animation-item">
+        <div class="pulse"></div>
+        <span>脉冲动画</span>
+      </div>
+      <div class="animation-item">
+        <div class="slide"></div>
+        <span>滑动动画</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>CSS 实现代码</h2>
+    <pre><code>/* 1. 禁用所有非必要动画 */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* 2. 保留关键动画（加载指示器） */
+.loading-spinner {
+  animation: spin 1s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-spinner {
+    /* 加载指示器保留，但可以用静态图标替代 */
+    animation: none;
+  }
+}
+
+/* 3. 选择性禁用动画 */
+.fade-in {
+  animation: fadeIn 0.5s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-in {
+    animation: none;
+    opacity: 1;
+    transform: translateX(0);
+  }
+}</code></pre>
+  </div>
+
+  <div class="demo-section">
+    <h2>JavaScript 检测</h2>
+    <pre><code>// 检测用户偏好
+const prefersReducedMotion = window.matchMedia(
+  '(prefers-reduced-motion: reduce)'
+).matches;
+
+console.log('减少动效:', prefersReducedMotion);
+
+// 监听变化
+window.matchMedia('(prefers-reduced-motion: reduce)')
+  .addEventListener('change', (e) => {
+    if (e.matches) {
+      console.log('用户启用了减少动效');
+      // 停止非必要动画
+    } else {
+      console.log('用户禁用了减少动效');
+      // 恢复动画
+    }
+  });</code></pre>
+  </div>
+
+  <div class="demo-section">
+    <h2>常见使用场景</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>场景</th>
+          <th>处理方式</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>页面入场动画</td>
+          <td>使用 <code>prefers-reduced-motion</code> 禁用</td>
+        </tr>
+        <tr>
+          <td>加载指示器</td>
+          <td>保留或用静态图标替代</td>
+        </tr>
+        <tr>
+          <td>模态框动画</td>
+          <td>禁用过渡效果</td>
+        </tr>
+        <tr>
+          <td>滚动动画</td>
+          <td>禁用 <code>scroll-behavior</code></td>
+        </tr>
+        <tr>
+          <td>悬停效果</td>
+          <td>保留（用户可主动触发）</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="demo-section">
+    <h2>最佳实践</h2>
+    <ul>
+      <li><strong>尊重用户设置</strong>：优先使用媒体查询，而不是依赖 JavaScript 检测</li>
+      <li><strong>保留功能性动画</strong>：加载指示器等让用户知道系统在工作</li>
+      <li><strong>使用过渡而非动画</strong>：过渡比动画更轻量，用户更容易控制</li>
+      <li><strong>提供备选方案</strong>：考虑静态替代方案（如静态加载图标）</li>
+      <li><strong>测试</strong>：在真实设备上测试，特别是辅助功能设置</li>
+    </ul>
+  </div>
+
+  <script>
+    // 检测当前设置并更新指示器
+    function updateMotionIndicator() {
+      const prefersReducedMotion = window.matchMedia(
+        '(prefers-reduced-motion: reduce)'
+      ).matches;
+
+      const indicator = document.getElementById('motionIndicator');
+
+      if (prefersReducedMotion) {
+        indicator.textContent = '动效偏好：减少';
+        indicator.className = 'motion-indicator reduce';
+      } else {
+        indicator.textContent = '动效偏好：全部';
+        indicator.className = 'motion-indicator no-preference';
+      }
+    }
+
+    // 初始化
+    updateMotionIndicator();
+
+    // 监听变化
+    window.matchMedia('(prefers-reduced-motion: reduce)')
+      .addEventListener('change', updateMotionIndicator);
+
+    // 输出当前设置
+    const isReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    console.log('prefers-reduced-motion:', isReduced ? 'reduce' : 'no-preference');
+  </script>
+</body>
+</html>

--- a/src/topics/08.responsive/css-prefers-reduced-motion/index.mdx
+++ b/src/topics/08.responsive/css-prefers-reduced-motion/index.mdx
@@ -1,0 +1,186 @@
+---
+title: prefers-reduced-motion 减少动效
+category: 响应式设计
+tags: [prefers-reduced-motion, 减少动效, 动画, 无障碍, accessibility]
+description: 详细介绍 CSS prefers-reduced-motion 媒体查询，尊重用户减少动效的设置。
+keywords: prefers-reduced-motion, 减少动效, 动画, 无障碍, accessibility, 动效偏好
+---
+
+# prefers-reduced-motion 减少动效
+
+`prefers-reduced-motion` 是 CSS 媒体查询，用于检测用户是否请求减少页面动画效果，提升无障碍体验。
+
+## 基本语法
+
+```css
+/* 用户偏好减少动效 */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+## 检测的值
+
+| 值 | 说明 |
+|---|---|
+| `no-preference` | 用户未设置偏好（默认值） |
+| `reduce` | 用户偏好减少或消除动画 |
+
+## 使用场景
+
+### 1. 禁用所有动画
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+### 2. 保留关键动画
+
+```css
+/* 关键加载动画保留 */
+.loading-spinner {
+  animation: spin 1s linear infinite;
+}
+
+/* 非关键动画禁用 */
+.fade-in {
+  animation: fadeIn 0.5s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-in {
+    animation: none;
+    opacity: 1;
+  }
+}
+```
+
+### 3. 使用 prefers-reduced-motion 查询
+
+```css
+/* 复杂的入场动画 */
+.hero-animation {
+  animation: slideIn 1s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-animation {
+    animation: none;
+    transform: translateX(0);
+  }
+}
+```
+
+## JavaScript 检测
+
+```javascript
+// 检测用户偏好
+const prefersReducedMotion = window.matchMedia(
+  '(prefers-reduced-motion: reduce)'
+).matches;
+
+// 监听变化
+window.matchMedia('(prefers-reduced-motion: reduce)')
+  .addEventListener('change', (e) => {
+    if (e.matches) {
+      console.log('用户启用了减少动效');
+    } else {
+      console.log('用户禁用了减少动效');
+    }
+  });
+```
+
+## 常见问题
+
+### 1. 滚动动画
+
+```css
+/* 禁用平滑滚动 */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+/* 禁用锚点平滑滚动 */
+a[href^="#"] {
+  scroll-behavior: auto;
+}
+```
+
+### 2. Loader 和 Spinner
+
+```css
+.loading-spinner {
+  animation: spin 1s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-spinner {
+    animation: none;
+  }
+}
+```
+
+### 3. 模态框动画
+
+```css
+.modal {
+  transition: opacity 0.3s, transform 0.3s;
+}
+
+.modal-enter {
+  opacity: 0;
+  transform: scale(0.95);
+}
+
+.modal-enter-active {
+  opacity: 1;
+  transform: scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal {
+    transition: none;
+  }
+
+  .modal-enter {
+    opacity: 1;
+    transform: none;
+  }
+}
+```
+
+## 浏览器支持
+
+| 浏览器 | 支持版本 |
+|--------|----------|
+| Chrome | 74+ |
+| Firefox | 63+ |
+| Safari | 10.1+ |
+| Edge | 79+ |
+| iOS Safari | 10.3+ |
+
+## 最佳实践
+
+1. **全局禁用非关键动画**：在 `@media (prefers-reduced-motion: reduce)` 中禁用不必要的动画
+2. **保留功能性动画**：如加载指示器，让用户知道系统在工作
+3. **使用 `prefers-reduced-motion`** 而不是完全禁用动画
+4. **添加过渡效果而非动画**：过渡比动画更轻量
+
+## 交互式演示
+
+{/* @playground id="prefers-reduced-motion-demo" mode="demo" */}

--- a/src/topics/12.fonts/css-font-display/index.mdx
+++ b/src/topics/12.fonts/css-font-display/index.mdx
@@ -1,0 +1,185 @@
+---
+title: CSS font-display 字体显示策略
+category: CSS 字体
+tags: [css, font, font-display, web-fonts, foit, fout]
+description: 详细介绍 font-display 属性如何控制 Web 字体加载时的显示策略，包括 swap、optional、block、fallback、auto 等值的行为和适用场景。
+keywords: font-display, web fonts, FOIT, FOUT, @font-face, 字体加载, 字体显示
+---
+
+font-display 属性控制 Web 字体加载过程中的文本显示行为。理解这个属性对于优化用户体验至关重要。
+
+## 基本概念
+
+### FOIT 和 FOUT
+
+- **FOIT (Flash of Invisible Text)**：字体加载期间文本不可见，造成闪烁问题
+- **FOUT (Flash of Unstyled Text)**：先用后备字体显示，加载后切换到自定义字体
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: swap;  /* 控制加载策略 */
+}
+```
+
+## font-display 取值
+
+### auto - 浏览器默认
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: auto;
+}
+```
+
+使用浏览器的默认字体加载策略，通常表现为 FOIT（文本在加载期间不可见）。
+
+### block - 短暂阻塞
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: block;
+}
+```
+
+- 阻塞时间约 **3 秒**
+- 超过则使用后备字体
+- 适合：希望保持视觉一致性，但愿意等待的情况
+
+### swap - 立即显示后备
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: swap;
+}
+```
+
+- **无阻塞**，立即显示后备字体
+- 字体加载完成后立即切换
+- 适合：图标字体、标题文字
+
+### fallback - 快速超时
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: fallback;
+}
+```
+
+- 阻塞时间极短（约 **100ms**）
+- 超时后使用后备字体
+- 如果字体未加载，下次访问时可能使用
+- 适合：正文文本，追求阅读体验
+
+### optional - 优先缓存
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: optional;
+}
+```
+
+- 如果字体已在缓存中使用，否则使用后备字体
+- 永远不会产生 FOUT
+- 适合：追求整体体验，不想文字跳动
+
+## 行为对比
+
+| 值 | 阻塞时间 | FOUT | 适用场景 |
+|---|---|---|---|
+| auto | 浏览器决定 | 可能 | 默认行为 |
+| block | ~3秒 | 是 | 视觉一致性优先 |
+| swap | 无 | 是 | 标题、图标 |
+| fallback | ~100ms | 是 | 正文文本 |
+| optional | 无/极短 | 否 | 最佳用户体验 |
+
+## 实际应用
+
+### 图标字体
+
+```css
+@font-face {
+  font-family: 'IconFont';
+  src: url('icons.woff2') format('woff2');
+  font-display: swap;  /* 图标需要立即显示 */
+}
+```
+
+### 正文文本
+
+```css
+@font-face {
+  font-family: 'BodyFont';
+  src: url('body.woff2') format('woff2');
+  font-display: optional;  /* 不希望文字跳动 */
+}
+```
+
+### 标题文字
+
+```css
+@font-face {
+  font-family: 'HeadingFont';
+  src: url('heading.woff2') format('woff2');
+  font-display: swap;  /* 允许轻微跳动但要显示 */
+}
+```
+
+## 性能优化
+
+### 结合预加载
+
+```html
+<!-- 预加载字体但不阻塞渲染 -->
+<link rel="preload" href="font.woff2" as="font" type="font/woff2" crossorigin>
+```
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: swap;
+}
+```
+
+### 最佳实践
+
+1. 使用 **woff2** 格式，兼容性最好且压缩率高
+2. 图标字体使用 `swap`，正文使用 `optional`
+3. 考虑使用 `font-display: optional` 减少网络请求
+4. 为不同字符集定义不同字体以减小文件
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('latin.woff2') format('woff2');
+  unicode-range: U+0000-00FF;
+  font-display: swap;
+}
+```
+
+## 浏览器支持
+
+所有现代浏览器都支持 `font-display` 属性。
+
+## 交互式演示
+
+{/* @playground id="css-font-display" mode="demo" */}
+
+## 总结
+
+- `swap` 适合需要立即显示的内容（标题、图标）
+- `optional` 适合正文，追求无跳动的阅读体验
+- `fallback` 是两者的折中方案
+- 选择合适的策略可以显著提升用户体验

--- a/src/topics/12.fonts/css-font-variation-settings/index.mdx
+++ b/src/topics/12.fonts/css-font-variation-settings/index.mdx
@@ -1,0 +1,232 @@
+---
+title: CSS font-variation-settings 可变字体
+category: CSS 字体
+tags: [css, font, variable-fonts, font-variation-settings,可变字体, opentype]
+description: 详细介绍可变字体（Variable Fonts）和 font-variation-settings 属性，如何通过轴控制字体的字重、宽度、倾斜等特性。
+keywords: font-variation-settings, 可变字体, Variable Fonts, wght, wdth, slnt, opentype
+---
+
+可变字体（Variable Fonts）是 OpenType 字体规范的重要发展，允许在单个字体文件中包含多个变体，通过轴（axis）来控制字体的外观。
+
+## 什么是可变字体？
+
+传统字体需要为每个字重（Regular、Bold、Light 等）单独的文件，而可变字体只需一个文件即可包含所有变体：
+
+```
+传统方式: Roboto-Regular.ttf, Roboto-Bold.ttf, Roboto-Light.ttf (3个文件)
+
+可变字体: RobotoFlex-Variable.ttf (1个文件，包含所有字重)
+```
+
+## 基本语法
+
+```css
+.element {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 400;
+}
+```
+
+## 常用特性轴
+
+### wght - 字重轴
+
+```css
+.text {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 700;  /* 粗体 */
+}
+```
+
+常用字重值：
+- 100 - Thin
+- 300 - Light
+- 400 - Regular
+- 500 - Medium
+- 700 - Bold
+- 900 - Black
+
+### wdth - 宽度轴
+
+```css
+.condensed {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wdth' 75;  /* 压缩字体 */
+}
+
+.expanded {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wdth' 125;  /* 扩展字体 */
+}
+```
+
+典型范围：75 - 125
+
+### slnt - 倾斜轴
+
+```css
+.italic-text {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'slnt' -12;  /* 倾斜12度 */
+}
+```
+
+典型范围：-10 - 0
+
+### ital - 斜体轴
+
+```css
+.italic {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'ital' 1;  /* 1 = 斜体，0 = 正体 */
+}
+```
+
+### opsz - 光学尺寸
+
+```css
+.caption {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'opsz' 8;  /* 小字号优化 */
+}
+
+.heading {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'opsz' 48;  /* 大字号优化 */
+}
+```
+
+## 组合使用多个轴
+
+```css
+.heading {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 700, 'wdth' 95, 'opsz' 24;
+  font-size: 48px;
+}
+```
+
+## 与标准字体属性的关系
+
+```css
+.text {
+  font-family: 'Roboto Flex', sans-serif;
+  
+  /* 标准属性 */
+  font-weight: 500;
+  font-stretch: 95%;
+  
+  /* 可变字体轴（更高精度控制） */
+  font-variation-settings: 'wght' 500, 'wdth' 95;
+}
+```
+
+当同时使用时，标准属性会被转换为 `font-variation-settings`。
+
+## 常用可变字体推荐
+
+### Google Fonts 可变字体
+
+| 字体名称 | 支持的轴 | 用途 |
+|---|---|---|
+| Roboto Flex | wght, wdth, slnt, opsz | 通用 |
+| Inter | wght | 界面字体 |
+|Recursive | wght, slnt, MONO, CASL | 多功能 |
+| Source Sans 3 | wght, wdth, ital, slnt | 文档 |
+| Amstelvar | wght, opsz, XTRA, YOPQ | 优雅衬线 |
+
+### 使用示例
+
+```css
+/* 来自 Google Fonts */
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,slnt,wdth,wght@8..144,-10..0,75..125,100..1000&display=swap');
+
+h1 {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 700;
+}
+
+.condensed-text {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 400, 'wdth' 75;
+}
+```
+
+## 浏览器支持
+
+所有现代浏览器都支持 `font-variation-settings`。
+
+## 可变字体轴注册表
+
+除了自定义轴，还有注册的标准化轴：
+
+| 轴名 | 全称 | 说明 |
+|---|---|---|
+| wght | Weight | 字重 |
+| wdth | Width | 字宽 |
+| ital | Italic | 斜体 |
+| slnt | Slant | 倾斜 |
+| opsz | Optical Size | 光学尺寸 |
+| GRAD | Grade | 字重等级 |
+| XTRA | Counter | 轮廓对比度 |
+| YOPQ | Y Opaque | 不透明度 |
+| GRAD | Grade | 等级 |
+
+## 实际应用场景
+
+### 响应式字体
+
+```css
+.text {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 300;
+}
+
+@media (min-width: 768px) {
+  .text {
+    font-variation-settings: 'wght' 400;
+  }
+}
+
+@media (min-width: 1200px) {
+  .text {
+    font-variation-settings: 'wght' 500;
+  }
+}
+```
+
+### 交互式字体
+
+```css
+.button {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 500;
+  transition: font-variation-settings 0.2s;
+}
+
+.button:hover {
+  font-variation-settings: 'wght' 700;
+}
+```
+
+### 性能优化
+
+```css
+@font-face {
+  font-family: 'MyVariableFont';
+  src: url('font.woff2') format('woff2-variations');
+  font-display: optional;  /* 不可用时使用后备字体 */
+}
+```
+
+## 交互式演示
+
+{/* @playground id="css-font-variation-settings" mode="demo" */}
+
+## 总结
+
+- 可变字体通过单一文件支持多种字形变体
+- 使用 `font-variation-settings` 控制各个轴
+- 常用轴：wght（字重）、wdth（宽度）、slnt（倾斜）、opsz（光学尺寸）
+- 可以动态调整实现平滑的字体动画
+- 相比传统多文件字体，更节省带宽


### PR DESCRIPTION
## Summary

Add CSS learning documentation and interactive demos for two font-related topics:

### Task 1: CSS font-display
- Documentation: src/topics/12.fonts/css-font-display/index.mdx
- Demo: examples/css/demos/css-font-display/index.html
- Covers: swap, optional, block, fallback, auto values
- Explains FOIT vs FOUT behavior

### Task 2: CSS font-variation-settings
- Documentation: src/topics/12.fonts/css-font-variation-settings/index.mdx
- Demo: examples/css/demos/css-font-variation-settings/index.html
- Covers: variable fonts, wght/wdth/slnt/opsz axes
- Interactive slider demo for real-time axis control

## Changes
- 4 files created (2 docs + 2 demos)
- Interactive HTML demos with live controls
- MDX documentation with code examples