### PR TITLE
docs: add CSS text-overflow complete guide

### DIFF
--- a/docs/css/positioning.md
+++ b/docs/css/positioning.md
@@ -1,0 +1,693 @@
+# CSS 定位完全指南
+
+> 本文档整理 CSS 定位各模式的原理、定位上下文、定位与布局的关系及常见问题。
+
+---
+
+## 目录
+
+- [1. 定位模式概述](#1-定位模式概述)
+- [2. 定位上下文（Containing Block）](#2-定位上下文-containing-block)
+- [3. static（静态定位）](#3-static静态定位)
+- [4. relative（相对定位）](#4-relative相对定位)
+- [5. absolute（绝对定位）](#5-absolute绝对定位)
+- [6. fixed（固定定位）](#6-fixed固定定位)
+- [7. sticky（粘性定位）](#7-sticky粘性定位)
+- [8. 定位与 Flex/Grid 的关系](#8-定位与-flexgrid-的关系)
+- [9. 常见问题与解决方案](#9-常见问题与解决方案)
+- [10. 实战场景](#10-实战场景)
+
+---
+
+## 1. 定位模式概述
+
+CSS 定位通过 `position` 属性控制元素的定位方式，共有 5 种模式：
+
+| 定位模式 | `position` 值 | 文档流 | 定位参考 | 使用场景 |
+|---------|--------------|--------|----------|---------|
+| 静态定位 | `static` | 正常 | 无 | 默认布局 |
+| 相对定位 | `relative` | 保留 | 自身原始位置 | 轻微调整、微动效 |
+| 绝对定位 | `absolute` | 脱离 | 最近已定位祖先 | 悬浮层、tooltip |
+| 固定定位 | `fixed` | 脱离 | 视口（viewport） | 固定导航、回到顶部 |
+| 粘性定位 | `sticky` | 保留 | 最近滚动祖先 | 吸顶/吸底效果 |
+
+---
+
+## 2. 定位上下文（Containing Block）
+
+理解定位上下文是掌握定位的关键。
+
+### 2.1 如何确定定位上下文
+
+元素的定位上下文由最近的**已定位祖先元素**决定：
+
+> **已定位元素**：position 不等于 `static` 的元素
+
+```
+定位上下文查找规则：
+1. 向上遍历 DOM 树
+2. 找到第一个 position ≠ static 的祖先
+3. 该祖先的 padding-box 边缘即为定位上下文
+4. 如果没有找到，则根元素（<html>）为定位上下文
+```
+
+### 2.2 各定位模式的上下文
+
+| 定位模式 | 定位参考 |
+|---------|---------|
+| `relative` | 自身在正常文档流中的位置 |
+| `absolute` | 最近已定位祖先的 padding-box |
+| `fixed` | 视口（viewport） |
+| `sticky` | 最近滚动祖先的滚动区域 |
+
+### 2.3 实战：定位上下文可视化
+
+```css
+.container { /* position: relative → 成为定位上下文 */
+  position: relative;
+  width: 500px;
+  height: 300px;
+}
+
+.tooltip {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  /* 相对于 .container 定位，而非页面 */
+}
+```
+
+---
+
+## 3. static（静态定位）
+
+### 3.1 特性
+
+- **默认定位模式**，所有元素初始都是 static
+- 元素按正常文档流排列
+- `top`、`right`、`bottom`、`left`、`z-index` **无效**
+
+### 3.2 用法
+
+```css
+.element {
+  position: static; /* 默认值，可以不写 */
+}
+```
+
+---
+
+## 4. relative（相对定位）
+
+### 4.1 特性
+
+- 保留在正常文档流中的位置（空间不释放）
+- 相对于**自身原始位置**偏移
+- `top`/`right`/`bottom`/`left` 控制偏移量
+- 支持 `z-index`，可创建新的堆叠上下文
+
+### 4.2 用法
+
+```css
+.element {
+  position: relative;
+  top: 10px;      /* 向下偏移 10px */
+  left: 20px;     /* 向右偏移 20px */
+  /* 负值也有效 */
+}
+```
+
+### 4.3 应用场景
+
+```css
+/* 微动效：hover 时轻微移动 */
+.button:hover {
+  position: relative;
+  top: -2px; /* 向上移动 */
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+}
+
+/* 作为 absolute 子元素的定位上下文 */
+.card {
+  position: relative;
+}
+.card .badge {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+```
+
+### 4.4 注意事项
+
+```css
+/* ❌ 常见误区：以为 relative 会脱离文档流 */
+.box {
+  position: relative;
+  top: 50px;
+  /* 元素仍在文档流中，原有空间保留 */
+  /* 视觉上向右下偏移，但后面的元素不会挤上来 */
+}
+```
+
+---
+
+## 5. absolute（绝对定位）
+
+### 5.1 特性
+
+- **脱离文档流**（不占用空间）
+- 相对于最近已定位祖先定位
+- 如果没有已定位祖先，则相对于初始包含块（<html>）
+- 宽高默认由内容决定（可手动设置）
+
+### 5.2 用法
+
+```css
+.modal-overlay {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  /* 覆盖整个父容器 */
+}
+```
+
+### 5.3 居中定位技巧
+
+```css
+/* 方法一：margin auto（需设置宽高）*/
+.absolute-center {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  margin: auto;
+  width: 200px;
+  height: 100px;
+}
+
+/* 方法二：transform（不需要知道宽高）*/
+.absolute-center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+/* 方法三：flexbox */
+.parent {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.child {
+  position: absolute;
+}
+```
+
+### 5.4 常见应用
+
+```css
+/* Tooltip */
+.tooltip-wrapper {
+  position: relative;
+  display: inline-block;
+}
+.tooltip {
+  position: absolute;
+  bottom: 100%;      /* 显示在元素上方 */
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+}
+
+/* 图片水印 */
+.watermarked-image {
+  position: relative;
+}
+.watermark {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(-30deg);
+  opacity: 0.3;
+  pointer-events: none; /* 不影响图片交互 */
+}
+
+/* 下拉菜单 */
+.dropdown {
+  position: relative;
+}
+.dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  min-width: 200px;
+}
+```
+
+---
+
+## 6. fixed（固定定位）
+
+### 6.1 特性
+
+- **脱离文档流**
+- 相对于**视口（viewport）**定位
+- 不随页面滚动移动
+- 始终保持在同一位置
+- 始终创建新的堆叠上下文
+
+### 6.2 用法
+
+```css
+.fixed-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 60px;
+  z-index: 1000;
+}
+
+.back-to-top {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  width: 50px;
+  height: 50px;
+}
+```
+
+### 6.3 移动端适配注意
+
+```css
+/* 移动端安全区域 */
+.mobile-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  /* 适配 iPhone 刘海屏 */
+  padding-top: env(safe-area-inset-top);
+}
+
+/* 适配 iPhone 底部横条 */
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding-bottom: env(safe-area-inset-bottom);
+}
+```
+
+### 6.4 常见陷阱
+
+```css
+/* ❌ fixed 元素在 transform 父元素内时失效 */
+.transform-parent {
+  transform: translateZ(0); /* 破坏 fixed 定位 */
+}
+.fixed-element {
+  position: fixed;
+  top: 0;
+  /* 相对于 .transform-parent 而非视口定位！ */
+}
+```
+
+---
+
+## 7. sticky（粘性定位）
+
+### 7.1 特性
+
+- 混合了 relative 和 fixed 的行为
+- 在滚动容器内表现为 relative
+- 滚动到阈值后表现为 fixed
+- **需要指定 `top`/`bottom` 等阈值**
+
+### 7.2 用法
+
+```css
+.sticky-header {
+  position: sticky;
+  top: 0;  /* 距离顶部 0px 时固定 */
+  background: white;
+  z-index: 10;
+}
+```
+
+### 7.3 适用场景
+
+```html
+<!-- 表格列头吸顶 -->
+<table>
+  <thead>
+    <tr>
+      <th style="position: sticky; top: 0;">列1</th>
+    </tr>
+  </thead>
+</table>
+
+<!-- 侧边栏吸顶 -->
+<style>
+.sidebar {
+  position: sticky;
+  top: 20px;  /* 距离顶部 20px 时开始固定 */
+  align-self: flex-start;
+}
+</style>
+```
+
+### 7.4 注意事项
+
+- **需要滚动祖先**：没有可滚动祖先则无效
+- **支持性**：IE 不支持，Safari 需 `-webkit-sticky`
+- **阈值必须指定**：否则等同于 relative
+
+```css
+/* Safari 兼容 */
+.sticky-header {
+  position: -webkit-sticky;
+  position: sticky;
+  top: 0;
+}
+```
+
+---
+
+## 8. 定位与 Flex/Grid 的关系
+
+### 8.1 Flex 容器中的定位
+
+```css
+/* ❌ 绝对定位在 flex 项目上会相对于 flex 容器定位 */
+.flex-container {
+  display: flex;
+  position: relative; /* 成为 absolute 子元素的定位上下文 */
+}
+.flex-item {
+  position: absolute;
+  /* 相对于 flex-container 定位，而非 flex 项目自身 */
+}
+```
+
+### 8.2 Grid 容器中的定位
+
+```css
+/* Grid 区域定位 */
+.grid-container {
+  display: grid;
+  grid-template-areas:
+    "header header"
+    "sidebar main"
+    "footer footer";
+}
+.grid-item {
+  position: relative;
+}
+.overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  /* 相对于 grid-item 定位 */
+}
+```
+
+### 8.3 定位在 Flex/Grid 中的实际行为
+
+```css
+/* Flex 项目使用 absolute 定位 */
+.flex-wrapper {
+  display: flex;
+  height: 200px;
+}
+.sibling {
+  flex: 1;
+  background: lightblue;
+}
+.abs-child {
+  position: absolute;
+  top: 0;
+  right: 0;
+  /* 相对于 .flex-wrapper（因为它有 position: relative） */
+  /* 而不是相对于 .sibling */
+}
+```
+
+---
+
+## 9. 常见问题与解决方案
+
+### 9.1 绝对定位元素居中
+
+```css
+/* 方案一：calc() */
+.center {
+  position: absolute;
+  top: calc(50% - 50px);
+  left: calc(50% - 100px);
+  width: 200px;
+  height: 100px;
+}
+
+/* 方案二：transform（推荐）*/
+.center {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+/* 方案三：margin auto（需设宽高）*/
+.center {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  margin: auto;
+  width: 200px;
+  height: 100px;
+}
+```
+
+### 9.2 绝对定位导致父元素高度塌陷
+
+```html
+<!-- 问题：父容器高度为 0 -->
+<div class="parent">
+  <div class="child">绝对定位元素</div>
+</div>
+
+<!-- 解决方案 1：父元素设置 padding -->
+.parent {
+  position: relative;
+  padding-bottom: 100px; /* 或 min-height */
+}
+
+/* 解决方案 2：伪元素撑开高度 */
+.parent::after {
+  content: '';
+  display: block;
+}
+
+/* 解决方案 3：父元素 min-height */
+.parent {
+  position: relative;
+  min-height: 200px;
+}
+```
+
+### 9.3 fixed 定位失效
+
+```css
+/* ❌ 祖先有 transform/perspective/filter 时失效 */
+.has-transform {
+  transform: translateZ(0);
+}
+
+/* ✅ 解决方案：将 fixed 元素移到 body 下 */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  /* 确保没有 transform 祖先 */
+}
+```
+
+### 9.4 z-index 不生效
+
+```css
+/* ❌ 父元素没有创建堆叠上下文 */
+.parent-1 { z-index: 10; }
+.parent-2 { z-index: 5; }
+.child { z-index: 100; /* 被父元素限制 */ }
+
+/* ✅ 解决方案：使用更高层级的 z-index 或打破父元素限制 */
+.parent-1 { z-index: 10; }
+.parent-2 { z-index: 5; }
+.child { z-index: 100; /* 实际渲染在 parent-1 之上 */ }
+```
+
+### 9.5 粘性定位不生效
+
+```css
+/* ❌ 没有滚动祖先 */
+.outer {
+  overflow: hidden; /* 滚动祖先被破坏了 */
+}
+.sticky {
+  position: sticky;
+  top: 0;
+  /* 无效！ */
+}
+
+/* ✅ 解决方案：确保有可滚动祖先 */
+.outer {
+  overflow: auto; /* 保留滚动能力 */
+  height: 100vh;
+}
+.sticky {
+  position: sticky;
+  top: 0;
+}
+```
+
+---
+
+## 10. 实战场景
+
+### 10.1 吸顶导航栏
+
+```css
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: white;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+/* 备用方案 */
+.header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+}
+/* 内容需要 padding-top 避免被遮挡 */
+.main-content {
+  padding-top: 60px;
+}
+```
+
+### 10.2 模态框
+
+```css
+.modal-overlay {
+  position: fixed;
+  inset: 0;  /* top:0; right:0; bottom:0; left:0 的简写 */
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.modal-content {
+  position: relative; /* 作为关闭按钮的定位上下文 */
+  background: white;
+  padding: 24px;
+  border-radius: 8px;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow: auto;
+}
+.close-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+}
+```
+
+### 10.3 浮动小徽章
+
+```css
+.badge-container {
+  position: relative;
+  display: inline-block;
+}
+.badge {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  background: red;
+  color: white;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  font-size: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+```
+
+### 10.4 图片画廊灯箱
+
+```css
+.gallery {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 16px;
+}
+.gallery-item {
+  position: relative;
+  cursor: pointer;
+}
+.gallery-item:hover::after {
+  content: '🔍';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.3);
+}
+```
+
+### 10.5 圣杯布局（经典三栏）
+
+```css
+.container {
+  display: flex;
+}
+.left {
+  position: relative;
+  flex-shrink: 0;
+  width: 200px;
+}
+.right {
+  position: relative;
+  flex-shrink: 0;
+  width: 200px;
+}
+.main {
+  flex: 1;
+  /* 中间栏自适应 */
+}
+```
+
+---
+
+## 参考资料
+
+- [MDN: CSS Position](https://developer.mozilla.org/en-US/docs/Web/CSS/position)
+- [CSS-TRICKS: Position](https://css-tricks.com/almanac/properties/p/position/)
+- [MDN: Layout and the containing block](https://developer.mozilla.org/en-US/docs/Web/CSS/Containing_block)

--- a/docs/css/text-overflow.md
+++ b/docs/css/text-overflow.md
@@ -1,0 +1,442 @@
+# CSS text-overflow 完全指南
+
+> 本文档整理 CSS text-overflow 属性的用法、必须配合的属性、多行文本溢出处理方案。
+
+---
+
+## 目录
+
+- [1. text-overflow 基础](#1-text-overflow-基础)
+- [2. 必须配合的属性](#2-必须配合的属性)
+- [3. clip vs ellipsis vs string](#3-clip-vs-ellipsis-vs-string)
+- [4. 单行文本溢出](#4-单行文本溢出)
+- [5. 多行文本溢出](#5-多行文本溢出)
+- [6. 双方向溢出](#6-双方向溢出)
+- [7. 与 Flex/Grid 布局的配合](#7-与-flexgrid-布局的配合)
+- [8. 常见问题与解决方案](#8-常见问题与解决方案)
+
+---
+
+## 1. text-overflow 基础
+
+### 1.1 概念
+
+`text-overflow` 属性指定当文本溢出其块容器时如何发出信号通知用户。
+
+### 1.2 关键前置条件
+
+> ⚠️ **必须同时满足以下两个条件才能生效**：
+> 1. `white-space: nowrap`（禁止换行）
+> 2. `overflow: hidden`（隐藏溢出）
+
+### 1.3 语法
+
+```css
+text-overflow: clip;        /* 默认值，截断 */
+text-overflow: ellipsis;    /* 显示省略号 ... */
+text-overflow: "***";       /* 自定义字符串（需引号）*/
+text-overflow: fade;        /* 淡出效果（实验性）*/
+text-overflow: ellipsis "...";  /* 省略号 + 自定义字符串 */
+```
+
+### 1.4 只影响内联方向
+
+text-overflow **只影响内联进展方向**的溢出（即横向溢出），不是底部溢出。
+
+---
+
+## 2. 必须配合的属性
+
+```css
+/* ❌ 错误：缺少任何一个都不生效 */
+.wrong {
+  text-overflow: ellipsis;
+  /* white-space 缺失 → 文本会换行 */
+  overflow: hidden;
+}
+
+/* ✅ 正确：三个属性缺一不可 */
+.correct {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+```
+
+---
+
+## 3. clip vs ellipsis vs string
+
+### 3.1 clip（默认值）
+
+```css
+.clip {
+  text-overflow: clip;
+  white-space: nowrap;
+  overflow: hidden;
+}
+/* 效果：直接截断，无省略号 */
+```
+
+### 3.2 ellipsis
+
+```css
+.ellipsis {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+/* 效果：显示 ... */
+```
+
+### 3.3 自定义字符串（现代浏览器支持）
+
+```css
+.custom {
+  text-overflow: "→";  /* 显示 → */
+  white-space: nowrap;
+  overflow: hidden;
+}
+```
+
+### 3.4 双方向省略号
+
+```css
+/* CSS4 语法：可以指定左右两侧的省略号 */
+.double {
+  text-overflow: ellipsis ellipsis;  /* 左省略号 右省略号 */
+  white-space: nowrap;
+  overflow: hidden;
+  direction: rtl;  /* 从右到左方向 */
+}
+```
+
+---
+
+## 4. 单行文本溢出
+
+### 4.1 基础写法
+
+```css
+.single-line {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+```
+
+### 4.2 完整示例
+
+```html
+<style>
+.card-title {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  /* 可选：添加渐变提示 */
+  background: linear-gradient(90deg, transparent, white 90%);
+}
+
+.card-title::after {
+  content: "...";
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  padding: 0 4px;
+  background: white;
+}
+</style>
+
+<div class="card">
+  <h3 class="card-title">这是一段很长的标题文本，超出容器宽度时会显示省略号</h3>
+</div>
+```
+
+### 4.3 带渐变提示
+
+```css
+.card-title {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  position: relative;
+}
+
+/* 渐变遮罩提示（现代方案） */
+.card-title::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  width: 40px;
+  background: linear-gradient(90deg, transparent, white);
+  pointer-events: none;
+}
+```
+
+---
+
+## 5. 多行文本溢出
+
+### 5.1 纯 CSS 方案（line-clamp）
+
+```css
+/* WebKit/Blink 浏览器（Chrome, Safari, Edge） */
+.multi-line {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;   /* 限制最多 3 行 */
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;  /* 可选，配合 ellipsis */
+}
+```
+
+### 5.2 兼容方案
+
+```css
+/* 标准写法 + 降级 */
+.multi-line {
+  /* WebKit/Blink */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+
+  /* Firefox（较新版本）*/
+  display: block;
+  overflow: hidden;
+  max-height: 4.5em; /* line-height(1.5) * 3行 = 4.5em，需计算调整 */
+  line-height: 1.5;
+}
+
+/* 渐进增强：仅在支持 line-clamp 的浏览器使用 */
+@supports (-webkit-line-clamp: 2) {
+  .multi-line {
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    max-height: none; /* 移除 Firefox 降级 */
+  }
+}
+```
+
+### 5.3 JS 方案（更广泛兼容）
+
+```js
+/**
+ * 多行文本溢出 JS 实现
+ * @param {HTMLElement} el - 目标元素
+ * @param {number} lineClamp - 最大行数
+ */
+function lineClamp(el, lineClamp) {
+  const style = getComputedStyle(el);
+  const lineHeight = parseFloat(style.lineHeight);
+  const maxHeight = lineHeight * lineClamp + parseFloat(style.paddingTop) + parseFloat(style.paddingBottom);
+
+  if (el.scrollHeight <= maxHeight) return; // 不需要截断
+
+  const text = el.textContent;
+  let low = 0, high = text.length;
+
+  while (low < high) {
+    const mid = Math.floor((low + high + 1) / 2);
+    el.textContent = text.slice(0, mid) + '...';
+    if (el.scrollHeight <= maxHeight) {
+      low = mid;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  el.textContent = text.slice(0, low) + '...';
+
+  // 处理单词边界
+  if (el.scrollHeight > maxHeight) {
+    el.textContent = text.slice(0, low - 1) + '...';
+  }
+}
+```
+
+---
+
+## 6. 双方向溢出
+
+### 6.1 overflow-x 和 overflow-y
+
+```css
+/* 仅水平方向溢出处理 */
+.horizontal-only {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow-x: hidden;
+  overflow-y: visible; /* 允许垂直方向显示 */
+}
+
+/* 两个方向都溢出处理 */
+.both-directions {
+  text-overflow: ellipsis ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  writing-mode: horizontal-tb; /* 默认 */
+}
+```
+
+### 6.2 RTL（从右到左）方向
+
+```css
+[dir="rtl"] .text {
+  text-overflow: ellipsis ellipsis; /* 左侧显示省略号 */
+  direction: rtl;
+}
+```
+
+---
+
+## 7. 与 Flex/Grid 布局的配合
+
+### 7.1 Flex 布局中的文本溢出
+
+```css
+/* ❌ 问题：flex 项目默认不收缩到内容以下 */
+.flex-container {
+  display: flex;
+}
+.flex-item {
+  flex: 1;
+  min-width: 0; /* 关键！允许 flex 项目收缩 */
+}
+.flex-item .text {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+/* ✅ 正确 */
+```
+
+### 7.2 Grid 布局中的文本溢出
+
+```css
+.grid-cell {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  /* 配合 min-width: 0 防止网格区域撑开 */
+  min-width: 0;
+}
+```
+
+### 7.3 防止容器被撑开
+
+```css
+/* 使用 max-width 限制容器宽度 */
+.container {
+  max-width: 300px;
+}
+
+/* 使用 table-layout: fixed */
+table {
+  table-layout: fixed;
+  width: 300px;
+}
+td {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+```
+
+---
+
+## 8. 常见问题与解决方案
+
+### 8.1 text-overflow 不生效
+
+```css
+/* ❌ 常见错误： */
+.element {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  /* white-space 缺失！文本会换行 */
+  white-space: normal; /* 默认值，不换行需要 nowrap */
+}
+
+/* ✅ 解决：必须同时设置 */
+.element {
+  text-overflow: ellipsis;
+  white-space: nowrap;  /* 禁止换行 */
+  overflow: hidden;     /* 隐藏溢出 */
+}
+```
+
+### 8.2 省略号位置不正确
+
+```css
+/* ❌ 省略号出现在中间（文字从右往左排列） */
+.element {
+  direction: rtl;  /* 可能是 direction 问题 */
+  text-align: left;
+}
+
+/* ✅ 解决：明确设置 direction */
+.element {
+  direction: ltr;
+  text-align: left;
+}
+```
+
+### 8.3 省略号后面仍有文字
+
+```css
+/* 可能是 min-width 或 width 问题 */
+.element {
+  width: 100%;  /* 可能被子元素撑开 */
+  min-width: 0; /* 关键：允许收缩 */
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+```
+
+### 8.4 line-clamp 在 Firefox 不生效
+
+```css
+/* Firefox 68+ 支持 -webkit-line-clamp */
+@supports not (-webkit-line-clamp: 2) {
+  .multi-line {
+    /* Firefox 降级方案：使用 max-height + overflow */
+    display: block;
+    overflow: hidden;
+    max-height: 4.5em; /* line-height(1.5) * 3 */
+    line-height: 1.5;
+  }
+}
+```
+
+### 8.5 配合 tooltip 使用
+
+```css
+/* 悬停显示完整文本 */
+.title {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  cursor: help;
+}
+
+.title:hover {
+  white-space: normal;
+  overflow: visible;
+  word-break: break-all; /* 允许换行显示完整内容 */
+}
+```
+
+---
+
+## 参考资料
+
+- [MDN: text-overflow](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow)
+- [CSS-TRICKS: The CSS white-space Property](https://css-tricks.com/almanac/properties/w/whitespace/)
+- [CSS-TRICKS: line-clamp](https://css-tricks.com/line-clampin/)
+- [W3Schools: CSS text-overflow](https://www.w3schools.com/css/css_text_overflow.asp)

--- a/examples/css/demos/css-filter/index.html
+++ b/examples/css/demos/css-filter/index.html
@@ -1,0 +1,1071 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS filter 滤镜效果演示</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f8fafc;
+      color: #1e293b;
+    }
+
+    h1 {
+      text-align: center;
+      color: #1e293b;
+      margin-bottom: 8px;
+    }
+
+    .subtitle {
+      text-align: center;
+      color: #64748b;
+      margin-bottom: 30px;
+    }
+
+    /* Tab Navigation */
+    .tabs {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 4px;
+      background: #e2e8f0;
+      padding: 4px;
+      border-radius: 12px;
+      margin-bottom: 24px;
+    }
+
+    .tab-btn {
+      flex: 1;
+      min-width: 90px;
+      padding: 10px 12px;
+      border: none;
+      background: transparent;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 13px;
+      font-weight: 500;
+      color: #64748b;
+      transition: all 0.2s ease;
+    }
+
+    .tab-btn:hover {
+      background: #f1f5f9;
+      color: #475569;
+    }
+
+    .tab-btn.active {
+      background: white;
+      color: #3b82f6;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+    }
+
+    /* Demo Area */
+    .demo-area {
+      display: grid;
+      grid-template-columns: 1fr 300px;
+      gap: 24px;
+      margin-bottom: 24px;
+    }
+
+    @media (max-width: 768px) {
+      .demo-area {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .preview-panel {
+      background: white;
+      border-radius: 12px;
+      padding: 24px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 320px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    /* Checkered background for transparency demo */
+    .preview-panel.has-bg {
+      background-image:
+        linear-gradient(45deg, #e2e8f0 25%, transparent 25%),
+        linear-gradient(-45deg, #e2e8f0 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, #e2e8f0 75%),
+        linear-gradient(-45deg, transparent 75%, #e2e8f0 75%);
+      background-size: 20px 20px;
+      background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
+      background-color: white;
+    }
+
+    .preview-box {
+      width: 200px;
+      height: 200px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      border-radius: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-size: 24px;
+      font-weight: bold;
+      text-shadow: 0 2px 4px rgba(0,0,0,0.3);
+      transition: filter 0.15s ease;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .preview-box img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+      border-radius: 16px;
+    }
+
+    /* SVG logo for better filter demo */
+    .preview-box svg {
+      width: 120px;
+      height: 120px;
+    }
+
+    /* Control Panel */
+    .control-panel {
+      background: white;
+      border-radius: 12px;
+      padding: 24px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    }
+
+    .control-panel h3 {
+      margin: 0 0 16px 0;
+      font-size: 1rem;
+      color: #3b82f6;
+    }
+
+    .slider-group {
+      margin-bottom: 16px;
+    }
+
+    .slider-label {
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 6px;
+      font-size: 13px;
+      color: #475569;
+    }
+
+    .slider-value {
+      font-family: monospace;
+      font-weight: 600;
+      color: #3b82f6;
+      background: #eff6ff;
+      padding: 2px 8px;
+      border-radius: 4px;
+    }
+
+    input[type="range"] {
+      width: 100%;
+      height: 6px;
+      border-radius: 3px;
+      background: #e2e8f0;
+      outline: none;
+      -webkit-appearance: none;
+    }
+
+    input[type="range"]::-webkit-slider-thumb {
+      -webkit-appearance: none;
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: #3b82f6;
+      cursor: pointer;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.2);
+    }
+
+    input[type="range"]::-moz-range-thumb {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: #3b82f6;
+      cursor: pointer;
+      border: none;
+    }
+
+    /* Color picker for drop-shadow */
+    .color-group {
+      margin-bottom: 16px;
+    }
+
+    .color-label {
+      font-size: 13px;
+      color: #475569;
+      margin-bottom: 6px;
+      display: block;
+    }
+
+    input[type="color"] {
+      width: 100%;
+      height: 36px;
+      border: 1px solid #e2e8f0;
+      border-radius: 6px;
+      cursor: pointer;
+      padding: 2px;
+    }
+
+    /* Code Output */
+    .code-output {
+      background: #1e1e1e;
+      border-radius: 8px;
+      padding: 16px;
+      margin-top: 16px;
+    }
+
+    .code-output pre {
+      margin: 0;
+      color: #d4d4d4;
+      font-family: "Fira Code", Consolas, monospace;
+      font-size: 13px;
+      overflow-x: auto;
+    }
+
+    .code-prop { color: #9cdcfe; }
+    .code-fn { color: #dcdcaa; }
+    .code-value { color: #ce9178; }
+
+    /* Preset Buttons */
+    .preset-section {
+      margin-top: 20px;
+      padding-top: 16px;
+      border-top: 1px solid #e2e8f0;
+    }
+
+    .preset-section h4 {
+      margin: 0 0 10px 0;
+      font-size: 13px;
+      color: #64748b;
+    }
+
+    .preset-buttons {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+    }
+
+    .preset-btn {
+      padding: 5px 10px;
+      border: 1px solid #e2e8f0;
+      background: #f8fafc;
+      border-radius: 6px;
+      font-size: 12px;
+      cursor: pointer;
+      color: #475569;
+      transition: all 0.2s ease;
+    }
+
+    .preset-btn:hover {
+      background: #3b82f6;
+      color: white;
+      border-color: #3b82f6;
+    }
+
+    /* Tab Content */
+    .tab-content {
+      display: none;
+    }
+
+    .tab-content.active {
+      display: block;
+    }
+
+    /* Info Box */
+    .info-box {
+      background: #eff6ff;
+      border: 1px solid #bfdbfe;
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 24px;
+    }
+
+    .info-box strong {
+      color: #1e40af;
+    }
+
+    .info-box p {
+      margin: 8px 0 0 0;
+      color: #1e40af;
+    }
+
+    /* Combo Section */
+    .combo-section {
+      background: white;
+      border-radius: 12px;
+      padding: 24px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+      margin-top: 24px;
+    }
+
+    .combo-section h2 {
+      margin: 0 0 16px 0;
+      color: #3b82f6;
+      font-size: 1.2em;
+    }
+
+    .combo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 16px;
+    }
+
+    .combo-item {
+      background: #f8fafc;
+      border-radius: 8px;
+      padding: 16px;
+      text-align: center;
+    }
+
+    .combo-item .preview-box {
+      width: 100%;
+      height: 100px;
+      margin-bottom: 12px;
+      font-size: 14px;
+    }
+
+    .combo-item .label {
+      font-size: 12px;
+      color: #64748b;
+      font-family: monospace;
+    }
+
+    .combo-item .desc {
+      font-size: 13px;
+      color: #475569;
+      margin-top: 4px;
+    }
+
+    /* Footer */
+    .footer {
+      text-align: center;
+      margin-top: 40px;
+      color: #94a3b8;
+      font-size: 13px;
+    }
+  </style>
+</head>
+<body>
+  <h1>🎨 CSS filter 滤镜效果演示</h1>
+  <p class="subtitle">交互式体验 10 种 CSS 滤镜函数</p>
+
+  <div class="info-box">
+    <strong>💡 关于 CSS filter</strong>
+    <p>
+      CSS filter 属性为元素应用图形效果，如模糊、亮度调整、对比度调整等。
+      可以组合多个滤镜函数，按从左到右的顺序依次应用。
+    </p>
+  </div>
+
+  <!-- Tab Navigation -->
+  <div class="tabs" id="tabNav">
+    <button class="tab-btn active" data-tab="blur">blur</button>
+    <button class="tab-btn" data-tab="brightness">brightness</button>
+    <button class="tab-btn" data-tab="contrast">contrast</button>
+    <button class="tab-btn" data-tab="drop-shadow">drop-shadow</button>
+    <button class="tab-btn" data-tab="grayscale">grayscale</button>
+    <button class="tab-btn" data-tab="hue-rotate">hue-rotate</button>
+    <button class="tab-btn" data-tab="invert">invert</button>
+    <button class="tab-btn" data-tab="opacity">opacity</button>
+    <button class="tab-btn" data-tab="saturate">saturate</button>
+    <button class="tab-btn" data-tab="sepia">sepia</button>
+    <button class="tab-btn" data-tab="combo">组合效果</button>
+  </div>
+
+  <!-- Tab Contents -->
+  <div id="tabContents">
+    <!-- blur -->
+    <div class="tab-content active" data-tab="blur">
+      <div class="demo-area">
+        <div class="preview-panel">
+          <div class="preview-box" id="previewBlur">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+              <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+              <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+              <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+            </svg>
+          </div>
+        </div>
+        <div class="control-panel">
+          <h3>blur() 高斯模糊</h3>
+          <div class="slider-group">
+            <div class="slider-label">
+              <span>模糊半径</span>
+              <span class="slider-value" id="blurVal">5px</span>
+            </div>
+            <input type="range" id="blurSlider" min="0" max="20" value="5" step="0.5">
+          </div>
+          <div class="code-output">
+            <pre><code><span class="code-prop">filter</span>: <span class="code-fn">blur</span>(<span class="code-value" id="blurCode">5px</span>);</code></pre>
+          </div>
+          <div class="preset-section">
+            <h4>预设值</h4>
+            <div class="preset-buttons">
+              <button class="preset-btn" data-filter="blur(0)">0px</button>
+              <button class="preset-btn" data-filter="blur(2px)">2px</button>
+              <button class="preset-btn" data-filter="blur(5px)">5px</button>
+              <button class="preset-btn" data-filter="blur(10px)">10px</button>
+              <button class="preset-btn" data-filter="blur(15px)">15px</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- brightness -->
+    <div class="tab-content" data-tab="brightness">
+      <div class="demo-area">
+        <div class="preview-panel has-bg">
+          <div class="preview-box" id="previewBrightness">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+              <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+              <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+              <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+            </svg>
+          </div>
+        </div>
+        <div class="control-panel">
+          <h3>brightness() 亮度调整</h3>
+          <div class="slider-group">
+            <div class="slider-label">
+              <span>亮度</span>
+              <span class="slider-value" id="brightnessVal">100%</span>
+            </div>
+            <input type="range" id="brightnessSlider" min="0" max="200" value="100" step="5">
+          </div>
+          <div class="code-output">
+            <pre><code><span class="code-prop">filter</span>: <span class="code-fn">brightness</span>(<span class="code-value" id="brightnessCode">100%</span>);</code></pre>
+          </div>
+          <div class="preset-section">
+            <h4>预设值</h4>
+            <div class="preset-buttons">
+              <button class="preset-btn" data-filter="brightness(0%)">0%</button>
+              <button class="preset-btn" data-filter="brightness(50%)">50%</button>
+              <button class="preset-btn" data-filter="brightness(100%)">100%</button>
+              <button class="preset-btn" data-filter="brightness(150%)">150%</button>
+              <button class="preset-btn" data-filter="brightness(200%)">200%</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- contrast -->
+    <div class="tab-content" data-tab="contrast">
+      <div class="demo-area">
+        <div class="preview-panel has-bg">
+          <div class="preview-box" id="previewContrast">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+              <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+              <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+              <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+            </svg>
+          </div>
+        </div>
+        <div class="control-panel">
+          <h3>contrast() 对比度调整</h3>
+          <div class="slider-group">
+            <div class="slider-label">
+              <span>对比度</span>
+              <span class="slider-value" id="contrastVal">100%</span>
+            </div>
+            <input type="range" id="contrastSlider" min="0" max="200" value="100" step="5">
+          </div>
+          <div class="code-output">
+            <pre><code><span class="code-prop">filter</span>: <span class="code-fn">contrast</span>(<span class="code-value" id="contrastCode">100%</span>);</code></pre>
+          </div>
+          <div class="preset-section">
+            <h4>预设值</h4>
+            <div class="preset-buttons">
+              <button class="preset-btn" data-filter="contrast(0%)">0%</button>
+              <button class="preset-btn" data-filter="contrast(50%)">50%</button>
+              <button class="preset-btn" data-filter="contrast(100%)">100%</button>
+              <button class="preset-btn" data-filter="contrast(150%)">150%</button>
+              <button class="preset-btn" data-filter="contrast(200%)">200%</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- drop-shadow -->
+    <div class="tab-content" data-tab="drop-shadow">
+      <div class="demo-area">
+        <div class="preview-panel">
+          <div class="preview-box" id="previewDropShadow" style="filter: drop-shadow(5px 5px 8px rgba(0,0,0,0.4));">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+              <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+              <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+              <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+            </svg>
+          </div>
+        </div>
+        <div class="control-panel">
+          <h3>drop-shadow() 投影</h3>
+          <div class="slider-group">
+            <div class="slider-label">
+              <span>水平偏移</span>
+              <span class="slider-value" id="shadowXVal">5px</span>
+            </div>
+            <input type="range" id="shadowXSlider" min="-20" max="20" value="5" step="1">
+          </div>
+          <div class="slider-group">
+            <div class="slider-label">
+              <span>垂直偏移</span>
+              <span class="slider-value" id="shadowYVal">5px</span>
+            </div>
+            <input type="range" id="shadowYSlider" min="-20" max="20" value="5" step="1">
+          </div>
+          <div class="slider-group">
+            <div class="slider-label">
+              <span>模糊半径</span>
+              <span class="slider-value" id="shadowBlurVal">8px</span>
+            </div>
+            <input type="range" id="shadowBlurSlider" min="0" max="30" value="8" step="1">
+          </div>
+          <div class="color-group">
+            <label class="color-label">投影颜色</label>
+            <input type="color" id="shadowColor" value="#000000">
+          </div>
+          <div class="code-output">
+            <pre><code><span class="code-prop">filter</span>: <span class="code-fn">drop-shadow</span>(<span class="code-value" id="shadowCode">5px 5px 8px rgba(0,0,0,0.4)</span>);</code></pre>
+          </div>
+          <div class="preset-section">
+            <h4>预设效果</h4>
+            <div class="preset-buttons">
+              <button class="preset-btn" data-filter="drop-shadow(3px 3px 5px rgba(0,0,0,0.3))">柔和</button>
+              <button class="preset-btn" data-filter="drop-shadow(5px 5px 8px rgba(0,0,0,0.4))">中等</button>
+              <button class="preset-btn" data-filter="drop-shadow(0 8px 16px rgba(0,0,0,0.5))">强烈</button>
+              <button class="preset-btn" data-filter="drop-shadow(0 0 10px rgba(102,126,234,0.8))">发光</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- grayscale -->
+    <div class="tab-content" data-tab="grayscale">
+      <div class="demo-area">
+        <div class="preview-panel has-bg">
+          <div class="preview-box" id="previewGrayscale">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+              <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+              <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+              <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+            </svg>
+          </div>
+        </div>
+        <div class="control-panel">
+          <h3>grayscale() 灰度转换</h3>
+          <div class="slider-group">
+            <div class="slider-label">
+              <span>灰度</span>
+              <span class="slider-value" id="grayscaleVal">50%</span>
+            </div>
+            <input type="range" id="grayscaleSlider" min="0" max="100" value="50" step="1">
+          </div>
+          <div class="code-output">
+            <pre><code><span class="code-prop">filter</span>: <span class="code-fn">grayscale</span>(<span class="code-value" id="grayscaleCode">50%</span>);</code></pre>
+          </div>
+          <div class="preset-section">
+            <h4>预设值</h4>
+            <div class="preset-buttons">
+              <button class="preset-btn" data-filter="grayscale(0%)">0%</button>
+              <button class="preset-btn" data-filter="grayscale(25%)">25%</button>
+              <button class="preset-btn" data-filter="grayscale(50%)">50%</button>
+              <button class="preset-btn" data-filter="grayscale(75%)">75%</button>
+              <button class="preset-btn" data-filter="grayscale(100%)">100%</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- hue-rotate -->
+    <div class="tab-content" data-tab="hue-rotate">
+      <div class="demo-area">
+        <div class="preview-panel has-bg">
+          <div class="preview-box" id="previewHueRotate">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+              <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+              <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+              <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+            </svg>
+          </div>
+        </div>
+        <div class="control-panel">
+          <h3>hue-rotate() 色相旋转</h3>
+          <div class="slider-group">
+            <div class="slider-label">
+              <span>旋转角度</span>
+              <span class="slider-value" id="hueRotateVal">90deg</span>
+            </div>
+            <input type="range" id="hueRotateSlider" min="0" max="360" value="90" step="5">
+          </div>
+          <div class="code-output">
+            <pre><code><span class="code-prop">filter</span>: <span class="code-fn">hue-rotate</span>(<span class="code-value" id="hueRotateCode">90deg</span>);</code></pre>
+          </div>
+          <div class="preset-section">
+            <h4>预设值</h4>
+            <div class="preset-buttons">
+              <button class="preset-btn" data-filter="hue-rotate(0deg)">0°</button>
+              <button class="preset-btn" data-filter="hue-rotate(90deg)">90°</button>
+              <button class="preset-btn" data-filter="hue-rotate(180deg)">180°</button>
+              <button class="preset-btn" data-filter="hue-rotate(270deg)">270°</button>
+              <button class="preset-btn" data-filter="hue-rotate(360deg)">360°</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- invert -->
+    <div class="tab-content" data-tab="invert">
+      <div class="demo-area">
+        <div class="preview-panel has-bg">
+          <div class="preview-box" id="previewInvert">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+              <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+              <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+              <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+            </svg>
+          </div>
+        </div>
+        <div class="control-panel">
+          <h3>invert() 反相</h3>
+          <div class="slider-group">
+            <div class="slider-label">
+              <span>反相程度</span>
+              <span class="slider-value" id="invertVal">50%</span>
+            </div>
+            <input type="range" id="invertSlider" min="0" max="100" value="50" step="1">
+          </div>
+          <div class="code-output">
+            <pre><code><span class="code-prop">filter</span>: <span class="code-fn">invert</span>(<span class="code-value" id="invertCode">50%</span>);</code></pre>
+          </div>
+          <div class="preset-section">
+            <h4>预设值</h4>
+            <div class="preset-buttons">
+              <button class="preset-btn" data-filter="invert(0%)">0%</button>
+              <button class="preset-btn" data-filter="invert(25%)">25%</button>
+              <button class="preset-btn" data-filter="invert(50%)">50%</button>
+              <button class="preset-btn" data-filter="invert(75%)">75%</button>
+              <button class="preset-btn" data-filter="invert(100%)">100%</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- opacity -->
+    <div class="tab-content" data-tab="opacity">
+      <div class="demo-area">
+        <div class="preview-panel has-bg">
+          <div class="preview-box" id="previewOpacity">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+              <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+              <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+              <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+            </svg>
+          </div>
+        </div>
+        <div class="control-panel">
+          <h3>opacity() 透明度</h3>
+          <div class="slider-group">
+            <div class="slider-label">
+              <span>透明度</span>
+              <span class="slider-value" id="opacityVal">50%</span>
+            </div>
+            <input type="range" id="opacitySlider" min="0" max="100" value="50" step="1">
+          </div>
+          <div class="code-output">
+            <pre><code><span class="code-prop">filter</span>: <span class="code-fn">opacity</span>(<span class="code-value" id="opacityCode">50%</span>);</code></pre>
+          </div>
+          <div class="preset-section">
+            <h4>预设值</h4>
+            <div class="preset-buttons">
+              <button class="preset-btn" data-filter="opacity(0%)">0%</button>
+              <button class="preset-btn" data-filter="opacity(25%)">25%</button>
+              <button class="preset-btn" data-filter="opacity(50%)">50%</button>
+              <button class="preset-btn" data-filter="opacity(75%)">75%</button>
+              <button class="preset-btn" data-filter="opacity(100%)">100%</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- saturate -->
+    <div class="tab-content" data-tab="saturate">
+      <div class="demo-area">
+        <div class="preview-panel has-bg">
+          <div class="preview-box" id="previewSaturate">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+              <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+              <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+              <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+            </svg>
+          </div>
+        </div>
+        <div class="control-panel">
+          <h3>saturate() 饱和度</h3>
+          <div class="slider-group">
+            <div class="slider-label">
+              <span>饱和度</span>
+              <span class="slider-value" id="saturateVal">100%</span>
+            </div>
+            <input type="range" id="saturateSlider" min="0" max="200" value="100" step="5">
+          </div>
+          <div class="code-output">
+            <pre><code><span class="code-prop">filter</span>: <span class="code-fn">saturate</span>(<span class="code-value" id="saturateCode">100%</span>);</code></pre>
+          </div>
+          <div class="preset-section">
+            <h4>预设值</h4>
+            <div class="preset-buttons">
+              <button class="preset-btn" data-filter="saturate(0%)">0%</button>
+              <button class="preset-btn" data-filter="saturate(50%)">50%</button>
+              <button class="preset-btn" data-filter="saturate(100%)">100%</button>
+              <button class="preset-btn" data-filter="saturate(150%)">150%</button>
+              <button class="preset-btn" data-filter="saturate(200%)">200%</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- sepia -->
+    <div class="tab-content" data-tab="sepia">
+      <div class="demo-area">
+        <div class="preview-panel has-bg">
+          <div class="preview-box" id="previewSepia">
+            <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+              <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+              <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+              <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+              <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+            </svg>
+          </div>
+        </div>
+        <div class="control-panel">
+          <h3>sepia() 棕褐色</h3>
+          <div class="slider-group">
+            <div class="slider-label">
+              <span>棕褐色</span>
+              <span class="slider-value" id="sepiaVal">50%</span>
+            </div>
+            <input type="range" id="sepiaSlider" min="0" max="100" value="50" step="1">
+          </div>
+          <div class="code-output">
+            <pre><code><span class="code-prop">filter</span>: <span class="code-fn">sepia</span>(<span class="code-value" id="sepiaCode">50%</span>);</code></pre>
+          </div>
+          <div class="preset-section">
+            <h4>预设值</h4>
+            <div class="preset-buttons">
+              <button class="preset-btn" data-filter="sepia(0%)">0%</button>
+              <button class="preset-btn" data-filter="sepia(25%)">25%</button>
+              <button class="preset-btn" data-filter="sepia(50%)">50%</button>
+              <button class="preset-btn" data-filter="sepia(75%)">75%</button>
+              <button class="preset-btn" data-filter="sepia(100%)">100%</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- combo -->
+    <div class="tab-content" data-tab="combo">
+      <div class="combo-section">
+        <h2>🎨 滤镜组合效果</h2>
+        <p style="color:#64748b; margin-bottom:16px;">多个滤镜函数可以链式组合，创造丰富的视觉效果</p>
+        <div class="combo-grid">
+          <div class="combo-item">
+            <div class="preview-box" style="filter: contrast(175%) brightness(3%);">
+              <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+                <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+                <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+                <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+              </svg>
+            </div>
+            <div class="label">contrast + brightness</div>
+            <div class="desc">增强对比与亮度</div>
+          </div>
+          <div class="combo-item">
+            <div class="preview-box" style="filter: grayscale(100%) contrast(150%);">
+              <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+                <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+                <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+                <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+              </svg>
+            </div>
+            <div class="label">grayscale + contrast</div>
+            <div class="desc">高对比黑白</div>
+          </div>
+          <div class="combo-item">
+            <div class="preview-box" style="filter: sepia(40%) contrast(110%) brightness(90%);">
+              <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+                <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+                <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+                <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+              </svg>
+            </div>
+            <div class="label">sepia + contrast + brightness</div>
+            <div class="desc">复古风格</div>
+          </div>
+          <div class="combo-item">
+            <div class="preview-box" style="filter: saturate(140%) hue-rotate(180deg);">
+              <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+                <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+                <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+                <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+              </svg>
+            </div>
+            <div class="label">saturate + hue-rotate</div>
+            <div class="desc">冷色调风格</div>
+          </div>
+          <div class="combo-item">
+            <div class="preview-box" style="filter: saturate(120%) brightness(105%) sepia(20%);">
+              <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+                <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+                <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+                <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+              </svg>
+            </div>
+            <div class="label">saturate + brightness + sepia</div>
+            <div class="desc">暖色调风格</div>
+          </div>
+          <div class="combo-item">
+            <div class="preview-box" style="filter: blur(2px) brightness(110%) contrast(90%);">
+              <svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+                <circle cx="50" cy="50" r="40" fill="#fbbf24"/>
+                <circle cx="35" cy="40" r="8" fill="#1e293b"/>
+                <circle cx="65" cy="40" r="8" fill="#1e293b"/>
+                <path d="M 30 65 Q 50 80 70 65" stroke="#1e293b" stroke-width="4" fill="none" stroke-linecap="round"/>
+              </svg>
+            </div>
+            <div class="label">blur + brightness + contrast</div>
+            <div class="desc">柔焦效果</div>
+          </div>
+        </div>
+        <div class="code-output" style="margin-top:20px;">
+          <pre><code><span class="code-comment">/* 常用组合示例 */</span>
+
+<span class="code-comment">/* 高对比黑白 */</span>
+<span class="code-prop">filter</span>: <span class="code-fn">grayscale</span>(<span class="code-value">100%</span>) <span class="code-fn">contrast</span>(<span class="code-value">150%</span>);
+
+<span class="code-comment">/* 复古风格 */</span>
+<span class="code-prop">filter</span>: <span class="code-fn">sepia</span>(<span class="code-value">40%</span>) <span class="code-fn">contrast</span>(<span class="code-value">110%</span>) <span class="code-fn">brightness</span>(<span class="code-value">90%</span>);
+
+<span class="code-comment">/* 冷色调 */</span>
+<span class="code-prop">filter</span>: <span class="code-fn">saturate</span>(<span class="code-value">140%</span>) <span class="code-fn">hue-rotate</span>(<span class="code-value">180deg</span>);
+
+<span class="code-comment">/* 柔焦 */</span>
+<span class="code-prop">filter</span>: <span class="code-fn">blur</span>(<span class="code-value">2px</span>) <span class="code-fn">brightness</span>(<span class="code-value">110%</span>) <span class="code-fn">contrast</span>(<span class="code-value">90%</span>);</code></pre>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="footer">
+    <p>更多 CSS 滤镜技巧，请访问 <a href="https://developer.mozilla.org/zh-CN/docs/Web/CSS/filter" target="_blank" style="color:#3b82f6;">MDN CSS filter</a></p>
+  </div>
+
+  <script>
+    // Tab Navigation
+    const tabNav = document.getElementById('tabNav');
+    const tabContents = document.getElementById('tabContents');
+
+    tabNav.addEventListener('click', (e) => {
+      if (e.target.classList.contains('tab-btn')) {
+        const tabName = e.target.dataset.tab;
+
+        // Update active tab button
+        tabNav.querySelectorAll('.tab-btn').forEach(btn => btn.classList.remove('active'));
+        e.target.classList.add('active');
+
+        // Update active tab content
+        tabContents.querySelectorAll('.tab-content').forEach(content => {
+          content.classList.remove('active');
+          if (content.dataset.tab === tabName) {
+            content.classList.add('active');
+          }
+        });
+      }
+    });
+
+    // Filter configs
+    const filterConfigs = {
+      blur: {
+        slider: 'blurSlider',
+        val: 'blurVal',
+        code: 'blurCode',
+        preview: 'previewBlur',
+        getFilter: (v) => `blur(${v}px)`
+      },
+      brightness: {
+        slider: 'brightnessSlider',
+        val: 'brightnessVal',
+        code: 'brightnessCode',
+        preview: 'previewBrightness',
+        getFilter: (v) => `brightness(${v}%)`
+      },
+      contrast: {
+        slider: 'contrastSlider',
+        val: 'contrastVal',
+        code: 'contrastCode',
+        preview: 'previewContrast',
+        getFilter: (v) => `contrast(${v}%)`
+      },
+      grayscale: {
+        slider: 'grayscaleSlider',
+        val: 'grayscaleVal',
+        code: 'grayscaleCode',
+        preview: 'previewGrayscale',
+        getFilter: (v) => `grayscale(${v}%)`
+      },
+      hueRotate: {
+        slider: 'hueRotateSlider',
+        val: 'hueRotateVal',
+        code: 'hueRotateCode',
+        preview: 'previewHueRotate',
+        getFilter: (v) => `hue-rotate(${v}deg)`
+      },
+      invert: {
+        slider: 'invertSlider',
+        val: 'invertVal',
+        code: 'invertCode',
+        preview: 'previewInvert',
+        getFilter: (v) => `invert(${v}%)`
+      },
+      opacity: {
+        slider: 'opacitySlider',
+        val: 'opacityVal',
+        code: 'opacityCode',
+        preview: 'previewOpacity',
+        getFilter: (v) => `opacity(${v}%)`
+      },
+      saturate: {
+        slider: 'saturateSlider',
+        val: 'saturateVal',
+        code: 'saturateCode',
+        preview: 'previewSaturate',
+        getFilter: (v) => `saturate(${v}%)`
+      },
+      sepia: {
+        slider: 'sepiaSlider',
+        val: 'sepiaVal',
+        code: 'sepiaCode',
+        preview: 'previewSepia',
+        getFilter: (v) => `sepia(${v}%)`
+      }
+    };
+
+    // Initialize filter controls
+    Object.entries(filterConfigs).forEach(([key, config]) => {
+      const slider = document.getElementById(config.slider);
+      const valEl = document.getElementById(config.val);
+      const codeEl = document.getElementById(config.code);
+      const preview = document.getElementById(config.preview);
+
+      if (slider && valEl && codeEl && preview) {
+        slider.addEventListener('input', () => {
+          const value = slider.value;
+          valEl.textContent = key === 'blur' ? `${value}px` : `${value}%`;
+          codeEl.textContent = key === 'blur' ? `${value}px` : `${value}%`;
+          preview.style.filter = config.getFilter(value);
+        });
+      }
+    });
+
+    // Drop-shadow special handling
+    const shadowX = document.getElementById('shadowXSlider');
+    const shadowY = document.getElementById('shadowYSlider');
+    const shadowBlur = document.getElementById('shadowBlurSlider');
+    const shadowColor = document.getElementById('shadowColor');
+    const shadowXVal = document.getElementById('shadowXVal');
+    const shadowYVal = document.getElementById('shadowYVal');
+    const shadowBlurVal = document.getElementById('shadowBlurVal');
+    const shadowCode = document.getElementById('shadowCode');
+    const previewShadow = document.getElementById('previewDropShadow');
+
+    function updateShadow() {
+      const x = shadowX.value;
+      const y = shadowY.value;
+      const blur = shadowBlur.value;
+      const color = shadowColor.value;
+      const alpha = 0.4;
+
+      shadowXVal.textContent = `${x}px`;
+      shadowYVal.textContent = `${y}px`;
+      shadowBlurVal.textContent = `${blur}px`;
+
+      const rgba = color.replace('#', '').match(/.{2}/g).map(c => parseInt(c, 16)).join(', ');
+      shadowCode.textContent = `${x}px ${y}px ${blur}px rgba(${rgba}, ${alpha})`;
+      previewShadow.style.filter = `drop-shadow(${x}px ${y}px ${blur}px rgba(${rgba}, ${alpha}))`;
+    }
+
+    [shadowX, shadowY, shadowBlur, shadowColor].forEach(el => {
+      if (el) el.addEventListener('input', updateShadow);
+    });
+
+    // Preset buttons
+    document.querySelectorAll('.preset-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const filter = btn.dataset.filter;
+        const tab = btn.closest('.tab-content');
+        if (tab) {
+          const preview = tab.querySelector('.preview-box');
+          if (preview) {
+            preview.style.filter = filter;
+
+            // Update code display
+            const codeEl = tab.querySelector('.code-output .code-value');
+            if (codeEl) {
+              codeEl.textContent = filter.match(/\(([^)]+)\)/)?.[1] || filter;
+            }
+
+            // Update slider if applicable
+            const match = filter.match(/\(([^)]+)\)/)?.[1];
+            if (match) {
+              const sliderId = Object.entries(filterConfigs).find(([key, config]) => filter.startsWith(key))[1]?.slider;
+              if (sliderId) {
+                const slider = document.getElementById(sliderId);
+                if (slider) {
+                  slider.value = parseFloat(match);
+                  slider.dispatchEvent(new Event('input'));
+                }
+              }
+            }
+          }
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/css-font-display/index.html
+++ b/examples/css/demos/css-font-display/index.html
@@ -1,0 +1,483 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>font-display 字体显示策略演示</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f5f5f5;
+    }
+
+    h1 {
+      text-align: center;
+      color: #333;
+    }
+
+    .demo-section {
+      background: white;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .demo-section h2 {
+      margin-top: 0;
+      color: #2563eb;
+      font-size: 1.2em;
+    }
+
+    /* 字体卡片样式 */
+    .font-card {
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 15px;
+      background: #fafafa;
+    }
+
+    .font-card h3 {
+      margin: 0 0 10px 0;
+      color: #1f2937;
+      font-size: 1rem;
+    }
+
+    .font-display-value {
+      display: inline-block;
+      padding: 4px 12px;
+      background: #dbeafe;
+      color: #1e40af;
+      border-radius: 4px;
+      font-size: 0.85em;
+      font-family: monospace;
+      margin-bottom: 15px;
+    }
+
+    .font-sample {
+      font-size: 24px;
+      padding: 15px;
+      background: white;
+      border-radius: 6px;
+      border: 1px solid #e5e7eb;
+      min-height: 80px;
+      display: flex;
+      align-items: center;
+    }
+
+    .font-description {
+      margin-top: 10px;
+      font-size: 0.9em;
+      color: #6b7280;
+    }
+
+    pre {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 15px;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.9em;
+      margin-top: 15px;
+    }
+
+    code {
+      font-family: "Fira Code", Consolas, monospace;
+    }
+
+    .info-box {
+      background: #eff6ff;
+      border: 1px solid #bfdbfe;
+      border-radius: 6px;
+      padding: 15px;
+      margin-bottom: 20px;
+    }
+
+    .info-box strong {
+      color: #1e40af;
+    }
+
+    /* 自定义字体加载 */
+    @font-face {
+      font-family: 'CustomFont';
+      src: url('https://fonts.gstatic.com/s/roboto/v30/Roboto-Light.woff2') format('woff2');
+      font-weight: 300;
+      font-display: swap;
+    }
+
+    @font-face {
+      font-family: 'CustomFontOptional';
+      src: url('https://fonts.gstatic.com/s/roboto/v30/Roboto-Light.woff2') format('woff2');
+      font-weight: 300;
+      font-display: optional;
+    }
+
+    @font-face {
+      font-family: 'CustomFontBlock';
+      src: url('https://fonts.gstatic.com/s/roboto/v30/Roboto-Light.woff2') format('woff2');
+      font-weight: 300;
+      font-display: block;
+    }
+
+    @font-face {
+      font-family: 'CustomFontAuto';
+      src: url('https://fonts.gstatic.com/s/roboto/v30/Roboto-Light.woff2') format('woff2');
+      font-weight: 300;
+      font-display: auto;
+    }
+
+    .font-swap {
+      font-family: 'CustomFont', sans-serif;
+    }
+
+    .font-optional {
+      font-family: 'CustomFontOptional', sans-serif;
+    }
+
+    .font-block {
+      font-family: 'CustomFontBlock', sans-serif;
+    }
+
+    .font-auto {
+      font-family: 'CustomFontAuto', sans-serif;
+    }
+
+    /* 模拟加载状态 */
+    .loading-indicator {
+      display: inline-block;
+      width: 12px;
+      height: 12px;
+      border: 2px solid #e5e7eb;
+      border-top-color: #2563eb;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+      margin-right: 8px;
+      vertical-align: middle;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    .font-card.loading .font-sample {
+      position: relative;
+    }
+
+    .font-card.loading .font-sample::after {
+      content: '字体加载中...';
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      background: #fef3c7;
+      padding: 5px 10px;
+      border-radius: 4px;
+      font-size: 14px;
+      color: #92400e;
+    }
+
+    /* 表格样式 */
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 15px;
+    }
+
+    th, td {
+      border: 1px solid #e5e7eb;
+      padding: 12px;
+      text-align: left;
+    }
+
+    th {
+      background: #f9fafb;
+      font-weight: 600;
+    }
+
+    .behavior-tag {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 0.85em;
+    }
+
+    .behavior-foit { background: #fee2e2; color: #991b1b; }
+    .behavior-fout { background: #d1fae5; color: #065f46; }
+    .behavior-hidden { background: #e0e7ff; color: #3730a3; }
+
+    /* 控制面板 */
+    .control-panel {
+      background: #1f2937;
+      color: #f9fafb;
+      padding: 20px;
+      border-radius: 8px;
+      margin-bottom: 20px;
+    }
+
+    .control-panel h3 {
+      margin-top: 0;
+      color: #60a5fa;
+    }
+
+    .control-row {
+      display: flex;
+      align-items: center;
+      margin-bottom: 15px;
+    }
+
+    .control-row label {
+      width: 120px;
+      font-size: 0.9em;
+    }
+
+    .control-row input[type="range"] {
+      flex: 1;
+      margin: 0 15px;
+    }
+
+    .control-row span {
+      width: 60px;
+      text-align: right;
+      font-family: monospace;
+    }
+
+    /* 可变字体演示 */
+    .vf-container {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 20px;
+      margin-top: 15px;
+    }
+
+    .vf-card {
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 15px;
+      background: white;
+    }
+
+    .vf-card h4 {
+      margin: 0 0 10px 0;
+      color: #374151;
+      font-size: 0.95em;
+    }
+
+    .vf-sample {
+      font-size: 32px;
+      text-align: center;
+      padding: 20px;
+      background: #f9fafb;
+      border-radius: 6px;
+      margin-bottom: 10px;
+    }
+
+    .vf-value {
+      font-family: monospace;
+      font-size: 0.85em;
+      color: #6b7280;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+  <h1>font-display 字体显示策略演示</h1>
+
+  <div class="info-box">
+    <strong>💡 什么是 FOIT 和 FOUT？</strong>
+    <ul style="margin: 10px 0 0 0; padding-left: 20px;">
+      <li><strong>FOIT</strong> (Flash of Invisible Text)：字体加载期间文本不可见，可能造成闪烁</li>
+      <li><strong>FOUT</strong> (Flash of Unstyled Text)：先用后备字体显示，加载后切换到自定义字体</li>
+    </ul>
+  </div>
+
+  <div class="demo-section">
+    <h2>font-display 取值对比</h2>
+    <p>每种 <code>font-display</code> 策略在字体加载过程中的表现：</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>值</th>
+          <th>阻塞时间</th>
+          <th>后备字体</th>
+          <th>行为</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>auto</code></td>
+          <td>浏览器决定</td>
+          <td>由浏览器决定</td>
+          <td><span class="behavior-tag behavior-foit">FOIT</span></td>
+        </tr>
+        <tr>
+          <td><code>block</code></td>
+          <td>短暂（约 3s）</td>
+          <td>使用</td>
+          <td><span class="behavior-tag behavior-foit">FOIT → FOUT</span></td>
+        </tr>
+        <tr>
+          <td><code>swap</code></td>
+          <td>无</td>
+          <td>使用</td>
+          <td><span class="behavior-tag behavior-fout">FOUT</span></td>
+        </tr>
+        <tr>
+          <td><code>fallback</code></td>
+          <td>极短（约 0.1s）</td>
+          <td>使用</td>
+          <td><span class="behavior-tag behavior-foit">FOIT → 放弃</span></td>
+        </tr>
+        <tr>
+          <td><code>optional</code></td>
+          <td>无或极短</td>
+          <td>使用</td>
+          <td><span class="behavior-tag behavior-hidden">由浏览器决定</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="demo-section">
+    <h2>swap - 立即显示后备字体</h2>
+    <div class="font-card">
+      <div class="font-display-value">font-display: swap</div>
+      <p class="font-description">
+        <strong>特点：</strong>字体加载前立即显示后备字体，加载完成后立即切换。适合图标字体或重要文本。
+      </p>
+      <div class="font-sample font-swap">
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <pre><code>@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: swap;
+}</code></pre>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>optional - 优先使用缓存</h2>
+    <div class="font-card">
+      <div class="font-display-value">font-display: optional</div>
+      <p class="font-description">
+        <strong>特点：</strong>如果字体已在缓存中则使用，否则使用后备字体。适合正文文本，追求整体体验。
+      </p>
+      <div class="font-sample font-optional">
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <pre><code>@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: optional;
+}</code></pre>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>block - 短暂阻塞后显示后备字体</h2>
+    <div class="font-card">
+      <div class="font-display-value">font-display: block</div>
+      <p class="font-description">
+        <strong>特点：</strong>阻塞较短时间（约 3 秒）等待字体加载，超时后显示后备字体。
+      </p>
+      <div class="font-sample font-block">
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <pre><code>@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: block;
+}</code></pre>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>auto - 浏览器默认行为</h2>
+    <div class="font-card">
+      <div class="font-display-value">font-display: auto</div>
+      <p class="font-description">
+        <strong>特点：</strong>使用浏览器的默认字体加载策略，通常表现为 FOIT。
+      </p>
+      <div class="font-sample font-auto">
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <pre><code>@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: auto;
+}</code></pre>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>fallback - 快速超时</h2>
+    <div class="font-card">
+      <div class="font-display-value">font-display: fallback</div>
+      <p class="font-description">
+        <strong>特点：</strong>阻塞极短时间（约 100ms），超时后使用后备字体。如果字体未加载，下次访问时可能使用。
+      </p>
+      <pre><code>@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: fallback;
+}</code></pre>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>实际应用建议</h2>
+    <ul>
+      <li><strong>图标字体：</strong>使用 <code>swap</code> - 图标需要立即显示</li>
+      <li><strong>正文文本：</strong>使用 <code>optional</code> 或 <code>fallback</code> - 避免文字跳动影响阅读</li>
+      <li><strong>标题文字：</strong>使用 <code>swap</code> - 允许轻微跳动但保证及时显示</li>
+      <li><strong>不重要装饰：</strong>使用 <code>optional</code> - 只在网络条件好时加载</li>
+    </ul>
+  </div>
+
+  <div class="demo-section">
+    <h2>性能优化技巧</h2>
+    <pre><code>/* 1. 使用 font-display 的同时，结合预加载 */
+&lt;link rel="preload" href="font.woff2" as="font" type="font/woff2" crossorigin&gt;
+
+/* 2. 使用 woff2 格式，兼容性最好且压缩率高 */
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: swap;
+}
+
+/* 3. 为不同字符集定义不同字体 */
+@font-face {
+  font-family: 'MyFont';
+  src: url('latin.woff2') format('woff2');
+  unicode-range: U+0000-00FF;
+  font-display: swap;
+}</code></pre>
+  </div>
+
+  <script>
+    // 检测字体加载状态
+    document.fonts.ready.then(function() {
+      console.log('所有字体加载完成');
+    });
+
+    // 监听特定字体加载
+    const font = new FontFace('CustomFont', 'url(https://fonts.gstatic.com/s/roboto/v30/Roboto-Light.woff2) format("woff2")');
+    font.load().then(function(loadedFont) {
+      document.fonts.add(loadedFont);
+      console.log('CustomFont 加载成功');
+    }).catch(function(error) {
+      console.log('CustomFont 加载失败:', error);
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/css-font-variation-settings/index.html
+++ b/examples/css/demos/css-font-variation-settings/index.html
@@ -1,0 +1,662 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>font-variation-settings 可变字体演示</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f5f5f5;
+    }
+
+    h1 {
+      text-align: center;
+      color: #333;
+    }
+
+    .demo-section {
+      background: white;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .demo-section h2 {
+      margin-top: 0;
+      color: #2563eb;
+      font-size: 1.2em;
+    }
+
+    pre {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 15px;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.9em;
+    }
+
+    code {
+      font-family: "Fira Code", Consolas, monospace;
+    }
+
+    .info-box {
+      background: #eff6ff;
+      border: 1px solid #bfdbfe;
+      border-radius: 6px;
+      padding: 15px;
+      margin-bottom: 20px;
+    }
+
+    .info-box strong {
+      color: #1e40af;
+    }
+
+    /* 可变字体特性轴表格 */
+    .axis-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 15px;
+    }
+
+    .axis-table th, .axis-table td {
+      border: 1px solid #e5e7eb;
+      padding: 12px;
+      text-align: left;
+    }
+
+    .axis-table th {
+      background: #f9fafb;
+      font-weight: 600;
+    }
+
+    .axis-tag {
+      display: inline-block;
+      padding: 2px 8px;
+      background: #dbeafe;
+      color: #1e40af;
+      border-radius: 4px;
+      font-size: 0.85em;
+      font-family: monospace;
+    }
+
+    /* 可变字体演示卡片 */
+    .vf-demo-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      gap: 20px;
+      margin-top: 15px;
+    }
+
+    .vf-card {
+      border: 1px solid #e5e7eb;
+      border-radius: 8px;
+      padding: 20px;
+      background: white;
+    }
+
+    .vf-card h3 {
+      margin: 0 0 15px 0;
+      color: #1f2937;
+      font-size: 1em;
+    }
+
+    .vf-sample {
+      font-size: 48px;
+      text-align: center;
+      padding: 30px;
+      background: #f9fafb;
+      border-radius: 6px;
+      margin-bottom: 15px;
+      min-height: 120px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .vf-controls {
+      margin-top: 15px;
+    }
+
+    .vf-controls label {
+      display: block;
+      font-size: 0.85em;
+      color: #6b7280;
+      margin-bottom: 5px;
+    }
+
+    .vf-controls input[type="range"] {
+      width: 100%;
+    }
+
+    .vf-controls .value-display {
+      font-family: monospace;
+      font-size: 0.85em;
+      color: #2563eb;
+      margin-top: 5px;
+    }
+
+    /* 字重渐变演示 */
+    .weight-gradient {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+
+    .weight-item {
+      padding: 15px 20px;
+      background: white;
+      border-bottom: 1px solid #e5e7eb;
+    }
+
+    .weight-item:last-child {
+      border-bottom: none;
+    }
+
+    .weight-label {
+      font-size: 0.8em;
+      color: #6b7280;
+      margin-bottom: 5px;
+    }
+
+    /* 宽度渐变 */
+    .width-gradient {
+      display: flex;
+      gap: 10px;
+      align-items: flex-end;
+    }
+
+    .width-item {
+      flex: 1;
+      text-align: center;
+      padding: 20px 10px;
+      background: #f9fafb;
+      border-radius: 6px;
+    }
+
+    .width-item span {
+      display: block;
+      font-size: 0.75em;
+      color: #6b7280;
+      margin-top: 10px;
+    }
+
+    /* 斜体演示 */
+    .ital-demo {
+      display: flex;
+      gap: 20px;
+    }
+
+    .ital-item {
+      flex: 1;
+      padding: 20px;
+      background: #f9fafb;
+      border-radius: 6px;
+    }
+
+    .ital-item h4 {
+      margin: 0 0 10px 0;
+      color: #374151;
+      font-size: 0.9em;
+    }
+
+    /* 倾斜演示 */
+    .slnt-demo {
+      display: flex;
+      gap: 20px;
+      align-items: center;
+    }
+
+    .slnt-item {
+      flex: 1;
+      text-align: center;
+    }
+
+    .slnt-item span {
+      display: block;
+      font-size: 0.8em;
+      color: #6b7280;
+      margin-top: 8px;
+    }
+
+    /* 使用 Google Fonts 可变字体 */
+    @import url('https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,slnt,wdth,wght@8..144,-10..0,75..125,100..1000&display=swap');
+
+    .roboto-flex {
+      font-family: 'Roboto Flex', sans-serif;
+    }
+
+    /* 使用 Inter 可变字体（通过 CDN） */
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100..900&display=swap');
+
+    .inter-variable {
+      font-family: 'Inter', sans-serif;
+    }
+
+    /* 自定义可变字体示例 */
+    .custom-vf-sample {
+      font-family: 'Roboto Flex', sans-serif;
+    }
+
+    /* 交互式控制面板 */
+    .control-panel {
+      background: #1f2937;
+      color: #f9fafb;
+      padding: 20px;
+      border-radius: 8px;
+      margin-bottom: 20px;
+    }
+
+    .control-panel h3 {
+      margin-top: 0;
+      color: #60a5fa;
+    }
+
+    .slider-group {
+      margin-bottom: 20px;
+    }
+
+    .slider-group label {
+      display: block;
+      margin-bottom: 8px;
+      font-size: 0.9em;
+      color: #d1d5db;
+    }
+
+    .slider-row {
+      display: flex;
+      align-items: center;
+      gap: 15px;
+    }
+
+    .slider-row input[type="range"] {
+      flex: 1;
+    }
+
+    .slider-row .axis-name {
+      width: 50px;
+      font-family: monospace;
+      font-size: 0.85em;
+      color: #9ca3af;
+    }
+
+    .slider-row .axis-value {
+      width: 60px;
+      text-align: right;
+      font-family: monospace;
+      color: #60a5fa;
+    }
+
+    /* 预设按钮 */
+    .preset-buttons {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+      margin-top: 15px;
+    }
+
+    .preset-btn {
+      padding: 8px 16px;
+      background: #374151;
+      color: #f9fafb;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 0.85em;
+      transition: background 0.2s;
+    }
+
+    .preset-btn:hover {
+      background: #4b5563;
+    }
+
+    .preset-btn.active {
+      background: #2563eb;
+    }
+
+    /* 动画效果 */
+    @keyframes pulse {
+      0%, 100% { opacity: 1; }
+      50% { opacity: 0.6; }
+    }
+
+    .loading {
+      animation: pulse 1.5s ease-in-out infinite;
+    }
+  </style>
+</head>
+<body>
+  <h1>font-variation-settings 可变字体演示</h1>
+
+  <div class="info-box">
+    <strong>💡 什么是可变字体？</strong>
+    <p style="margin: 10px 0 0 0;">
+      可变字体（Variable Fonts）是 OpenType 字体规范的发展，它允许在单个字体文件中包含多个变体，
+      通过轴（axis）来控制字体的外观。相比传统字体，可变字体文件更小，功能更强大。
+    </p>
+  </div>
+
+  <div class="demo-section">
+    <h2>常用特性轴</h2>
+    <table class="axis-table">
+      <thead>
+        <tr>
+          <th>轴名</th>
+          <th>全称</th>
+          <th>说明</th>
+          <th>典型范围</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="axis-tag">wght</span></td>
+          <td>Weight</td>
+          <td>字重（粗细）</td>
+          <td>100 - 900</td>
+        </tr>
+        <tr>
+          <td><span class="axis-tag">wdth</span></td>
+          <td>Width</td>
+          <td>字宽（压缩/扩展）</td>
+          <td>75 - 125</td>
+        </tr>
+        <tr>
+          <td><span class="axis-tag">ital</span></td>
+          <td>Italic</td>
+          <td>斜体（0=正体，1=斜体）</td>
+          <td>0 - 1</td>
+        </tr>
+        <tr>
+          <td><span class="axis-tag">slnt</span></td>
+          <td>Slant</td>
+          <td>倾斜角度</td>
+          <td>-10 - 0</td>
+        </tr>
+        <tr>
+          <td><span class="axis-tag">opsz</span></td>
+          <td>Optical Size</td>
+          <td>光学尺寸（字号相关）</td>
+          <td>6 - 144</td>
+        </tr>
+        <tr>
+          <td><span class="axis-tag">GRAD</span></td>
+          <td>Grade</td>
+          <td>字重等级（不影响布局）</td>
+          <td>-50 - 150</td>
+        </tr>
+        <tr>
+          <td><span class="axis-tag">XTRA</span></td>
+          <td>Contrast</td>
+          <td>轮廓对比度</td>
+          <td>63 - 1000</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="demo-section">
+    <h2>字重轴 (wght) 演示</h2>
+    <p>使用 Roboto Flex 可变字体展示不同字重：</p>
+
+    <div class="weight-gradient roboto-flex">
+      <div class="weight-item" style="font-variation-settings: 'wght' 100;">
+        <div class="weight-label">100 - Thin (极细)</div>
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <div class="weight-item" style="font-variation-settings: 'wght' 300;">
+        <div class="weight-label">300 - Light (细体)</div>
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <div class="weight-item" style="font-variation-settings: 'wght' 400;">
+        <div class="weight-label">400 - Regular (常规)</div>
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <div class="weight-item" style="font-variation-settings: 'wght' 500;">
+        <div class="weight-label">500 - Medium (中等)</div>
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <div class="weight-item" style="font-variation-settings: 'wght' 700;">
+        <div class="weight-label">700 - Bold (粗体)</div>
+        The quick brown fox jumps over the lazy dog
+      </div>
+      <div class="weight-item" style="font-variation-settings: 'wght' 900;">
+        <div class="weight-label">900 - Black (黑体)</div>
+        The quick brown fox jumps over the lazy dog
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>宽度轴 (wdth) 演示</h2>
+    <p>同一个字体，不同宽度：</p>
+
+    <div class="width-gradient roboto-flex">
+      <div class="width-item" style="font-variation-settings: 'wght' 400, 'wdth' 75;">
+        <div style="font-size: 32px;">Aa</div>
+        <span>wdth: 75</span>
+      </div>
+      <div class="width-item" style="font-variation-settings: 'wght' 400, 'wdth' 87;">
+        <div style="font-size: 32px;">Aa</div>
+        <span>wdth: 87</span>
+      </div>
+      <div class="width-item" style="font-variation-settings: 'wght' 400, 'wdth' 100;">
+        <div style="font-size: 32px;">Aa</div>
+        <span>wdth: 100</span>
+      </div>
+      <div class="width-item" style="font-variation-settings: 'wght' 400, 'wdth' 112;">
+        <div style="font-size: 32px;">Aa</div>
+        <span>wdth: 112</span>
+      </div>
+      <div class="width-item" style="font-variation-settings: 'wght' 400, 'wdth' 125;">
+        <div style="font-size: 32px;">Aa</div>
+        <span>wdth: 125</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>倾斜轴 (slnt) 演示</h2>
+
+    <div class="slnt-demo roboto-flex">
+      <div class="slnt-item">
+        <div class="vf-sample" style="font-variation-settings: 'slnt' 0; font-size: 36px;">
+          Normal
+        </div>
+        <span>slnt: 0</span>
+      </div>
+      <div class="slnt-item">
+        <div class="vf-sample" style="font-variation-settings: 'slnt' -6; font-size: 36px;">
+          Slanted
+        </div>
+        <span>slnt: -6</span>
+      </div>
+      <div class="slnt-item">
+        <div class="vf-sample" style="font-variation-settings: 'slnt' -12; font-size: 36px;">
+          More Slant
+        </div>
+        <span>slnt: -12</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>交互式演示</h2>
+    <p>拖动滑块实时调整可变字体的各个轴：</p>
+
+    <div class="control-panel">
+      <h3>Roboto Flex 可变字体控制</h3>
+
+      <div class="slider-group">
+        <label>字重 (wght): <span id="wghtValue">400</span></label>
+        <div class="slider-row">
+          <span class="axis-name">wght</span>
+          <input type="range" id="wghtSlider" min="100" max="900" value="400" step="1">
+          <span class="axis-value" id="wghtDisplay">400</span>
+        </div>
+      </div>
+
+      <div class="slider-group">
+        <label>字宽 (wdth): <span id="wdthValue">100</span></label>
+        <div class="slider-row">
+          <span class="axis-name">wdth</span>
+          <input type="range" id="wdthSlider" min="75" max="125" value="100" step="1">
+          <span class="axis-value" id="wdthDisplay">100</span>
+        </div>
+      </div>
+
+      <div class="slider-group">
+        <label>倾斜 (slnt): <span id="slntValue">0</span></label>
+        <div class="slider-row">
+          <span class="axis-name">slnt</span>
+          <input type="range" id="slntSlider" min="-10" max="0" value="0" step="0.5">
+          <span class="axis-value" id="slntDisplay">0</span>
+        </div>
+      </div>
+
+      <div class="slider-group">
+        <label>光学尺寸 (opsz): <span id="opszValue">14</span></label>
+        <div class="slider-row">
+          <span class="axis-name">opsz</span>
+          <input type="range" id="opszSlider" min="6" max="144" value="14" step="1">
+          <span class="axis-value" id="opszDisplay">14</span>
+        </div>
+      </div>
+
+      <div class="preset-buttons">
+        <button class="preset-btn" data-wght="100" data-wdth="100" data-slnt="0" data-opsz="14">Thin</button>
+        <button class="preset-btn" data-wght="300" data-wdth="100" data-slnt="0" data-opsz="14">Light</button>
+        <button class="preset-btn" data-wght="400" data-wdth="100" data-slnt="0" data-opsz="14">Regular</button>
+        <button class="preset-btn" data-wght="700" data-wdth="100" data-slnt="0" data-opsz="14">Bold</button>
+        <button class="preset-btn" data-wght="900" data-wdth="100" data-slnt="0" data-opsz="14">Black</button>
+        <button class="preset-btn" data-wght="400" data-wdth="75" data-slnt="0" data-opsz="14">Condensed</button>
+        <button class="preset-btn" data-wght="400" data-wdth="125" data-slnt="0" data-opsz="14">Expanded</button>
+      </div>
+    </div>
+
+    <div class="vf-card" style="margin-top: 20px;">
+      <div class="vf-sample roboto-flex" id="vfSample">
+        可变字体
+      </div>
+      <p style="font-family: monospace; font-size: 0.85em; color: #6b7280; margin-top: 10px;" id="vfSettings">
+        font-variation-settings: 'wght' 400, 'wdth' 100, 'slnt' 0, 'opsz' 14
+      </p>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>CSS 语法</h2>
+    <pre><code>/* 基本语法 */
+.element {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 400;
+}
+
+/* 多个轴同时设置 */
+.heading {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 700, 'wdth' 100;
+  font-size: 48px;
+}
+
+/* 与普通字体属性配合使用 */
+.text {
+  font-family: 'Roboto Flex', sans-serif;
+  font-weight: 500;        /* 标准属性 */
+  font-variation-settings: 'wght' 500, 'wdth' 95;  /* 可变字体轴 */
+}</code></pre>
+  </div>
+
+  <div class="demo-section">
+    <h2>注意事项</h2>
+    <ul>
+      <li><strong>兼容性：</strong>现代浏览器都支持可变字体，但需要使用支持可变字体的字体文件</li>
+      <li><strong>性能：</strong>使用 <code>font-display: optional</code> 可在网络不佳时跳过字体加载</li>
+      <li><strong>回退：</strong>为不支持可变字体的浏览器提供 fallback 字体</li>
+      <li><strong>Google Fonts：</strong>Google Fonts 上的可变字体 URL 包含完整的轴范围</li>
+    </ul>
+  </div>
+
+  <div class="demo-section">
+    <h2>常用可变字体推荐</h2>
+    <ul>
+      <li><strong>Roboto Flex</strong> - Google Fonts，支持 wght, wdth, slnt, opsz</li>
+      <li><strong>Inter</strong> - Google Fonts，支持 wght</li>
+      <li><strong>Recursive</strong> - Google Fonts，支持 wght, slnt, MONO, CASL, CRSV</li>
+      <li><strong>Source Sans 3</strong> - Google Fonts，支持 wght, wdth, ital, slnt, SOFT, ZERO</li>
+      <li><strong>Amstelvar</strong> - Google Fonts，支持 wght, opsz, XTRA, YOPQ 等</li>
+    </ul>
+  </div>
+
+  <script>
+    const wghtSlider = document.getElementById('wghtSlider');
+    const wdthSlider = document.getElementById('wdthSlider');
+    const slntSlider = document.getElementById('slntSlider');
+    const opszSlider = document.getElementById('opszSlider');
+
+    const wghtValue = document.getElementById('wghtValue');
+    const wdthValue = document.getElementById('wdthValue');
+    const slntValue = document.getElementById('slntValue');
+    const opszValue = document.getElementById('opszValue');
+
+    const wghtDisplay = document.getElementById('wghtDisplay');
+    const wdthDisplay = document.getElementById('wdthDisplay');
+    const slntDisplay = document.getElementById('slntDisplay');
+    const opszDisplay = document.getElementById('opszDisplay');
+
+    const vfSample = document.getElementById('vfSample');
+    const vfSettings = document.getElementById('vfSettings');
+
+    function updateFontVariation() {
+      const wght = wghtSlider.value;
+      const wdth = wdthSlider.value;
+      const slnt = slntSlider.value;
+      const opsz = opszSlider.value;
+
+      wghtValue.textContent = wght;
+      wdthValue.textContent = wdth;
+      slntValue.textContent = slnt;
+      opszValue.textContent = opsz;
+
+      wghtDisplay.textContent = wght;
+      wdthDisplay.textContent = wdth;
+      slntDisplay.textContent = slnt;
+      opszDisplay.textContent = opsz;
+
+      const settings = `'wght' ${wght}, 'wdth' ${wdth}, 'slnt' ${slnt}, 'opsz' ${opsz}`;
+      vfSample.style.fontVariationSettings = settings;
+      vfSettings.textContent = `font-variation-settings: ${settings}`;
+    }
+
+    wghtSlider.addEventListener('input', updateFontVariation);
+    wdthSlider.addEventListener('input', updateFontVariation);
+    slntSlider.addEventListener('input', updateFontVariation);
+    opszSlider.addEventListener('input', updateFontVariation);
+
+    // 预设按钮
+    document.querySelectorAll('.preset-btn').forEach(btn => {
+      btn.addEventListener('click', function() {
+        wghtSlider.value = this.dataset.wght;
+        wdthSlider.value = this.dataset.wdth;
+        slntSlider.value = this.dataset.slnt;
+        opszSlider.value = this.dataset.opsz;
+        updateFontVariation();
+
+        document.querySelectorAll('.preset-btn').forEach(b => b.classList.remove('active'));
+        this.classList.add('active');
+      });
+    });
+
+    // 初始化
+    updateFontVariation();
+  </script>
+</body>
+</html>

--- a/examples/css/demos/css-mix-blend-mode/image-overlay.html
+++ b/examples/css/demos/css-mix-blend-mode/image-overlay.html
@@ -1,0 +1,342 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>图片叠加混合 - mix-blend-mode 演示</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f8fafc;
+    }
+
+    h1 {
+      text-align: center;
+      color: #1e293b;
+      margin-bottom: 24px;
+    }
+
+    .demo-section {
+      background: white;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 24px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    }
+
+    .demo-section h2 {
+      margin-top: 0;
+      color: #2563eb;
+      font-size: 1.2em;
+    }
+
+    /* 图片叠加容器 */
+    .image-blend-container {
+      position: relative;
+      width: 100%;
+      height: 300px;
+      border-radius: 12px;
+      overflow: hidden;
+      background: #1e1e1e;
+      margin-bottom: 16px;
+    }
+
+    .image-blend-container img {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .image-blend-container img:first-child {
+      /* 底层图片 */
+    }
+
+    .image-blend-container img:last-child {
+      width: 50%;
+      height: 50%;
+      top: 25%;
+      left: 25%;
+      mix-blend-mode: multiply;
+    }
+
+    .blend-multiply img:last-child { mix-blend-mode: multiply; }
+    .blend-screen img:last-child { mix-blend-mode: screen; }
+    .blend-overlay img:last-child { mix-blend-mode: overlay; }
+    .blend-difference img:last-child { mix-blend-mode: difference; }
+    .blend-color img:last-child { mix-blend-mode: color; }
+
+    /* 双图叠加对比 */
+    .compare-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 16px;
+      margin-top: 16px;
+    }
+
+    .compare-item {
+      position: relative;
+      border-radius: 8px;
+      overflow: hidden;
+      height: 200px;
+    }
+
+    .compare-item img {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .compare-item .overlay-img {
+      width: 60%;
+      height: 60%;
+      top: 20%;
+      left: 20%;
+    }
+
+    .compare-label {
+      position: absolute;
+      bottom: 8px;
+      left: 8px;
+      background: rgba(0,0,0,0.7);
+      color: white;
+      padding: 4px 10px;
+      border-radius: 4px;
+      font-size: 12px;
+      font-family: monospace;
+      z-index: 10;
+    }
+
+    /* 色彩叠加层 */
+    .color-overlay-demo {
+      position: relative;
+      height: 250px;
+      border-radius: 12px;
+      overflow: hidden;
+      margin-bottom: 16px;
+    }
+
+    .color-overlay-demo img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+
+    .color-overlay-demo .color-layer {
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, rgba(102, 126, 234, 0.6) 0%, rgba(118, 75, 162, 0.6) 100%);
+    }
+
+    .color-overlay-demo .text {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 48px;
+      font-weight: 900;
+      color: white;
+      mix-blend-mode: overlay;
+    }
+
+    /* 网格效果 */
+    .grid-blend-demo {
+      position: relative;
+      height: 250px;
+      border-radius: 12px;
+      overflow: hidden;
+      background: url('https://picsum.photos/seed/gridbase/600/400') center/cover;
+      margin-bottom: 16px;
+    }
+
+    .grid-blend-demo .grid-overlay {
+      position: absolute;
+      inset: 0;
+      background-image:
+        linear-gradient(rgba(255,255,255,0.3) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.3) 1px, transparent 1px);
+      background-size: 30px 30px;
+    }
+
+    .grid-blend-demo .grid-overlay.blend {
+      mix-blend-mode: multiply;
+    }
+
+    /* 选择器 */
+    .mode-selector {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      margin-bottom: 16px;
+    }
+
+    .mode-btn {
+      padding: 8px 16px;
+      border: 2px solid #e5e7eb;
+      background: white;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 14px;
+      font-family: monospace;
+      transition: all 0.2s;
+    }
+
+    .mode-btn:hover {
+      border-color: #667eea;
+      background: #eff6ff;
+    }
+
+    .mode-btn.active {
+      border-color: #667eea;
+      background: #667eea;
+      color: white;
+    }
+
+    pre {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 16px;
+      border-radius: 8px;
+      overflow-x: auto;
+      font-size: 0.9em;
+    }
+
+    code {
+      font-family: "Fira Code", Consolas, monospace;
+    }
+
+    .code-comment { color: #6a9955; }
+    .code-prop { color: #9cdcfe; }
+    .code-value { color: #ce9178; }
+  </style>
+</head>
+<body>
+  <h1>🖼️ 图片叠加混合模式</h1>
+
+  <div class="demo-section">
+    <h2>两张图片叠加对比</h2>
+    <p>底层图片 + 上层图片（半透明），不同混合模式产生不同效果：</p>
+
+    <div class="mode-selector">
+      <button class="mode-btn active" onclick="setBlendMode('normal')">normal</button>
+      <button class="mode-btn" onclick="setBlendMode('multiply')">multiply</button>
+      <button class="mode-btn" onclick="setBlendMode('screen')">screen</button>
+      <button class="mode-btn" onclick="setBlendMode('overlay')">overlay</button>
+      <button class="mode-btn" onclick="setBlendMode('difference')">difference</button>
+    </div>
+
+    <div class="image-blend-container" id="blendDemo">
+      <img src="https://picsum.photos/seed/blendbase/600/400" alt="底层图片">
+      <img src="https://picsum.photos/seed/blendoverlay/600/400" alt="叠加层" class="overlay-img">
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>快速对比：不同混合模式</h2>
+    <div class="compare-grid">
+      <div class="compare-item blend-multiply">
+        <img src="https://picsum.photos/seed/blendbase2/400/300" alt="背景">
+        <img src="https://picsum.photos/seed/blendoverlay2/400/300" alt="叠加" class="overlay-img">
+        <span class="compare-label">multiply</span>
+      </div>
+      <div class="compare-item blend-screen">
+        <img src="https://picsum.photos/seed/blendbase2/400/300" alt="背景">
+        <img src="https://picsum.photos/seed/blendoverlay2/400/300" alt="叠加" class="overlay-img">
+        <span class="compare-label">screen</span>
+      </div>
+      <div class="compare-item blend-overlay">
+        <img src="https://picsum.photos/seed/blendbase2/400/300" alt="背景">
+        <img src="https://picsum.photos/seed/blendoverlay2/400/300" alt="叠加" class="overlay-img">
+        <span class="compare-label">overlay</span>
+      </div>
+      <div class="compare-item blend-difference">
+        <img src="https://picsum.photos/seed/blendbase2/400/300" alt="背景">
+        <img src="https://picsum.photos/seed/blendoverlay2/400/300" alt="叠加" class="overlay-img">
+        <span class="compare-label">difference</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>彩色叠加层 + 文字</h2>
+    <p>图片 + 半透明渐变 + 文字，多层叠加：</p>
+
+    <div class="color-overlay-demo">
+      <img src="https://picsum.photos/seed/colormix/800/400" alt="背景图片">
+      <div class="color-layer"></div>
+      <div class="text">COLOR BLEND</div>
+    </div>
+    <pre><code><span class="code-comment">/* 图片 + 彩色叠加层 + 文字混合 */</span>
+<span class="code-prop">.color-overlay-demo</span> {
+  <span class="code-prop">position</span>: <span class="code-value">relative</span>;
+  <span class="code-prop">height</span>: <span class="code-value">250px</span>;
+}
+
+<span class="code-prop">.color-overlay-demo img</span> {
+  <span class="code-prop">width</span>: <span class="code-value">100%</span>;
+  <span class="code-prop">height</span>: <span class="code-value">100%</span>;
+  <span class="code-prop">object-fit</span>: <span class="code-value">cover</span>;
+}
+
+<span class="code-prop">.color-layer</span> {
+  <span class="code-prop">position</span>: <span class="code-value">absolute</span>;
+  <span class="code-prop">inset</span>: <span class="code-value">0</span>;
+  <span class="code-prop">background</span>: <span class="code-value">linear-gradient(135deg,
+    rgba(102, 126, 234, 0.6),
+    rgba(118, 75, 162, 0.6))</span>;
+}
+
+<span class="code-prop">.text</span> {
+  <span class="code-prop">position</span>: <span class="code-value">absolute</span>;
+  <span class="code-prop">inset</span>: <span class="code-value">0</span>;
+  <span class="code-prop">display</span>: <span class="code-value">flex</span>;
+  <span class="code-prop">align-items</span>: <span class="code-value">center</span>;
+  <span class="code-prop">justify-content</span>: <span class="code-value">center</span>;
+  <span class="code-prop">font-size</span>: <span class="code-value">48px</span>;
+  <span class="code-prop">font-weight</span>: <span class="code-value">900</span>;
+  <span class="code-prop">color</span>: <span class="code-value">white</span>;
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">overlay</span>;
+}</code></pre>
+  </div>
+
+  <div class="demo-section">
+    <h2>网格叠加效果</h2>
+    <p>图片上叠加网格线，使用 multiply 混合让网格融入图片：</p>
+
+    <div class="grid-blend-demo">
+      <div class="grid-overlay blend"></div>
+    </div>
+    <pre><code><span class="code-comment">/* 网格叠加 - 使用 multiply 让网格融入图片 */</span>
+<span class="code-prop">.grid-overlay</span> {
+  <span class="code-prop">position</span>: <span class="code-value">absolute</span>;
+  <span class="code-prop">inset</span>: <span class="code-value">0</span>;
+  <span class="code-prop">background-image</span>:
+    <span class="code-value">linear-gradient(rgba(255,255,255,0.3) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.3) 1px, transparent 1px)</span>;
+  <span class="code-prop">background-size</span>: <span class="code-value">30px 30px</span>;
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">multiply</span>; <span class="code-comment">/* 白色网格融入图片 */</span>
+}</code></pre>
+  </div>
+
+  <script>
+    const demo = document.getElementById('blendDemo');
+    const buttons = document.querySelectorAll('.mode-btn');
+    const overlay = demo.querySelector('.overlay-img');
+
+    function setBlendMode(mode) {
+      overlay.style.mixBlendMode = mode;
+      buttons.forEach(btn => btn.classList.remove('active'));
+      event.target.classList.add('active');
+    }
+  </script>
+</body>
+</html>

--- a/examples/css/demos/css-mix-blend-mode/index.html
+++ b/examples/css/demos/css-mix-blend-mode/index.html
@@ -1,0 +1,331 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>mix-blend-mode 混合模式演示</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f8fafc;
+    }
+
+    h1 {
+      text-align: center;
+      color: #1e293b;
+      margin-bottom: 30px;
+    }
+
+    .info-box {
+      background: #eff6ff;
+      border: 1px solid #bfdbfe;
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 24px;
+    }
+
+    .info-box strong {
+      color: #1e40af;
+    }
+
+    .demo-section {
+      background: white;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 24px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    }
+
+    .demo-section h2 {
+      margin-top: 0;
+      color: #2563eb;
+      font-size: 1.3em;
+    }
+
+    .demo-section p {
+      color: #64748b;
+      line-height: 1.6;
+    }
+
+    /* 混合模式网格 */
+    .blend-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 16px;
+      margin-top: 16px;
+    }
+
+    .blend-item {
+      position: relative;
+      height: 120px;
+      border-radius: 8px;
+      overflow: hidden;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    }
+
+    .blend-item .overlay {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 14px;
+      font-weight: bold;
+      color: white;
+      text-shadow: 0 1px 3px rgba(0,0,0,0.3);
+    }
+
+    .blend-item .mode-label {
+      position: absolute;
+      bottom: 6px;
+      right: 8px;
+      font-size: 11px;
+      font-family: monospace;
+      color: rgba(255,255,255,0.8);
+      background: rgba(0,0,0,0.3);
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+
+    /* 各混合模式 */
+    .blend-normal { mix-blend-mode: normal; }
+    .blend-multiply { mix-blend-mode: multiply; background: #ff6b6b; }
+    .blend-screen { mix-blend-mode: screen; background: #4ecdc4; }
+    .blend-overlay { mix-blend-mode: overlay; background: #ffe66d; }
+    .blend-darken { mix-blend-mode: darken; background: linear-gradient(45deg, #667eea 50%, #764ba2 50%); }
+    .blend-lighten { mix-blend-mode: lighten; background: linear-gradient(45deg, #667eea 50%, #764ba2 50%); }
+    .blend-color-dodge { mix-blend-mode: color-dodge; background: #ff6b6b; }
+    .blend-color-burn { mix-blend-mode: color-burn; background: #ff6b6b; }
+    .blend-difference { mix-blend-mode: difference; background: #4ecdc4; }
+    .blend-exclusion { mix-blend-mode: exclusion; background: #4ecdc4; }
+    .blend-hue { mix-blend-mode: hue; background: #ff6b6b; }
+    .blend-saturation { mix-blend-mode: saturation; background: #ff6b6b; }
+    .blend-color { mix-blend-mode: color; background: #4ecdc4; }
+    .blend-luminosity { mix-blend-mode: luminosity; background: #ff6b6b; }
+
+    /* 代码块 */
+    pre {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 16px;
+      border-radius: 8px;
+      overflow-x: auto;
+      font-size: 0.9em;
+      margin-top: 16px;
+    }
+
+    code {
+      font-family: "Fira Code", Consolas, monospace;
+    }
+
+    .code-comment { color: #6a9955; }
+    .code-prop { color: #9cdcfe; }
+    .code-value { color: #ce9178; }
+
+    /* 对比表格 */
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 16px;
+    }
+
+    th, td {
+      border: 1px solid #e5e7eb;
+      padding: 12px;
+      text-align: left;
+    }
+
+    th {
+      background: #f9fafb;
+      font-weight: 600;
+    }
+
+    th:first-child, td:first-child {
+      font-family: monospace;
+      color: #7c3aed;
+    }
+  </style>
+</head>
+<body>
+  <h1>🎨 mix-blend-mode 混合模式演示</h1>
+
+  <div class="info-box">
+    <strong>💡 什么是混合模式？</strong>
+    <p style="margin: 8px 0 0 0;">
+      混合模式控制两个图层叠加时的视觉效果。当元素放在其它内容之上时，
+      通过设置不同的混合模式，可以创造出丰富的视觉效果，如同 Photoshop 中的图层混合。
+    </p>
+  </div>
+
+  <div class="demo-section">
+    <h2>所有混合模式一览</h2>
+    <p>下方展示所有可用的混合模式效果。白色文字叠加在不同颜色背景上，产生不同的视觉效果。</p>
+
+    <div class="blend-grid">
+      <div class="blend-item blend-normal">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">normal</span>
+      </div>
+      <div class="blend-item blend-multiply">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">multiply</span>
+      </div>
+      <div class="blend-item blend-screen">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">screen</span>
+      </div>
+      <div class="blend-item blend-overlay">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">overlay</span>
+      </div>
+      <div class="blend-item blend-darken">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">darken</span>
+      </div>
+      <div class="blend-item blend-lighten">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">lighten</span>
+      </div>
+      <div class="blend-item blend-color-dodge">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">color-dodge</span>
+      </div>
+      <div class="blend-item blend-color-burn">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">color-burn</span>
+      </div>
+      <div class="blend-item blend-difference">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">difference</span>
+      </div>
+      <div class="blend-item blend-exclusion">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">exclusion</span>
+      </div>
+      <div class="blend-item blend-hue">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">hue</span>
+      </div>
+      <div class="blend-item blend-saturation">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">saturation</span>
+      </div>
+      <div class="blend-item blend-color">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">color</span>
+      </div>
+      <div class="blend-item blend-luminosity">
+        <div class="overlay">Hello</div>
+        <span class="mode-label">luminosity</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>混合模式原理对比</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>模式</th>
+          <th>原理</th>
+          <th>效果特点</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>multiply</td>
+          <td>前景 × 背景</td>
+          <td>黑色完全变黑，白色保持不变</td>
+        </tr>
+        <tr>
+          <td>screen</td>
+          <td>1 - (1-前景) × (1-背景)</td>
+          <td>与 multiply 相反，白色完全保留</td>
+        </tr>
+        <tr>
+          <td>overlay</td>
+          <td>根据背景交替使用 multiply/screen</td>
+          <td>暗部加深，亮部提亮</td>
+        </tr>
+        <tr>
+          <td>darken</td>
+          <td>取较暗的颜色</td>
+          <td>保留较暗的像素</td>
+        </tr>
+        <tr>
+          <td>lighten</td>
+          <td>取较亮的颜色</td>
+          <td>保留较亮的像素</td>
+        </tr>
+        <tr>
+          <td>difference</td>
+          <td>|前景 - 背景|</td>
+          <td>高对比度，产生负片效果</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="demo-section">
+    <h2>核心代码示例</h2>
+    <pre><code><span class="code-comment">/* 基础用法：文字与背景混合 */</span>
+<span class="code-prop">.text-blend</span> {
+  <span class="code-prop">position</span>: relative;
+  <span class="code-prop">background</span>: linear-gradient(135deg, <span class="code-value">#667eea</span>, <span class="code-value">#764ba2</span>);
+}
+
+<span class="code-prop">.text-blend h1</span> {
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">multiply</span>; <span class="code-comment">/* 文字与背景混合 */</span>
+  <span class="code-prop">color</span>: white;
+}
+
+<span class="code-comment">/* 与 background-blend-mode 的区别 */</span>
+<span class="code-prop">.bg-blend</span> {
+  <span class="code-prop">background-image</span>: url(<span class="code-value">'image.jpg'</span>);
+  <span class="code-prop">background-blend-mode</span>: <span class="code-value">multiply</span>; <span class="code-comment">/* 仅背景图片之间混合 */</span>
+}
+
+<span class="code-prop">.content-blend</span> {
+  <span class="code-prop">background-image</span>: url(<span class="code-value">'image.jpg'</span>);
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">multiply</span>; <span class="code-comment">/* 包括文字在内整体混合 */</span>
+}
+
+<span class="code-comment">/* 使用 isolation 隔离混合效果 */</span>
+<span class="code-prop">.container</span> {
+  <span class="code-prop">isolation</span>: <span class="code-value">isolate</span>; <span class="code-comment">/* 混合只在容器内生效 */</span>
+}</code></pre>
+  </div>
+
+  <div class="demo-section">
+    <h2>混用 vs 隔离：isolation 的作用</h2>
+    <p>
+      <strong>不隔离：</strong>混合效果会传播到父元素外部<br>
+      <strong>隔离（isolation: isolate）：</strong>混合效果只在当前容器内生效
+    </p>
+    <pre><code><span class="code-comment">/* 不隔离：.inner 的混合会影响整个页面背景 */</span>
+<span class="code-prop">.outer</span> {
+  <span class="code-prop">background</span>: <span class="code-value">#764ba2</span>;
+}
+<span class="code-prop">.inner</span> {
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">multiply</span>;
+  <span class="code-prop">background</span>: <span class="code-value">#ff6b6b</span>;
+}
+
+<span class="code-comment">/* 隔离：混合只在 .group 内生效 */</span>
+<span class="code-prop">.group</span> {
+  <span class="code-prop">isolation</span>: <span class="code-value">isolate</span>;
+}</code></pre>
+  </div>
+
+  <div style="text-align: center; margin-top: 40px; color: #94a3b8;">
+    <p>更多演示请查看：text-blend.html | image-overlay.html | layer-blend.html</p>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-mix-blend-mode/layer-blend.html
+++ b/examples/css/demos/css-mix-blend-mode/layer-blend.html
@@ -1,0 +1,508 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>图层混合与隔离 - mix-blend-mode 演示</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f8fafc;
+  }
+
+    h1 {
+      text-align: center;
+      color: #1e293b;
+      margin-bottom: 24px;
+    }
+
+    .demo-section {
+      background: white;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 24px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    }
+
+    .demo-section h2 {
+      margin-top: 0;
+      color: #2563eb;
+      font-size: 1.2em;
+    }
+
+    .demo-section p {
+      color: #64748b;
+      line-height: 1.6;
+    }
+
+    /* 隔离效果演示 */
+    .isolation-demo {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 20px;
+      margin-top: 16px;
+    }
+
+    .isolation-demo .demo-box {
+      border-radius: 12px;
+      overflow: hidden;
+    }
+
+    .demo-box-header {
+      background: #f1f5f9;
+      padding: 12px 16px;
+      font-weight: 600;
+      color: #475569;
+      border-bottom: 1px solid #e2e8f0;
+    }
+
+    .demo-box-header .tag {
+      display: inline-block;
+      padding: 2px 8px;
+      border-radius: 4px;
+      font-size: 12px;
+      font-family: monospace;
+      margin-left: 8px;
+    }
+
+    .tag-yes {
+      background: #d1fae5;
+      color: #065f46;
+    }
+
+    .tag-no {
+      background: #fee2e2;
+      color: #991b1b;
+    }
+
+    .demo-content {
+      position: relative;
+      height: 200px;
+    }
+
+    .layer-bg {
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    }
+
+    .layer-1, .layer-2 {
+      position: absolute;
+      border-radius: 8px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: bold;
+      color: white;
+    }
+
+    .layer-1 {
+      width: 60%;
+      height: 60%;
+      top: 20%;
+      left: 10%;
+      background: #ff6b6b;
+      mix-blend-mode: multiply;
+    }
+
+    .layer-2 {
+      width: 60%;
+      height: 60%;
+      bottom: 20%;
+      right: 10%;
+      top: auto;
+      left: auto;
+      background: #4ecdc4;
+      mix-blend-mode: screen;
+    }
+
+    /* 页面背景影响演示 */
+    .page-bg-demo {
+      position: relative;
+      height: 150px;
+      background: #fbbf24;
+      border-radius: 12px;
+      margin-top: 16px;
+    }
+
+    .page-bg-demo .inner-box {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 200px;
+      height: 100px;
+      background: #ff6b6b;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: white;
+      font-weight: bold;
+      mix-blend-mode: multiply;
+    }
+
+    /* 多层混合组 */
+    .blend-group {
+      position: relative;
+      height: 250px;
+      border-radius: 12px;
+      overflow: hidden;
+      background: #1e1e1e;
+      margin-bottom: 16px;
+    }
+
+    .blend-layer {
+      position: absolute;
+      border-radius: 50%;
+    }
+
+    .blend-layer.circle-1 {
+      width: 150px;
+      height: 150px;
+      top: 20%;
+      left: 20%;
+      background: #ff6b6b;
+      mix-blend-mode: screen;
+    }
+
+    .blend-layer.circle-2 {
+      width: 150px;
+      height: 150px;
+      top: 20%;
+      right: 20%;
+      background: #4ecdc4;
+      mix-blend-mode: multiply;
+    }
+
+    .blend-layer.circle-3 {
+      width: 150px;
+      height: 150px;
+      bottom: 20%;
+      left: 35%;
+      background: #ffe66d;
+      mix-blend-mode: overlay;
+    }
+
+    .blend-group.isolated {
+      isolation: isolate;
+    }
+
+    /* 文字层叠效果 */
+    .text-stack {
+      position: relative;
+      height: 200px;
+      border-radius: 12px;
+      overflow: hidden;
+      background: linear-gradient(180deg, #1e1e1e 0%, #2d2d2d 100%);
+      margin-bottom: 16px;
+    }
+
+    .text-stack .word {
+      position: absolute;
+      font-size: 80px;
+      font-weight: 900;
+      color: white;
+    }
+
+    .text-stack .word-1 {
+      top: 20%;
+      left: 10%;
+      mix-blend-mode: multiply;
+      color: #ff6b6b;
+    }
+
+    .text-stack .word-2 {
+      top: 40%;
+      left: 25%;
+      mix-blend-mode: screen;
+      color: #4ecdc4;
+    }
+
+    .text-stack .word-3 {
+      top: 60%;
+      left: 40%;
+      mix-blend-mode: overlay;
+      color: #ffe66d;
+    }
+
+    /* SVG 混合 */
+    .svg-blend-demo {
+      position: relative;
+      height: 250px;
+      border-radius: 12px;
+      overflow: hidden;
+      background: #764ba2;
+      margin-bottom: 16px;
+    }
+
+    .svg-blend-demo svg {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+    }
+
+    .svg-blend-demo .text-overlay {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      font-size: 48px;
+      font-weight: 900;
+      color: white;
+      mix-blend-mode: multiply;
+    }
+
+    pre {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 16px;
+      border-radius: 8px;
+      overflow-x: auto;
+      font-size: 0.9em;
+    }
+
+    code {
+      font-family: "Fira Code", Consolas, monospace;
+    }
+
+    .code-comment { color: #6a9955; }
+    .code-prop { color: #9cdcfe; }
+    .code-value { color: #ce9178; }
+
+    @media (max-width: 600px) {
+      .isolation-demo {
+        grid-template-columns: 1fr;
+      }
+    }
+  </style>
+</head>
+<body>
+  <h1>🔬 图层混合与 isolation 隔离</h1>
+
+  <div class="demo-section">
+    <h2>isolation 的作用</h2>
+    <p>
+      <code>isolation: isolate</code> 创建一个新的层叠上下文，阻止混合模式影响父元素外部的内容。
+      这在需要将混合效果限制在某个区域内时非常有用。
+    </p>
+
+    <div class="isolation-demo">
+      <div>
+        <div class="demo-box-header">
+          无隔离 <span class="tag tag-no">isolation: auto</span>
+        </div>
+        <div class="demo-content" style="background: #fbbf24;">
+          <p style="position:absolute;top:8px;left:8px;font-size:12px;color:#92400e;margin:0;">
+            页面黄色背景参与了混合
+          </p>
+          <div class="layer-1">Multiply</div>
+          <div class="layer-2">Screen</div>
+        </div>
+      </div>
+      <div>
+        <div class="demo-box-header">
+          有隔离 <span class="tag tag-yes">isolation: isolate</span>
+        </div>
+        <div class="demo-content" style="background: #fbbf24;">
+          <p style="position:absolute;top:8px;left:8px;font-size:12px;color:#065f46;margin:0;">
+            混合只在容器内，黄色背景不参与
+          </p>
+          <div class="layer-1">Multiply</div>
+          <div class="layer-2">Screen</div>
+        </div>
+      </div>
+    </div>
+    <pre><code><span class="code-comment">/* 无隔离：混合会传播到父元素背景 */</span>
+<span class="code-prop">.outer</span> {
+  <span class="code-prop">background</span>: <span class="code-value">#fbbf24</span>; <span class="code-comment">/* 这会影响混合结果 */</span>
+}
+<span class="code-prop">.inner</span> {
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">multiply</span>;
+  <span class="code-prop">background</span>: <span class="code-value">#ff6b6b</span>;
+}
+
+<span class="code-comment">/* 有隔离：混合只在容器内 */</span>
+<span class="code-prop">.container</span> {
+  <span class="code-prop">isolation</span>: <span class="code-value">isolate</span>; <span class="code-comment">/* 创建隔离层 */</span>
+}
+<span class="code-prop">.container .layer</span> {
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">multiply</span>;
+}</code></pre>
+  </div>
+
+  <div class="demo-section">
+    <h2>多层圆形叠加</h2>
+    <p>三个圆形使用不同的混合模式，在有隔离和无隔离下的效果对比：</p>
+
+    <div class="blend-group" style="margin-bottom: 12px;">
+      <div class="blend-layer circle-1">1</div>
+      <div class="blend-layer circle-2">2</div>
+      <div class="blend-layer circle-3">3</div>
+      <p style="position:absolute;bottom:8px;left:8px;font-size:12px;color:#94a3b8;margin:0;">
+        无隔离：页面背景（深灰色）参与混合
+      </p>
+    </div>
+
+    <div class="blend-group isolated">
+      <div class="blend-layer circle-1">1</div>
+      <div class="blend-layer circle-2">2</div>
+      <div class="blend-layer circle-3">3</div>
+      <p style="position:absolute;bottom:8px;left:8px;font-size:12px;color:#94a3b8;margin:0;">
+        有隔离：混合只在组内，背景不参与
+      </p>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>文字层叠混合</h2>
+    <p>多层文字使用不同的混合模式叠加在一起：</p>
+
+    <div class="text-stack">
+      <span class="word word-1">HELLO</span>
+      <span class="word word-2">CSS</span>
+      <span class="word word-3">BLEND</span>
+    </div>
+    <pre><code><span class="code-comment">/* 文字层叠混合 */</span>
+<span class="code-prop">.text-stack</span> {
+  <span class="code-prop">position</span>: <span class="code-value">relative</span>;
+  <span class="code-prop">background</span>: <span class="code-value">linear-gradient(180deg, #1e1e1e, #2d2d2d)</span>;
+}
+
+<span class="code-prop">.word-1</span> {
+  <span class="code-prop">top</span>: <span class="code-value">20%</span>;
+  <span class="code-prop">left</span>: <span class="code-value">10%</span>;
+  <span class="code-prop">color</span>: <span class="code-value">#ff6b6b</span>;
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">multiply</span>;
+}
+
+<span class="code-prop">.word-2</span> {
+  <span class="code-prop">top</span>: <span class="code-value">40%</span>;
+  <span class="code-prop">left</span>: <span class="code-value">25%</span>;
+  <span class="code-prop">color</span>: <span class="code-value">#4ecdc4</span>;
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">screen</span>;
+}
+
+<span class="code-prop">.word-3</span> {
+  <span class="code-prop">top</span>: <span class="code-value">60%</span>;
+  <span class="code-prop">left</span>: <span class="code-value">40%</span>;
+  <span class="code-prop">color</span>: <span class="code-value">#ffe66d</span>;
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">overlay</span>;
+}</code></pre>
+  </div>
+
+  <div class="demo-section">
+    <h2>SVG 与 HTML 混合</h2>
+    <p>SVG 图形与 HTML 内容的混合效果：</p>
+
+    <div class="svg-blend-demo">
+      <svg viewBox="0 0 400 250" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <linearGradient id="svgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" style="stop-color:#ff6b6b;stop-opacity:1" />
+            <stop offset="100%" style="stop-color:#4ecdc4;stop-opacity:1" />
+          </linearGradient>
+        </defs>
+        <circle cx="120" cy="125" r="80" fill="url(#svgGrad)" style="mix-blend-mode: screen;" />
+        <circle cx="200" cy="100" r="60" fill="#ffe66d" style="mix-blend-mode: multiply;" />
+        <circle cx="280" cy="150" r="70" fill="#764ba2" style="mix-blend-mode: overlay;" />
+      </svg>
+      <div class="text-overlay">SVG BLEND</div>
+    </div>
+    <pre><code><span class="code-comment">/* SVG 与 HTML 内容的混合 */</span>
+<span class="code-prop">.svg-blend-demo</span> {
+  <span class="code-prop">position</span>: <span class="code-value">relative</span>;
+  <span class="code-prop">background</span>: <span class="code-value">#764ba2</span>;
+}
+
+<span class="code-prop">.svg-blend-demo svg</span> {
+  <span class="code-prop">position</span>: <span class="code-value">absolute</span>;
+  <span class="code-prop">width</span>: <span class="code-value">100%</span>;
+  <span class="code-prop">height</span>: <span class="code-value">100%</span>;
+}
+
+<span class="code-prop">.svg-blend-demo svg circle</span> {
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">screen</span>; <span class="code-comment">/* SVG 元素也可使用混合模式 */</span>
+}
+
+<span class="code-prop">.text-overlay</span> {
+  <span class="code-prop">position</span>: <span class="code-value">absolute</span>;
+  <span class="code-prop">top</span>: <span class="code-value">50%</span>;
+  <span class="code-prop">left</span>: <span class="code-value">50%</span>;
+  <span class="code-prop">transform</span>: <span class="code-value">translate(-50%, -50%)</span>;
+  <span class="code-prop">color</span>: <span class="code-value">white</span>;
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">multiply</span>;
+}</code></pre>
+  </div>
+
+  <div class="demo-section">
+    <h2>实战：制作发光按钮</h2>
+    <p>结合混合模式和发光效果，制作独特的按钮样式：</p>
+
+    <style>
+      .glow-btn-container {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+        margin-top: 16px;
+      }
+
+      .glow-btn {
+        position: relative;
+        padding: 12px 32px;
+        font-size: 16px;
+        font-weight: 600;
+        color: white;
+        background: linear-gradient(135deg, #667eea, #764ba2);
+        border: none;
+        border-radius: 8px;
+        cursor: pointer;
+        overflow: hidden;
+      }
+
+      .glow-btn::before {
+        content: '';
+        position: absolute;
+        inset: 0;
+        background: linear-gradient(135deg, #ff6b6b, #feca57);
+        mix-blend-mode: multiply;
+        opacity: 0.7;
+      }
+
+      .glow-btn span {
+        position: relative;
+        z-index: 1;
+      }
+
+      .glow-btn.screen::before {
+        mix-blend-mode: screen;
+      }
+
+      .glow-btn.isolated {
+        isolation: isolate;
+      }
+    </style>
+
+    <div class="glow-btn-container">
+      <div>
+        <p style="font-size:12px;color:#64748b;margin:0 0 8px 0;">multiply</p>
+        <button class="glow-btn"><span>Hover Me</span></button>
+      </div>
+      <div>
+        <p style="font-size:12px;color:#64748b;margin:0 0 8px 0;">screen</p>
+        <button class="glow-btn screen"><span>Hover Me</span></button>
+      </div>
+      <div>
+        <p style="font-size:12px;color:#64748b;margin:0 0 8px 0;">screen + isolate</p>
+        <button class="glow-btn screen isolated"><span>Hover Me</span></button>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/css-mix-blend-mode/text-blend.html
+++ b/examples/css/demos/css-mix-blend-mode/text-blend.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>文字与背景混合 - mix-blend-mode 演示</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 1000px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f8fafc;
+    }
+
+    h1 {
+      text-align: center;
+      color: #1e293b;
+      margin-bottom: 24px;
+    }
+
+    .demo-section {
+      background: white;
+      border-radius: 12px;
+      padding: 24px;
+      margin-bottom: 24px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    }
+
+    .demo-section h2 {
+      margin-top: 0;
+      color: #2563eb;
+      font-size: 1.2em;
+    }
+
+    /* 文字混合演示区域 */
+    .text-blend-demo {
+      position: relative;
+      height: 200px;
+      border-radius: 12px;
+      overflow: hidden;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      margin-bottom: 16px;
+    }
+
+    .text-blend-demo .overlay-text {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 64px;
+      font-weight: 900;
+      color: white;
+      letter-spacing: -2px;
+    }
+
+    .text-blend-demo.multiply .overlay-text { mix-blend-mode: multiply; }
+    .text-blend-demo.screen .overlay-text { mix-blend-mode: screen; }
+    .text-blend-demo.overlay .overlay-text { mix-blend-mode: overlay; }
+    .text-blend-demo.darken .overlay-text { mix-blend-mode: darken; }
+    .text-blend-demo.lighten .overlay-text { mix-blend-mode: lighten; }
+    .text-blend-demo.difference .overlay-text { mix-blend-mode: difference; }
+
+    .demo-label {
+      position: absolute;
+      bottom: 12px;
+      left: 16px;
+      background: rgba(0,0,0,0.5);
+      color: white;
+      padding: 4px 12px;
+      border-radius: 20px;
+      font-size: 13px;
+      font-family: monospace;
+    }
+
+    /* 文字描边效果 */
+    .stroke-demo {
+      position: relative;
+      height: 180px;
+      border-radius: 12px;
+      overflow: hidden;
+      background: url('https://picsum.photos/seed/blend1/800/400') center/cover;
+      margin-bottom: 16px;
+    }
+
+    .stroke-demo .stroke-text {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      font-size: 72px;
+      font-weight: 900;
+      color: white;
+      -webkit-text-stroke: 2px white;
+      paint-order: stroke fill;
+    }
+
+    .stroke-demo.blend .stroke-text {
+      mix-blend-mode: multiply;
+    }
+
+    /* 多行文字混合 */
+    .multi-text-demo {
+      position: relative;
+      height: 250px;
+      border-radius: 12px;
+      overflow: hidden;
+      background: linear-gradient(180deg, #ff6b6b 0%, #4ecdc4 100%);
+      margin-bottom: 16px;
+    }
+
+    .multi-text-demo .big-text {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      font-size: 100px;
+      font-weight: 900;
+      color: white;
+      line-height: 1;
+    }
+
+    .multi-text-demo .big-text span {
+      mix-blend-mode: multiply;
+    }
+
+    .multi-text-demo .big-text span:nth-child(2) {
+      mix-blend-mode: screen;
+      color: #ffe66d;
+    }
+
+    /* 选择器切换模式 */
+    .mode-selector {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 16px;
+      flex-wrap: wrap;
+    }
+
+    .mode-btn {
+      padding: 8px 16px;
+      border: 2px solid #e5e7eb;
+      background: white;
+      border-radius: 8px;
+      cursor: pointer;
+      font-size: 14px;
+      font-family: monospace;
+      transition: all 0.2s;
+    }
+
+    .mode-btn:hover {
+      border-color: #667eea;
+      background: #eff6ff;
+    }
+
+    .mode-btn.active {
+      border-color: #667eea;
+      background: #667eea;
+      color: white;
+    }
+
+    /* 交互式演示 */
+    .interactive-demo {
+      position: relative;
+      height: 220px;
+      border-radius: 12px;
+      overflow: hidden;
+      background: linear-gradient(135deg, #f093fb 0%, #f5576c 100%);
+      margin-bottom: 16px;
+    }
+
+    .interactive-demo .word {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      font-size: 80px;
+      font-weight: 900;
+      color: white;
+      cursor: pointer;
+      transition: mix-blend-mode 0.3s;
+    }
+
+    pre {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 16px;
+      border-radius: 8px;
+      overflow-x: auto;
+      font-size: 0.9em;
+    }
+
+    code {
+      font-family: "Fira Code", Consolas, monospace;
+    }
+
+    .code-comment { color: #6a9955; }
+    .code-prop { color: #9cdcfe; }
+    .code-value { color: #ce9178; }
+  </style>
+</head>
+<body>
+  <h1>📝 文字与背景混合模式</h1>
+
+  <div class="demo-section">
+    <h2>不同混合模式下的文字效果</h2>
+    <p>白色文字叠加在渐变背景上，不同混合模式产生不同视觉效果：</p>
+
+    <div class="text-blend-demo multiply">
+      <div class="overlay-text">BLEND</div>
+      <span class="demo-label">mix-blend-mode: multiply</span>
+    </div>
+
+    <div class="text-blend-demo screen">
+      <div class="overlay-text">SCREEN</div>
+      <span class="demo-label">mix-blend-mode: screen</span>
+    </div>
+
+    <div class="text-blend-demo overlay">
+      <div class="overlay-text">OVERLAY</div>
+      <span class="demo-label">mix-blend-mode: overlay</span>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>文字描边 + 混合模式</h2>
+    <p>结合文字描边和混合模式，创造独特的文字效果：</p>
+
+    <div class="stroke-demo blend">
+      <div class="stroke-text">Hello World</div>
+    </div>
+    <pre><code><span class="code-comment">/* 文字描边 + 混合模式 */</span>
+<span class="code-prop">.stroke-text</span> {
+  <span class="code-prop">font-size</span>: <span class="code-value">72px</span>;
+  <span class="code-prop">font-weight</span>: <span class="code-value">900</span>;
+  <span class="code-prop">color</span>: <span class="code-value">white</span>;
+  <span class="code-prop">-webkit-text-stroke</span>: <span class="code-value">2px white</span>; <span class="code-comment">/* 文字描边 */</span>
+  <span class="code-prop">paint-order</span>: <span class="code-value">stroke fill</span>; <span class="code-comment">/* 先描边后填充 */</span>
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">multiply</span>; <span class="code-comment">/* 与背景混合 */</span>
+}</code></pre>
+  </div>
+
+  <div class="demo-section">
+    <h2>多行文字不同混合模式</h2>
+    <p>同一区域内，多行文字可以设置不同的混合模式：</p>
+
+    <div class="multi-text-demo">
+      <div class="big-text">
+        <span>HELLO</span>
+        <span>WORLD</span>
+      </div>
+    </div>
+    <pre><code><span class="code-comment">/* 多行文字不同混合模式 */</span>
+<span class="code-prop">.big-text</span> {
+  <span class="code-prop">display</span>: <span class="code-value">flex</span>;
+  <span class="code-prop">flex-direction</span>: <span class="code-value">column</span>;
+}
+
+<span class="code-prop">.big-text span:nth-child(1)</span> {
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">multiply</span>; <span class="code-comment">/* 白色文字在渐变上变暗 */</span>
+}
+
+<span class="code-prop">.big-text span:nth-child(2)</span> {
+  <span class="code-prop">mix-blend-mode</span>: <span class="code-value">screen</span>; <span class="code-comment">/* 黄色文字在渐变上变亮 */</span>
+  <span class="code-prop">color</span>: <span class="code-value">#ffe66d</span>;
+}</code></pre>
+  </div>
+
+  <div class="demo-section">
+    <h2>交互式演示：点击切换混合模式</h2>
+    <p>点击按钮切换文字的混合模式，观察效果变化：</p>
+
+    <div class="mode-selector">
+      <button class="mode-btn active" onclick="setMode('normal')">normal</button>
+      <button class="mode-btn" onclick="setMode('multiply')">multiply</button>
+      <button class="mode-btn" onclick="setMode('screen')">screen</button>
+      <button class="mode-btn" onclick="setMode('overlay')">overlay</button>
+      <button class="mode-btn" onclick="setMode('darken')">darken</button>
+      <button class="mode-btn" onclick="setMode('lighten')">lighten</button>
+      <button class="mode-btn" onclick="setMode('difference')">difference</button>
+    </div>
+
+    <div class="interactive-demo">
+      <div class="word" id="interactiveWord">TEXT</div>
+    </div>
+  </div>
+
+  <script>
+    const word = document.getElementById('interactiveWord');
+    const buttons = document.querySelectorAll('.mode-btn');
+
+    function setMode(mode) {
+      word.style.mixBlendMode = mode;
+      buttons.forEach(btn => btn.classList.remove('active'));
+      event.target.classList.add('active');
+    }
+  </script>
+</body>
+</html>

--- a/examples/css/demos/css-prefers-reduced-motion/index.html
+++ b/examples/css/demos/css-prefers-reduced-motion/index.html
@@ -1,0 +1,424 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>prefers-reduced-motion 减少动效演示</title>
+  <style>
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 20px;
+      background: #f5f5f5;
+    }
+
+    h1 {
+      text-align: center;
+      color: #333;
+    }
+
+    .demo-section {
+      background: white;
+      border-radius: 8px;
+      padding: 20px;
+      margin-bottom: 20px;
+      box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+    }
+
+    .demo-section h2 {
+      margin-top: 0;
+      color: #2563eb;
+      font-size: 1.2em;
+    }
+
+    .demo-box {
+      padding: 15px;
+      border: 2px dashed #ccc;
+      border-radius: 6px;
+      margin: 10px 0;
+      background: #fafafa;
+    }
+
+    pre {
+      background: #1e1e1e;
+      color: #d4d4d4;
+      padding: 15px;
+      border-radius: 6px;
+      overflow-x: auto;
+      font-size: 0.9em;
+    }
+
+    code {
+      font-family: "Fira Code", Consolas, monospace;
+    }
+
+    /* 状态指示器 */
+    .motion-indicator {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      padding: 10px 20px;
+      border-radius: 20px;
+      font-size: 14px;
+      font-weight: bold;
+      z-index: 1000;
+    }
+
+    .motion-indicator.reduce {
+      background: #fef3c7;
+      color: #92400e;
+    }
+
+    .motion-indicator.no-preference {
+      background: #e0e7ff;
+      color: #3730a3;
+    }
+
+    /* ========== 动画示例 ========== */
+
+    /* 1. 旋转动画 */
+    .spinner {
+      width: 50px;
+      height: 50px;
+      border: 4px solid #e5e7eb;
+      border-top-color: #2563eb;
+      border-radius: 50%;
+      animation: spin 1s linear infinite;
+    }
+
+    @keyframes spin {
+      to { transform: rotate(360deg); }
+    }
+
+    /* 2. 弹跳动画 */
+    .bounce {
+      width: 50px;
+      height: 50px;
+      background: #dc2626;
+      border-radius: 50%;
+      animation: bounce 0.6s ease-in-out infinite alternate;
+    }
+
+    @keyframes bounce {
+      from { transform: translateY(0); }
+      to { transform: translateY(-50px); }
+    }
+
+    /* 3. 淡入动画 */
+    .fade-in {
+      opacity: 0;
+      animation: fadeIn 1s ease-out forwards;
+    }
+
+    @keyframes fadeIn {
+      from { opacity: 0; transform: translateY(20px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+
+    /* 4. 脉冲动画 */
+    .pulse {
+      width: 50px;
+      height: 50px;
+      background: #059669;
+      border-radius: 50%;
+      animation: pulse 1.5s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { transform: scale(1); opacity: 1; }
+      50% { transform: scale(1.2); opacity: 0.7; }
+    }
+
+    /* 5. 滑动动画 */
+    .slide {
+      width: 50px;
+      height: 50px;
+      background: #7c3aed;
+      animation: slide 2s ease-in-out infinite;
+    }
+
+    @keyframes slide {
+      0%, 100% { transform: translateX(0); }
+      50% { transform: translateX(100px); }
+    }
+
+    /* 动画容器 */
+    .animation-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 20px;
+      margin-top: 20px;
+    }
+
+    .animation-item {
+      text-align: center;
+      padding: 20px;
+      background: #f9fafb;
+      border-radius: 8px;
+    }
+
+    .animation-item span {
+      display: block;
+      margin-top: 10px;
+      font-size: 14px;
+      color: #666;
+    }
+
+    /* ========== 减少动效覆盖 ========== */
+    @media (prefers-reduced-motion: reduce) {
+      /* 禁用旋转 */
+      .spinner {
+        animation: none;
+        border-top-color: #2563eb;
+        background: transparent;
+      }
+
+      /* 禁用弹跳 */
+      .bounce {
+        animation: none;
+        transform: translateY(0);
+      }
+
+      /* 禁用淡入 */
+      .fade-in {
+        animation: none;
+        opacity: 1;
+        transform: translateY(0);
+      }
+
+      /* 禁用脉冲 */
+      .pulse {
+        animation: none;
+        transform: scale(1);
+        opacity: 1;
+      }
+
+      /* 禁用滑动 */
+      .slide {
+        animation: none;
+        transform: translateX(0);
+      }
+
+      /* 禁用平滑滚动 */
+      html {
+        scroll-behavior: auto;
+      }
+    }
+
+    /* 说明文字 */
+    .info-box {
+      background: #eff6ff;
+      border: 1px solid #bfdbfe;
+      border-radius: 6px;
+      padding: 15px;
+      margin-bottom: 20px;
+    }
+
+    .info-box strong {
+      color: #1e40af;
+    }
+
+    .warning-box {
+      background: #fef3c7;
+      border: 1px solid #fcd34d;
+      border-radius: 6px;
+      padding: 15px;
+      margin-bottom: 20px;
+    }
+
+    .warning-box strong {
+      color: #92400e;
+    }
+  </style>
+</head>
+<body>
+  <div class="motion-indicator no-preference" id="motionIndicator">
+    动效偏好：未设置
+  </div>
+
+  <h1>prefers-reduced-motion 减少动效演示</h1>
+
+  <div class="info-box">
+    <strong>💡 提示：</strong>本页面演示了各种 CSS 动画效果，以及它们在启用「减少动效」时的行为。
+  </div>
+
+  <div class="warning-box">
+    <strong>⚠️ 如何启用减少动效：</strong>
+    <ul style="margin: 10px 0 0 0; padding-left: 20px;">
+      <li>macOS: 系统设置 → 辅助功能 → 显示 → 减弱动态效果</li>
+      <li>Windows: 设置 → 轻松使用 → 显示 → 在 Windows 中显示动画</li>
+      <li>iOS: 设置 → 辅助功能 → 减弱动态效果</li>
+    </ul>
+  </div>
+
+  <div class="demo-section">
+    <h2>动画示例</h2>
+    <p>以下动画在启用了「减少动效」后将停止或变成静态：</p>
+
+    <div class="animation-grid">
+      <div class="animation-item">
+        <div class="spinner"></div>
+        <span>旋转动画</span>
+      </div>
+      <div class="animation-item">
+        <div class="bounce"></div>
+        <span>弹跳动画</span>
+      </div>
+      <div class="animation-item">
+        <div class="fade-in" style="background: #059669; width: 50px; height: 50px; border-radius: 4px;"></div>
+        <span>淡入动画</span>
+      </div>
+      <div class="animation-item">
+        <div class="pulse"></div>
+        <span>脉冲动画</span>
+      </div>
+      <div class="animation-item">
+        <div class="slide"></div>
+        <span>滑动动画</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="demo-section">
+    <h2>CSS 实现代码</h2>
+    <pre><code>/* 1. 禁用所有非必要动画 */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+/* 2. 保留关键动画（加载指示器） */
+.loading-spinner {
+  animation: spin 1s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-spinner {
+    /* 加载指示器保留，但可以用静态图标替代 */
+    animation: none;
+  }
+}
+
+/* 3. 选择性禁用动画 */
+.fade-in {
+  animation: fadeIn 0.5s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-in {
+    animation: none;
+    opacity: 1;
+    transform: translateX(0);
+  }
+}</code></pre>
+  </div>
+
+  <div class="demo-section">
+    <h2>JavaScript 检测</h2>
+    <pre><code>// 检测用户偏好
+const prefersReducedMotion = window.matchMedia(
+  '(prefers-reduced-motion: reduce)'
+).matches;
+
+console.log('减少动效:', prefersReducedMotion);
+
+// 监听变化
+window.matchMedia('(prefers-reduced-motion: reduce)')
+  .addEventListener('change', (e) => {
+    if (e.matches) {
+      console.log('用户启用了减少动效');
+      // 停止非必要动画
+    } else {
+      console.log('用户禁用了减少动效');
+      // 恢复动画
+    }
+  });</code></pre>
+  </div>
+
+  <div class="demo-section">
+    <h2>常见使用场景</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>场景</th>
+          <th>处理方式</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>页面入场动画</td>
+          <td>使用 <code>prefers-reduced-motion</code> 禁用</td>
+        </tr>
+        <tr>
+          <td>加载指示器</td>
+          <td>保留或用静态图标替代</td>
+        </tr>
+        <tr>
+          <td>模态框动画</td>
+          <td>禁用过渡效果</td>
+        </tr>
+        <tr>
+          <td>滚动动画</td>
+          <td>禁用 <code>scroll-behavior</code></td>
+        </tr>
+        <tr>
+          <td>悬停效果</td>
+          <td>保留（用户可主动触发）</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="demo-section">
+    <h2>最佳实践</h2>
+    <ul>
+      <li><strong>尊重用户设置</strong>：优先使用媒体查询，而不是依赖 JavaScript 检测</li>
+      <li><strong>保留功能性动画</strong>：加载指示器等让用户知道系统在工作</li>
+      <li><strong>使用过渡而非动画</strong>：过渡比动画更轻量，用户更容易控制</li>
+      <li><strong>提供备选方案</strong>：考虑静态替代方案（如静态加载图标）</li>
+      <li><strong>测试</strong>：在真实设备上测试，特别是辅助功能设置</li>
+    </ul>
+  </div>
+
+  <script>
+    // 检测当前设置并更新指示器
+    function updateMotionIndicator() {
+      const prefersReducedMotion = window.matchMedia(
+        '(prefers-reduced-motion: reduce)'
+      ).matches;
+
+      const indicator = document.getElementById('motionIndicator');
+
+      if (prefersReducedMotion) {
+        indicator.textContent = '动效偏好：减少';
+        indicator.className = 'motion-indicator reduce';
+      } else {
+        indicator.textContent = '动效偏好：全部';
+        indicator.className = 'motion-indicator no-preference';
+      }
+    }
+
+    // 初始化
+    updateMotionIndicator();
+
+    // 监听变化
+    window.matchMedia('(prefers-reduced-motion: reduce)')
+      .addEventListener('change', updateMotionIndicator);
+
+    // 输出当前设置
+    const isReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    console.log('prefers-reduced-motion:', isReduced ? 'reduce' : 'no-preference');
+  </script>
+</body>
+</html>

--- a/src/topics/04.effects/css-filter/index.mdx
+++ b/src/topics/04.effects/css-filter/index.mdx
@@ -1,0 +1,422 @@
+---
+title: CSS filter
+category: 视觉效果
+tags: [filter, blur, brightness, contrast, drop-shadow, grayscale, hue-rotate, invert, opacity, saturate, sepia, css-effects]
+description: 详细介绍 CSS filter 滤镜属性，包括10种滤镜函数的工作原理和视觉效果。
+keywords: CSS filter, blur, brightness, contrast, drop-shadow, grayscale, hue-rotate, invert, opacity, saturate, sepia, 滤镜, CSS 效果
+---
+
+## 学习目标
+
+通过本章学习，你将：
+
+1. 理解 CSS filter 滤镜的基本概念和滤镜链原理
+2. 掌握 10 种滤镜函数的取值和工作原理
+3. 学会组合使用多个滤镜函数创造丰富效果
+4. 能够使用滤镜实现常见的视觉交互效果
+
+---
+
+## 快速上手
+
+### filter 属性
+
+`filter` 属性将图形变化效果应用于元素。通过滤镜函数，可以实现模糊、亮度调整、对比度调整、投影、灰度转换、色相旋转等效果。
+
+```css
+.element {
+  filter: blur(5px);
+  filter: grayscale(100%);
+}
+```
+
+### 基本示例
+
+{/* @playground id="css-filter-demo" mode="code" */}
+
+---
+
+## 工作原理
+
+### 滤镜链
+
+`filter` 属性接受一个或多个滤镜函数，以空格分隔，按从左到右的顺序依次应用。这种链式调用（Filter Functions Chain）使得可以组合多个效果。
+
+```css
+/* 组合多个滤镜函数 */
+.photo-effect {
+  filter: contrast(175%) brightness(3%);
+}
+
+/* 等价于 */
+.complex-effect {
+  filter: grayscale(80%) contrast(150%) brightness(1.2);
+}
+```
+
+### 取值类型
+
+滤镜函数的值主要有两种类型：
+
+- **绝对长度**：`blur(5px)` 中的 `px`
+- **百分比/倍数**：`brightness(150%)`、`brightness(1.5)`
+
+### 滤镜函数一览
+
+| 函数 | 取值 | 说明 |
+|------|------|------|
+| `blur()` | `<length>`（px, em, rem） | 高斯模糊 |
+| `brightness()` | `<number>` 或 `<percentage>` | 亮度调整 |
+| `contrast()` | `<number>` 或 `<percentage>` | 对比度调整 |
+| `drop-shadow()` | `<shadow>`（类似 box-shadow） | 投影 |
+| `grayscale()` | `<number>` 或 `<percentage>` | 灰度转换 |
+| `hue-rotate()` | `<angle>`（deg, rad, grad, turn） | 色相旋转 |
+| `invert()` | `<number>` 或 `<percentage>` | 反相 |
+| `opacity()` | `<number>` 或 `<percentage>` | 透明度 |
+| `saturate()` | `<number>` 或 `<percentage>` | 饱和度 |
+| `sepia()` | `<number>` 或 `<percentage>` | 棕褐色 |
+
+---
+
+## 主要属性详解
+
+### blur()
+
+高斯模糊函数，使用标准差（σ）控制模糊程度。
+
+```css
+.blur-sm { filter: blur(2px); }
+.blur-md { filter: blur(5px); }
+.blur-lg { filter: blur(10px); }
+```
+
+- **取值**：`0` 表示不模糊
+- **原理**：通过高斯函数计算周围像素的加权平均值
+
+### brightness()
+
+调整元素的明暗程度。
+
+```css
+.bright { filter: brightness(150%); }   /* 变亮 50% */
+.dark { filter: brightness(50%); }      /* 变暗 50% */
+.normal { filter: brightness(100%); }   /* 原始亮度 */
+```
+
+- `100%` 或 `1` = 原始亮度
+- `0%` 或 `0` = 全黑
+- 超过 `100%` 或 `1` = 更亮
+
+### contrast()
+
+调整元素的对比度，即明暗之间的差异程度。
+
+```css
+.high-contrast { filter: contrast(200%); }
+.low-contrast { filter: contrast(50%); }
+```
+
+- `100%` 或 `1` = 原始对比度
+- `0%` 或 `0` = 全灰（无对比度）
+- 超过 `100%` = 更高对比度
+
+### drop-shadow()
+
+为元素添加投影效果，类似于 `box-shadow`，但**会遵循Alpha通道**，产生更自然的投影。
+
+```css
+/* drop-shadow 的语法 */
+.shadow-1 { filter: drop-shadow(3px 3px 5px rgba(0,0,0,0.3)); }
+.shadow-2 { filter: drop-shadow(0 4px 6px rgba(0,0,0,0.2)); }
+
+/* 与 box-shadow 对比：box-shadow 不遵循 Alpha 通道 */
+.bad-shadow {
+  box-shadow: 3px 3px 5px rgba(0,0,0,0.3);  /* 矩形投影，不跟随形状 */
+}
+.good-shadow {
+  filter: drop-shadow(3px 3px 5px rgba(0,0,0,0.3));  /* 跟随形状 */
+}
+```
+
+`drop-shadow()` 的 `<shadow>` 值语法：
+
+```
+drop-shadow(offset-x offset-y blur-radius spread-radius color)
+```
+
+- `offset-x`：水平偏移（必需）
+- `offset-y`：垂直偏移（必需）
+- `blur-radius`：模糊半径（可选，默认 0）
+- `spread-radius`：扩展半径（可选，默认 0）
+- `color`：投影颜色（可选，默认跟随 color 属性）
+
+### grayscale()
+
+将元素转换为灰度图像。
+
+```css
+.gray { filter: grayscale(100%); }      /* 完全灰度 */
+.half-gray { filter: grayscale(50%); }  /* 50% 灰度 */
+.color { filter: grayscale(0%); }        /* 原始颜色 */
+```
+
+- `0%` = 原始颜色
+- `100%` = 完全灰度
+
+### hue-rotate()
+
+通过色轮旋转改变图像的色相。
+
+```css
+.hue-0 { filter: hue-rotate(0deg); }    /* 原始颜色 */
+.hue-90 { filter: hue-rotate(90deg); }   /* 旋转 90° */
+.hue-180 { filter: hue-rotate(180deg); } /* 反相色（互补色） */
+.hue-360 { filter: hue-rotate(360deg); } /* 回到原始 */
+```
+
+- `0deg` = 无变化
+- `360deg` = 色轮完整旋转一圈
+- 负值向相反方向旋转
+
+### invert()
+
+反转元素的颜色，产生照片负片效果。
+
+```css
+.negative { filter: invert(100%); }     /* 完全反相 */
+.partial { filter: invert(50%); }        /* 50% 反相 */
+.original { filter: invert(0%); }        /* 原始颜色 */
+```
+
+- `0%` = 原始颜色
+- `100%` = 完全反相
+
+### opacity()
+
+调整元素的透明度，与 `opacity` 属性效果类似，但滤镜版本可以利用硬件加速。
+
+```css
+.transparent { filter: opacity(0%); }  /* 完全透明 */
+.half { filter: opacity(50%); }         /* 50% 透明度 */
+.opaque { filter: opacity(100%); }       /* 完全不透明 */
+```
+
+### saturate()
+
+调整元素的饱和度，即颜色的鲜艳程度。
+
+```css
+.vivid { filter: saturate(200%); }      /* 高度饱和 */
+.muted { filter: saturate(50%); }       /* 低饱和度 */
+.desaturate { filter: saturate(0%); }  /* 完全去饱和（灰度） */
+.normal { filter: saturate(100%); }    /* 原始饱和度 */
+```
+
+- `0%` = 完全去饱和（灰度）
+- `100%` = 原始饱和度
+- `200%` = 双倍饱和度
+
+### sepia()
+
+将元素转换为棕褐色怀旧风格。
+
+```css
+.sepia { filter: sepia(100%); }         /* 完全棕褐色 */
+.vintage { filter: sepia(50%); }       /* 50% 棕褐色 */
+.original { filter: sepia(0%); }        /* 原始颜色 */
+```
+
+- `0%` = 原始颜色
+- `100%` = 完全棕褐色
+
+---
+
+## 实战应用示例
+
+### 场景一：卡片悬停效果
+
+鼠标悬停时应用模糊和亮度变化：
+
+```css
+.card {
+  transition: filter 0.3s ease;
+}
+
+.card:hover {
+  filter: blur(2px) brightness(1.1);
+}
+```
+
+### 场景二：图片滤镜处理
+
+为图片添加统一的视觉风格：
+
+```css
+/* 黑白照片效果 */
+.photo-bw {
+  filter: grayscale(100%);
+}
+
+/* 复古风格 */
+.photo-vintage {
+  filter: sepia(40%) contrast(110%) brightness(90%);
+}
+
+/* 高饱和风格 */
+.photo-vivid {
+  filter: saturate(150%) contrast(110%);
+}
+```
+
+### 场景三：文本投影
+
+使用 `drop-shadow` 为文本添加清晰可读的投影：
+
+```css
+.text-shadow {
+  color: white;
+  font-size: 48px;
+  font-weight: bold;
+  filter: drop-shadow(2px 2px 4px rgba(0, 0, 0, 0.5));
+}
+```
+
+### 场景四：按钮点击反馈
+
+点击时改变按钮的亮度和对比度：
+
+```css
+.button {
+  transition: filter 0.1s ease;
+}
+
+.button:active {
+  filter: brightness(0.8) contrast(1.2);
+}
+```
+
+### 场景五：loading 动画
+
+利用模糊和旋转创造动态效果：
+
+```css
+.loader {
+  width: 50px;
+  height: 50px;
+  border: 4px solid #667eea;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  filter: blur(1px);
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+```
+
+---
+
+## 组合使用
+
+### 常用组合
+
+```css
+/* 提升图片清晰度 */
+.enhance {
+  filter: contrast(110%) saturate(130%);
+}
+
+/* 怀旧风格 */
+.vintage {
+  filter: sepia(30%) contrast(90%) brightness(110%);
+}
+
+/* 冷色调风格 */
+.cool-tone {
+  filter: saturate(140%) hue-rotate(180deg);
+}
+
+/* 暖色调风格 */
+.warm-tone {
+  filter: saturate(120%) brightness(105%) sepia(20%);
+}
+
+/* 高对比黑白 */
+.bw-high-contrast {
+  filter: grayscale(100%) contrast(150%);
+}
+
+/* 柔焦效果 */
+.soft-focus {
+  filter: blur(2px) brightness(110%) contrast(90%);
+}
+```
+
+---
+
+## 最佳实践与注意事项
+
+### 性能方面
+
+- `blur()` 是计算密集型滤镜，大面积使用可能影响性能
+- 滤镜会创建新的层叠上下文，考虑使用 `will-change` 优化
+- 在移动设备上谨慎使用复杂滤镜链
+
+### 可访问性
+
+- 使用 `prefers-reduced-motion` 媒体查询禁用动画滤镜
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .animated-filter {
+    filter: none;
+    animation: none;
+  }
+}
+```
+
+### 常见陷阱
+
+- **陷阱 1**：`filter` 和 `opacity` 混淆
+  - `opacity` 是 CSS 属性，整体控制透明度
+  - `filter: opacity()` 是滤镜函数，效果类似但可以利用硬件加速
+- **陷阱 2**：`box-shadow` 和 `drop-shadow()` 混淆
+  - `box-shadow` 只生成矩形投影
+  - `drop-shadow()` 遵循 Alpha 通道，跟随元素形状
+- **陷阱 3**：滤镜链顺序影响结果
+  - `grayscale(100%) contrast(200%)` vs `contrast(200%) grayscale(100%)`
+  - 不同顺序可能产生不同效果
+
+### 浏览器兼容性
+
+- 现代浏览器支持良好
+- IE 不支持
+- 部分老版本浏览器可能需要前缀 `-webkit-filter`
+
+---
+
+## 总结
+
+### 核心知识点回顾
+
+- `filter` 属性通过滤镜函数改变元素的视觉表现
+- 10 种滤镜函数：
+  - 模糊：`blur()`
+  - 亮度：`brightness()`
+  - 对比度：`contrast()`
+  - 投影：`drop-shadow()`
+  - 灰度：`grayscale()`
+  - 色相旋转：`hue-rotate()`
+  - 反相：`invert()`
+  - 透明度：`opacity()`
+  - 饱和度：`saturate()`
+  - 棕褐色：`sepia()`
+- 多个滤镜函数可以链式组合，效果按顺序应用
+- `drop-shadow()` 会遵循 Alpha 通道，`box-shadow` 不会
+
+### 延伸阅读
+
+- [MDN: filter](https://developer.mozilla.org/zh-CN/docs/Web/CSS/filter)
+- [CSS Filters (W3C)](https://www.w3.org/TR/filter-effects-1/)
+- [CSS Filter Tricks](https://css-tricks.com/almanac/properties/f/filter/)

--- a/src/topics/04.effects/css-mix-blend-mode/index.mdx
+++ b/src/topics/04.effects/css-mix-blend-mode/index.mdx
@@ -1,0 +1,281 @@
+---
+title: mix-blend-mode
+category: 视觉效果
+tags: [mix-blend-mode, blend-mode, css-effects]
+description: 详细介绍 CSS mix-blend-mode 混合模式属性，包括各种混合模式值的原理和视觉效果。
+keywords: mix-blend-mode, multiply, screen, overlay, 混合模式, CSS 混合
+---
+
+## 学习目标
+
+通过本章学习，你将：
+
+1. 理解 CSS 混合模式的基本概念和混合原理
+2. 掌握 `mix-blend-mode` 的各种取值及其视觉效果
+3. 学会区分 `mix-blend-mode` 和 `background-blend-mode`
+4. 能够灵活运用混合模式实现各种视觉效果
+
+---
+
+## 快速上手
+
+### mix-blend-mode
+
+`mix-blend-mode` 属性控制元素内容与父元素内容的混合方式。当元素叠加在其它内容之上时，使用混合模式可以创造出丰富的视觉效果。
+
+```css
+.element {
+  mix-blend-mode: multiply;
+}
+```
+
+### 基本示例
+
+{/* @playground id="mix-blend-mode-demo" mode="code" */}
+
+---
+
+## 工作原理
+
+### 混合模式基础
+
+混合模式源于图形编辑软件（如 Photoshop），其核心思想是：**当两层图像叠加时，根据数学公式计算每个像素的最终颜色**。
+
+- **前景层**：应用 `mix-blend-mode` 的元素
+- **背景层**：前景层下方的所有内容
+- **结果**：混合后的视觉效果
+
+### 常用混合模式原理
+
+| 模式 | 原理 | 效果特点 |
+|------|------|----------|
+| `multiply` | 正片叠底 | 黑色完全变黑，白色保持不变，类似照片叠底片 |
+| `screen` | 滤色 | 与 multiply 相反，白色完全保留，黑色变透明 |
+| `overlay` | 叠加 | 根据底层颜色交替使用 multiply/screen，暗部加深，亮部提亮 |
+| `darken` | 变暗 | 保留较暗的像素 |
+| `lighten` | 变亮 | 保留较亮的像素 |
+| `difference` | 差值 | 两种颜色相减，产生高对比度效果 |
+| `color-dodge` | 颜色减淡 | 使底层颜色变亮以反映混合颜色 |
+| `color-burn` | 颜色加深 | 使底层颜色变暗以反映混合颜色 |
+
+---
+
+## 主要属性详解
+
+### mix-blend-mode
+
+- **作用**：定义元素的Content与父元素内容的混合方式
+- **默认值**：`normal`（无混合）
+- **适用于**：所有元素
+- **继承性**：不继承
+
+#### 取值列表
+
+```css
+/* 基础混合模式 */
+mix-blend-mode: normal;      /* 正常，无混合 */
+mix-blend-mode: multiply;    /* 正片叠底 */
+mix-blend-mode: screen;      /* 滤色 */
+mix-blend-mode: overlay;     /* 叠加 */
+mix-blend-mode: darken;      /* 变暗 */
+mix-blend-mode: lighten;     /* 变亮 */
+mix-blend-mode: color-dodge; /* 颜色减淡 */
+mix-blend-mode: color-burn;  /* 颜色加深 */
+mix-blend-mode: hard-light;  /* 强光 */
+mix-blend-mode: soft-light;  /* 柔光 */
+mix-blend-mode: difference;  /* 差值 */
+mix-blend-mode: exclusion;   /* 排除 */
+
+/* 颜色混合模式（CSS Compositing and Blending Level 1） */
+mix-blend-mode: hue;         /* 色相 */
+mix-blend-mode: saturation;  /* 饱和度 */
+mix-blend-mode: color;       /* 颜色 */
+mix-blend-mode: luminosity;  /* 亮度 */
+
+/* 全局值 */
+mix-blend-mode: inherit;      /* 继承 */
+mix-blend-mode: initial;     /*初始值 */
+mix-blend-mode: unset;       /* 未设置 */
+```
+
+### background-blend-mode（对比）
+
+`background-blend-mode` 与 `mix-blend-mode` 的关键区别：
+
+| 特性 | `mix-blend-mode` | `background-blend-mode` |
+|------|------------------|------------------------|
+| 作用对象 | 元素的整个内容（包括文字、图片、子元素） | 仅元素的背景（背景色、背景图） |
+| 混合内容 | 与父元素所有内容混合 | 与同一元素的其它背景混合 |
+| 使用场景 | 文字与背景混合、多元素叠加 | 多重背景图混合 |
+
+```css
+/* 错误示例：background-blend-mode 不能混合文字 */
+.element {
+  background-image: url('image.jpg');
+  background-blend-mode: multiply; /* 仅混合背景，不影响文字 */
+}
+
+/* 正确示例：mix-blend-mode 混合包括文字 */
+.element {
+  background-image: url('image.jpg');
+  mix-blend-mode: multiply; /* 文字和背景一起混合 */
+}
+```
+
+### isolation
+
+`isolation` 属性创建一个新的层叠上下文，阻止混合模式影响父元素外部的内容。
+
+```css
+.container {
+  isolation: isolate; /* 创建一个隔离层，混合模式只在容器内生效 */
+}
+```
+
+- `auto`：默认，不创建隔离层
+- `isolate`：创建隔离层
+
+---
+
+## 实战应用示例
+
+### 场景一：文字与背景图片混合
+
+将文字与背景图片混合，创造独特的视觉效果：
+
+1. **目标分析**：文字作为前景层，背景图片作为背景层，通过 `mix-blend-mode` 融合
+2. **HTML 结构**：
+
+```html
+<div class="text-blend">
+  <h1>Hello Blend</h1>
+</div>
+```
+
+3. **CSS 实现**：
+
+```css
+.text-blend {
+  position: relative;
+  width: 100%;
+  height: 300px;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+.text-blend h1 {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 80px;
+  font-weight: bold;
+  color: white;
+  mix-blend-mode: multiply; /* 文字与渐变背景混合 */
+}
+```
+
+4. **效果演示**：白色文字与渐变背景通过 multiply 混合，产生深色文字效果
+
+---
+
+### 场景二：图片叠加效果
+
+将两张图片通过混合模式叠加：
+
+```css
+.overlay-container {
+  position: relative;
+  width: 400px;
+  height: 300px;
+}
+
+.overlay-container img:first-child {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.overlay-container img:last-child {
+  position: absolute;
+  width: 50%;
+  height: 50%;
+  top: 25%;
+  left: 25%;
+  mix-blend-mode: screen; /* 叠加区域产生滤色效果 */
+}
+```
+
+---
+
+### 场景三：图层混合与隔离
+
+使用 `isolation` 属性控制混合范围：
+
+```css
+.effect-group {
+  isolation: isolate; /* 整个组的混合不影响页面其它内容 */
+}
+
+.effect-group .layer-1 {
+  mix-blend-mode: multiply;
+}
+
+.effect-group .layer-2 {
+  mix-blend-mode: screen;
+}
+```
+
+---
+
+## 最佳实践与注意事项
+
+### 性能方面
+
+- 混合模式涉及像素计算，复杂场景可能影响渲染性能
+- 避免在动画中频繁改变混合模式
+- 在移动设备上谨慎使用多层混合
+
+### 可访问性 (Accessibility)
+
+- 确保文字在混合模式下仍然具有良好的对比度
+- 不要仅依赖视觉混合效果传达重要信息
+- 提供足够的背景色或阴影确保文字可读
+
+### 常见陷阱
+
+- **陷阱 1**：忘记父元素的背景色会影响混合结果
+  - **解决**：使用 `isolation: isolate` 创建隔离层
+- **陷阱 2**：`background-blend-mode` 和 `mix-blend-mode` 混淆使用
+  - **解决**：前者只影响背景，后者影响整个元素内容
+- **陷阱 3**：在透明背景上混合模式不生效
+  - **解决**：确保有实际的背景内容可以混合
+
+### 浏览器兼容性
+
+- `mix-blend-mode` 在现代浏览器中支持良好
+- IE 和旧版 Edge 不支持
+- Safari 早期版本可能有细微差异
+
+---
+
+## 总结
+
+### 核心知识点回顾
+
+- `mix-blend-mode` 控制元素内容与父元素内容的混合
+- 常用混合模式：
+  - `multiply`：正片叠底，黑色变黑
+  - `screen`：滤色，白色保留
+  - `overlay`：叠加，暗部加深、亮部提亮
+  - `darken`/`lighten`：变暗/变亮
+  - `difference`：差值，高对比度
+- `background-blend-mode` 仅作用于背景图片/颜色
+- `isolation: isolate` 可创建隔离层，限制混合范围
+- SVG 中使用 `mix-blend-mode` 需注意 `enable-background` 属性
+
+### 延伸阅读
+
+- [MDN: mix-blend-mode](https://developer.mozilla.org/zh-CN/docs/Web/CSS/mix-blend-mode)
+- [CSS Compositing and Blending Level 1](https://www.w3.org/TR/compositing-1/)
+- [CSS Mix Blend Mode — Quick Reference](https://css-tricks.com/almanac/properties/m/mix-blend-mode/)

--- a/src/topics/08.responsive/css-prefers-reduced-motion/index.mdx
+++ b/src/topics/08.responsive/css-prefers-reduced-motion/index.mdx
@@ -1,0 +1,186 @@
+---
+title: prefers-reduced-motion 减少动效
+category: 响应式设计
+tags: [prefers-reduced-motion, 减少动效, 动画, 无障碍, accessibility]
+description: 详细介绍 CSS prefers-reduced-motion 媒体查询，尊重用户减少动效的设置。
+keywords: prefers-reduced-motion, 减少动效, 动画, 无障碍, accessibility, 动效偏好
+---
+
+# prefers-reduced-motion 减少动效
+
+`prefers-reduced-motion` 是 CSS 媒体查询，用于检测用户是否请求减少页面动画效果，提升无障碍体验。
+
+## 基本语法
+
+```css
+/* 用户偏好减少动效 */
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+```
+
+## 检测的值
+
+| 值 | 说明 |
+|---|---|
+| `no-preference` | 用户未设置偏好（默认值） |
+| `reduce` | 用户偏好减少或消除动画 |
+
+## 使用场景
+
+### 1. 禁用所有动画
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+### 2. 保留关键动画
+
+```css
+/* 关键加载动画保留 */
+.loading-spinner {
+  animation: spin 1s linear infinite;
+}
+
+/* 非关键动画禁用 */
+.fade-in {
+  animation: fadeIn 0.5s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fade-in {
+    animation: none;
+    opacity: 1;
+  }
+}
+```
+
+### 3. 使用 prefers-reduced-motion 查询
+
+```css
+/* 复杂的入场动画 */
+.hero-animation {
+  animation: slideIn 1s ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-animation {
+    animation: none;
+    transform: translateX(0);
+  }
+}
+```
+
+## JavaScript 检测
+
+```javascript
+// 检测用户偏好
+const prefersReducedMotion = window.matchMedia(
+  '(prefers-reduced-motion: reduce)'
+).matches;
+
+// 监听变化
+window.matchMedia('(prefers-reduced-motion: reduce)')
+  .addEventListener('change', (e) => {
+    if (e.matches) {
+      console.log('用户启用了减少动效');
+    } else {
+      console.log('用户禁用了减少动效');
+    }
+  });
+```
+
+## 常见问题
+
+### 1. 滚动动画
+
+```css
+/* 禁用平滑滚动 */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
+/* 禁用锚点平滑滚动 */
+a[href^="#"] {
+  scroll-behavior: auto;
+}
+```
+
+### 2. Loader 和 Spinner
+
+```css
+.loading-spinner {
+  animation: spin 1s linear infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .loading-spinner {
+    animation: none;
+  }
+}
+```
+
+### 3. 模态框动画
+
+```css
+.modal {
+  transition: opacity 0.3s, transform 0.3s;
+}
+
+.modal-enter {
+  opacity: 0;
+  transform: scale(0.95);
+}
+
+.modal-enter-active {
+  opacity: 1;
+  transform: scale(1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .modal {
+    transition: none;
+  }
+
+  .modal-enter {
+    opacity: 1;
+    transform: none;
+  }
+}
+```
+
+## 浏览器支持
+
+| 浏览器 | 支持版本 |
+|--------|----------|
+| Chrome | 74+ |
+| Firefox | 63+ |
+| Safari | 10.1+ |
+| Edge | 79+ |
+| iOS Safari | 10.3+ |
+
+## 最佳实践
+
+1. **全局禁用非关键动画**：在 `@media (prefers-reduced-motion: reduce)` 中禁用不必要的动画
+2. **保留功能性动画**：如加载指示器，让用户知道系统在工作
+3. **使用 `prefers-reduced-motion`** 而不是完全禁用动画
+4. **添加过渡效果而非动画**：过渡比动画更轻量
+
+## 交互式演示
+
+{/* @playground id="prefers-reduced-motion-demo" mode="demo" */}

--- a/src/topics/12.fonts/css-font-display/index.mdx
+++ b/src/topics/12.fonts/css-font-display/index.mdx
@@ -1,0 +1,185 @@
+---
+title: CSS font-display 字体显示策略
+category: CSS 字体
+tags: [css, font, font-display, web-fonts, foit, fout]
+description: 详细介绍 font-display 属性如何控制 Web 字体加载时的显示策略，包括 swap、optional、block、fallback、auto 等值的行为和适用场景。
+keywords: font-display, web fonts, FOIT, FOUT, @font-face, 字体加载, 字体显示
+---
+
+font-display 属性控制 Web 字体加载过程中的文本显示行为。理解这个属性对于优化用户体验至关重要。
+
+## 基本概念
+
+### FOIT 和 FOUT
+
+- **FOIT (Flash of Invisible Text)**：字体加载期间文本不可见，造成闪烁问题
+- **FOUT (Flash of Unstyled Text)**：先用后备字体显示，加载后切换到自定义字体
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: swap;  /* 控制加载策略 */
+}
+```
+
+## font-display 取值
+
+### auto - 浏览器默认
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: auto;
+}
+```
+
+使用浏览器的默认字体加载策略，通常表现为 FOIT（文本在加载期间不可见）。
+
+### block - 短暂阻塞
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: block;
+}
+```
+
+- 阻塞时间约 **3 秒**
+- 超过则使用后备字体
+- 适合：希望保持视觉一致性，但愿意等待的情况
+
+### swap - 立即显示后备
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: swap;
+}
+```
+
+- **无阻塞**，立即显示后备字体
+- 字体加载完成后立即切换
+- 适合：图标字体、标题文字
+
+### fallback - 快速超时
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: fallback;
+}
+```
+
+- 阻塞时间极短（约 **100ms**）
+- 超时后使用后备字体
+- 如果字体未加载，下次访问时可能使用
+- 适合：正文文本，追求阅读体验
+
+### optional - 优先缓存
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: optional;
+}
+```
+
+- 如果字体已在缓存中使用，否则使用后备字体
+- 永远不会产生 FOUT
+- 适合：追求整体体验，不想文字跳动
+
+## 行为对比
+
+| 值 | 阻塞时间 | FOUT | 适用场景 |
+|---|---|---|---|
+| auto | 浏览器决定 | 可能 | 默认行为 |
+| block | ~3秒 | 是 | 视觉一致性优先 |
+| swap | 无 | 是 | 标题、图标 |
+| fallback | ~100ms | 是 | 正文文本 |
+| optional | 无/极短 | 否 | 最佳用户体验 |
+
+## 实际应用
+
+### 图标字体
+
+```css
+@font-face {
+  font-family: 'IconFont';
+  src: url('icons.woff2') format('woff2');
+  font-display: swap;  /* 图标需要立即显示 */
+}
+```
+
+### 正文文本
+
+```css
+@font-face {
+  font-family: 'BodyFont';
+  src: url('body.woff2') format('woff2');
+  font-display: optional;  /* 不希望文字跳动 */
+}
+```
+
+### 标题文字
+
+```css
+@font-face {
+  font-family: 'HeadingFont';
+  src: url('heading.woff2') format('woff2');
+  font-display: swap;  /* 允许轻微跳动但要显示 */
+}
+```
+
+## 性能优化
+
+### 结合预加载
+
+```html
+<!-- 预加载字体但不阻塞渲染 -->
+<link rel="preload" href="font.woff2" as="font" type="font/woff2" crossorigin>
+```
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('font.woff2') format('woff2');
+  font-display: swap;
+}
+```
+
+### 最佳实践
+
+1. 使用 **woff2** 格式，兼容性最好且压缩率高
+2. 图标字体使用 `swap`，正文使用 `optional`
+3. 考虑使用 `font-display: optional` 减少网络请求
+4. 为不同字符集定义不同字体以减小文件
+
+```css
+@font-face {
+  font-family: 'MyFont';
+  src: url('latin.woff2') format('woff2');
+  unicode-range: U+0000-00FF;
+  font-display: swap;
+}
+```
+
+## 浏览器支持
+
+所有现代浏览器都支持 `font-display` 属性。
+
+## 交互式演示
+
+{/* @playground id="css-font-display" mode="demo" */}
+
+## 总结
+
+- `swap` 适合需要立即显示的内容（标题、图标）
+- `optional` 适合正文，追求无跳动的阅读体验
+- `fallback` 是两者的折中方案
+- 选择合适的策略可以显著提升用户体验

--- a/src/topics/12.fonts/css-font-variation-settings/index.mdx
+++ b/src/topics/12.fonts/css-font-variation-settings/index.mdx
@@ -1,0 +1,232 @@
+---
+title: CSS font-variation-settings 可变字体
+category: CSS 字体
+tags: [css, font, variable-fonts, font-variation-settings,可变字体, opentype]
+description: 详细介绍可变字体（Variable Fonts）和 font-variation-settings 属性，如何通过轴控制字体的字重、宽度、倾斜等特性。
+keywords: font-variation-settings, 可变字体, Variable Fonts, wght, wdth, slnt, opentype
+---
+
+可变字体（Variable Fonts）是 OpenType 字体规范的重要发展，允许在单个字体文件中包含多个变体，通过轴（axis）来控制字体的外观。
+
+## 什么是可变字体？
+
+传统字体需要为每个字重（Regular、Bold、Light 等）单独的文件，而可变字体只需一个文件即可包含所有变体：
+
+```
+传统方式: Roboto-Regular.ttf, Roboto-Bold.ttf, Roboto-Light.ttf (3个文件)
+
+可变字体: RobotoFlex-Variable.ttf (1个文件，包含所有字重)
+```
+
+## 基本语法
+
+```css
+.element {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 400;
+}
+```
+
+## 常用特性轴
+
+### wght - 字重轴
+
+```css
+.text {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 700;  /* 粗体 */
+}
+```
+
+常用字重值：
+- 100 - Thin
+- 300 - Light
+- 400 - Regular
+- 500 - Medium
+- 700 - Bold
+- 900 - Black
+
+### wdth - 宽度轴
+
+```css
+.condensed {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wdth' 75;  /* 压缩字体 */
+}
+
+.expanded {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wdth' 125;  /* 扩展字体 */
+}
+```
+
+典型范围：75 - 125
+
+### slnt - 倾斜轴
+
+```css
+.italic-text {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'slnt' -12;  /* 倾斜12度 */
+}
+```
+
+典型范围：-10 - 0
+
+### ital - 斜体轴
+
+```css
+.italic {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'ital' 1;  /* 1 = 斜体，0 = 正体 */
+}
+```
+
+### opsz - 光学尺寸
+
+```css
+.caption {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'opsz' 8;  /* 小字号优化 */
+}
+
+.heading {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'opsz' 48;  /* 大字号优化 */
+}
+```
+
+## 组合使用多个轴
+
+```css
+.heading {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 700, 'wdth' 95, 'opsz' 24;
+  font-size: 48px;
+}
+```
+
+## 与标准字体属性的关系
+
+```css
+.text {
+  font-family: 'Roboto Flex', sans-serif;
+  
+  /* 标准属性 */
+  font-weight: 500;
+  font-stretch: 95%;
+  
+  /* 可变字体轴（更高精度控制） */
+  font-variation-settings: 'wght' 500, 'wdth' 95;
+}
+```
+
+当同时使用时，标准属性会被转换为 `font-variation-settings`。
+
+## 常用可变字体推荐
+
+### Google Fonts 可变字体
+
+| 字体名称 | 支持的轴 | 用途 |
+|---|---|---|
+| Roboto Flex | wght, wdth, slnt, opsz | 通用 |
+| Inter | wght | 界面字体 |
+|Recursive | wght, slnt, MONO, CASL | 多功能 |
+| Source Sans 3 | wght, wdth, ital, slnt | 文档 |
+| Amstelvar | wght, opsz, XTRA, YOPQ | 优雅衬线 |
+
+### 使用示例
+
+```css
+/* 来自 Google Fonts */
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Flex:opsz,slnt,wdth,wght@8..144,-10..0,75..125,100..1000&display=swap');
+
+h1 {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 700;
+}
+
+.condensed-text {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 400, 'wdth' 75;
+}
+```
+
+## 浏览器支持
+
+所有现代浏览器都支持 `font-variation-settings`。
+
+## 可变字体轴注册表
+
+除了自定义轴，还有注册的标准化轴：
+
+| 轴名 | 全称 | 说明 |
+|---|---|---|
+| wght | Weight | 字重 |
+| wdth | Width | 字宽 |
+| ital | Italic | 斜体 |
+| slnt | Slant | 倾斜 |
+| opsz | Optical Size | 光学尺寸 |
+| GRAD | Grade | 字重等级 |
+| XTRA | Counter | 轮廓对比度 |
+| YOPQ | Y Opaque | 不透明度 |
+| GRAD | Grade | 等级 |
+
+## 实际应用场景
+
+### 响应式字体
+
+```css
+.text {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 300;
+}
+
+@media (min-width: 768px) {
+  .text {
+    font-variation-settings: 'wght' 400;
+  }
+}
+
+@media (min-width: 1200px) {
+  .text {
+    font-variation-settings: 'wght' 500;
+  }
+}
+```
+
+### 交互式字体
+
+```css
+.button {
+  font-family: 'Roboto Flex', sans-serif;
+  font-variation-settings: 'wght' 500;
+  transition: font-variation-settings 0.2s;
+}
+
+.button:hover {
+  font-variation-settings: 'wght' 700;
+}
+```
+
+### 性能优化
+
+```css
+@font-face {
+  font-family: 'MyVariableFont';
+  src: url('font.woff2') format('woff2-variations');
+  font-display: optional;  /* 不可用时使用后备字体 */
+}
+```
+
+## 交互式演示
+
+{/* @playground id="css-font-variation-settings" mode="demo" */}
+
+## 总结
+
+- 可变字体通过单一文件支持多种字形变体
+- 使用 `font-variation-settings` 控制各个轴
+- 常用轴：wght（字重）、wdth（宽度）、slnt（倾斜）、opsz（光学尺寸）
+- 可以动态调整实现平滑的字体动画
+- 相比传统多文件字体，更节省带宽


### PR DESCRIPTION
新增 docs/css/text-overflow.md，整理 CSS text-overflow 完整指南。

### 包含内容
- text-overflow 基础概念（必须配合 white-space: nowrap + overflow: hidden）
- clip/ellipsis/string 三种值的区别
- 单行文本溢出：基础写法 + 渐变提示
- 多行文本溢出：line-clamp（WebKit）+ 降级方案 + JS 实现
- 双方向溢出：overflow-x/y + RTL 方向处理
- 与 Flex/Grid 布局的配合：min-width: 0 的关键作用
- 常见问题及解决方案

### 关联
- GitHub Issue: zenHeart/learn-css#10
- Jarvis 委派 recvfpDUIxF0Nm