### PR TITLE
[zen-css-41] CSS Houdini Paint API

### DIFF
--- a/examples/css/demos/houdini-paint-api/ctx-methods-demo.html
+++ b/examples/css/demos/houdini-paint-api/ctx-methods-demo.html
@@ -1,0 +1,329 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Houdini Paint API — ctx 绘图方法演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 14px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .section h3 { font-size: 14px; color: #8b949e; margin: 16px 0 8px; }
+    .demo-canvas { display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 16px; }
+    .canvas-item { flex: 1; min-width: 200px; }
+    .canvas-box { height: 150px; border-radius: 8px; border: 1px solid #30363d; margin-bottom: 8px; position: relative; }
+    .canvas-label { font-size: 12px; color: #8b949e; text-align: center; }
+    .info { font-size: 13px; color: #8b949e; margin-top: 12px; padding: 12px; background: rgba(88,166,255,0.1); border-radius: 4px; border-left: 3px solid #58a6ff; }
+    .warning { font-size: 13px; color: #f0883e; margin-top: 12px; padding: 12px; background: rgba(240,136,62,0.1); border-radius: 4px; border-left: 3px solid #f0883e; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; margin-top: 12px; }
+    table { width: 100%; border-collapse: collapse; font-size: 13px; }
+    th, td { padding: 8px 12px; text-align: left; border-bottom: 1px solid #30363d; }
+    th { color: #58a6ff; font-weight: 600; }
+    td:first-child { color: #f0883e; font-family: monospace; }
+    tr:hover { background: rgba(88,166,255,0.05); }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 600; margin-right: 4px; }
+    .badge-yes { background: #238636; color: #fff; }
+    .badge-no { background: #da3633; color: #fff; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Houdini Paint API — ctx 绘图方法详解</h1>
+    <p class="subtitle">paint(ctx, geom, properties) 回调中 ctx 绘图上下文支持的常用方法</p>
+
+    <div class="info">
+      <strong>浏览器支持：</strong>
+      <span class="badge badge-yes">Chrome 65+</span>
+      <span class="badge badge-yes">Edge 79+</span>
+      <span class="badge badge-no">Firefox ❌</span>
+      <span class="badge badge-no">Safari ❌</span>
+      &nbsp;|&nbsp; 需要 HTTP 服务器或 localhost 访问
+    </div>
+
+    <!-- 矩形操作 -->
+    <div class="section">
+      <h2>1. 矩形操作方法</h2>
+      <div class="demo-canvas" id="rect-demos">
+        <div class="canvas-item">
+          <div class="canvas-box" id="rect-fill"></div>
+          <p class="canvas-label">fillRect — 填充矩形</p>
+        </div>
+        <div class="canvas-item">
+          <div class="canvas-box" id="rect-stroke"></div>
+          <p class="canvas-label">strokeRect — 描边矩形</p>
+        </div>
+        <div class="canvas-item">
+          <div class="canvas-box" id="rect-clear"></div>
+          <p class="canvas-label">clearRect — 清除区域</p>
+        </div>
+      </div>
+      <div class="code-block">paint(ctx, geom) {
+  // 填充矩形
+  ctx.fillStyle = '#6366f1';
+  ctx.fillRect(10, 10, 80, 50);
+
+  // 描边矩形
+  ctx.strokeStyle = '#ec4899';
+  ctx.lineWidth = 3;
+  ctx.strokeRect(10, 70, 80, 50);
+
+  // 清除区域（透明）
+  ctx.clearRect(30, 30, 40, 40);
+}</div>
+    </div>
+
+    <!-- 渐变 -->
+    <div class="section">
+      <h2>2. 渐变方法</h2>
+      <div class="demo-canvas" id="gradient-demos">
+        <div class="canvas-item">
+          <div class="canvas-box" id="gradient-linear"></div>
+          <p class="canvas-label">createLinearGradient</p>
+        </div>
+        <div class="canvas-item">
+          <div class="canvas-box" id="gradient-radial"></div>
+          <p class="canvas-label">createRadialGradient</p>
+        </div>
+      </div>
+      <div class="code-block">// 线性渐变
+const linear = ctx.createLinearGradient(0, 0, geom.width, geom.height);
+linear.addColorStop(0, '#f97316');
+linear.addColorStop(0.5, '#eab308');
+linear.addColorStop(1, '#22c55e');
+ctx.fillStyle = linear;
+ctx.fillRect(0, 0, geom.width, geom.height);
+
+// 径向渐变
+const radial = ctx.createRadialGradient(
+  geom.width/2, geom.height/2, 0,
+  geom.width/2, geom.height/2, geom.width/2
+);
+radial.addColorStop(0, '#fff');
+radial.addColorStop(1, '#000');
+ctx.fillStyle = radial;
+ctx.fillRect(0, 0, geom.width, geom.height);</div>
+    </div>
+
+    <!-- 路径绘制 -->
+    <div class="section">
+      <h2>3. 路径绘制方法</h2>
+      <div class="demo-canvas" id="path-demos">
+        <div class="canvas-item">
+          <div class="canvas-box" id="path-circle"></div>
+          <p class="canvas-label">arc — 圆弧</p>
+        </div>
+        <div class="canvas-item">
+          <div class="canvas-box" id="path-polygon"></div>
+          <p class="canvas-label">lineTo — 多边形</p>
+        </div>
+        <div class="canvas-item">
+          <div class="canvas-box" id="path-heart"></div>
+          <p class="canvas-label">bezierCurveTo — 爱心</p>
+        </div>
+      </div>
+      <div class="code-block">// 圆弧
+ctx.beginPath();
+ctx.arc(geom.width/2, geom.height/2, 40, 0, Math.PI * 2);
+ctx.fillStyle = '#f97316';
+ctx.fill();
+
+// 多边形
+ctx.beginPath();
+ctx.moveTo(geom.width/2, 10);
+ctx.lineTo(geom.width - 10, geom.height - 10);
+ctx.lineTo(10, geom.height - 10);
+ctx.closePath();
+ctx.fillStyle = '#8b5cf6';
+ctx.fill();
+
+// 贝塞尔曲线
+ctx.beginPath();
+ctx.moveTo(geom.width/2, geom.height);
+ctx.bezierCurveTo(0, geom.height*0.7, 0, geom.height*0.3, geom.width/2, geom.height*0.3);
+ctx.bezierCurveTo(geom.width, geom.height*0.3, geom.width, geom.height*0.7, geom.width/2, geom.height);
+ctx.fillStyle = '#ec4899';
+ctx.fill();</div>
+    </div>
+
+    <!-- 方法对照表 -->
+    <div class="section">
+      <h2>4. ctx 方法速查表</h2>
+      <table>
+        <thead>
+          <tr><th>方法</th><th>说明</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>fillRect(x,y,w,h)</td><td>填充矩形区域</td></tr>
+          <tr><td>strokeRect(x,y,w,h)</td><td>描边矩形区域</td></tr>
+          <tr><td>clearRect(x,y,w,h)</td><td>清除矩形区域（变透明）</td></tr>
+          <tr><td>createLinearGradient(x0,y0,x1,y1)</td><td>创建线性渐变</td></tr>
+          <tr><td>createRadialGradient(x0,y0,r0,x1,y1,r1)</td><td>创建径向渐变</td></tr>
+          <tr><td>beginPath()</td><td>开始新路径</td></tr>
+          <tr><td>moveTo(x,y)</td><td>移动画笔到坐标</td></tr>
+          <tr><td>lineTo(x,y)</td><td>画线到坐标</td></tr>
+          <tr><td>arc(x,y,r,start,end)</td><td>画圆弧</td></tr>
+          <tr><td>bezierCurveTo(cp1x,cp1y,cp2x,cp2y,x,y)</td><td>贝塞尔曲线</td></tr>
+          <tr><td>quadraticCurveTo(cpx,cpy,x,y)</td><td>二次贝塞尔曲线</td></tr>
+          <tr><td>closePath()</td><td>闭合路径</td></tr>
+          <tr><td>fill()</td><td>填充路径</td></tr>
+          <tr><td>stroke()</td><td>描边路径</td></tr>
+          <tr><td>clip()</td><td>裁剪后续绘制区域</td></tr>
+          <tr><td>save()</td><td>保存绘图状态</td></tr>
+          <tr><td>restore()</td><td>恢复绘图状态</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- inputProperties 示例 -->
+    <div class="section">
+      <h2>5. inputProperties 自定义属性</h2>
+      <div class="demo-canvas" id="props-demo">
+        <div class="canvas-item">
+          <div class="canvas-box" id="props-box"></div>
+          <p class="canvas-label">--custom-color / --custom-size</p>
+        </div>
+      </div>
+      <div class="code-block">class CustomPaint {
+  // 声明要监听的自定义属性
+  static get inputProperties() {
+    return ['--custom-color', '--custom-size'];
+  }
+
+  paint(ctx, geom, properties) {
+    // 读取自定义属性值
+    const color = properties.get('--custom-color')?.toString() || '#6366f1';
+    const size = parseFloat(properties.get('--custom-size')) || 20;
+
+    ctx.fillStyle = color;
+    ctx.beginPath();
+    ctx.arc(geom.width/2, geom.height/2, size, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+registerPaint('custom-circle', CustomPaint);
+
+/* CSS 使用 */
+.element {
+  --custom-color: #ec4899;
+  --custom-size: 30;
+  background-image: paint(custom-circle);
+}</div>
+    </div>
+
+  </div>
+
+  <script>
+    // 模拟 paint() 方法的 Canvas 渲染
+    // 注：在真实 Houdini 中，这些需要 worklet 文件和 CSS.paintWorklet.addModule()
+    // 这里用 Canvas 2D API 直接渲染来演示 ctx 方法
+
+    function simulatePaint(demoId, paintFn) {
+      const el = document.getElementById(demoId);
+      const canvas = document.createElement('canvas');
+      canvas.width = el.offsetWidth;
+      canvas.height = el.offsetHeight;
+      el.appendChild(canvas);
+      const ctx = canvas.getContext('2d');
+      const geom = { width: canvas.width, height: canvas.height };
+      paintFn(ctx, geom);
+    }
+
+    // 1. 矩形操作
+    simulatePaint('rect-fill', (ctx, geom) => {
+      ctx.fillStyle = '#6366f1';
+      ctx.fillRect(10, 10, 80, 50);
+      ctx.fillStyle = '#8b5cf6';
+      ctx.fillRect(50, 30, 80, 50);
+    });
+
+    simulatePaint('rect-stroke', (ctx, geom) => {
+      ctx.strokeStyle = '#ec4899';
+      ctx.lineWidth = 3;
+      ctx.strokeRect(10, 10, 80, 50);
+      ctx.strokeStyle = '#f97316';
+      ctx.lineWidth = 2;
+      ctx.strokeRect(50, 30, 80, 50);
+    });
+
+    simulatePaint('rect-clear', (ctx, geom) => {
+      ctx.fillStyle = '#3b82f6';
+      ctx.fillRect(0, 0, geom.width, geom.height);
+      ctx.clearRect(30, 30, geom.width - 60, geom.height - 60);
+    });
+
+    // 2. 渐变
+    simulatePaint('gradient-linear', (ctx, geom) => {
+      const grad = ctx.createLinearGradient(0, 0, geom.width, geom.height);
+      grad.addColorStop(0, '#f97316');
+      grad.addColorStop(0.5, '#eab308');
+      grad.addColorStop(1, '#22c55e');
+      ctx.fillStyle = grad;
+      ctx.fillRect(0, 0, geom.width, geom.height);
+    });
+
+    simulatePaint('gradient-radial', (ctx, geom) => {
+      const grad = ctx.createRadialGradient(
+        geom.width/2, geom.height/2, 5,
+        geom.width/2, geom.height/2, geom.width/2
+      );
+      grad.addColorStop(0, '#fff');
+      grad.addColorStop(0.5, '#fbbf24');
+      grad.addColorStop(1, '#000');
+      ctx.fillStyle = grad;
+      ctx.fillRect(0, 0, geom.width, geom.height);
+    });
+
+    // 3. 路径
+    simulatePaint('path-circle', (ctx, geom) => {
+      ctx.fillStyle = '#f97316';
+      ctx.beginPath();
+      ctx.arc(geom.width/2, geom.height/2, 40, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = '#fff';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    });
+
+    simulatePaint('path-polygon', (ctx, geom) => {
+      const cx = geom.width/2, cy = geom.height/2, r = 50, sides = 6;
+      ctx.fillStyle = '#8b5cf6';
+      ctx.beginPath();
+      for (let i = 0; i <= sides; i++) {
+        const angle = (i / sides) * Math.PI * 2 - Math.PI / 2;
+        const x = cx + r * Math.cos(angle);
+        const y = cy + r * Math.sin(angle);
+        if (i === 0) ctx.moveTo(x, y);
+        else ctx.lineTo(x, y);
+      }
+      ctx.fill();
+      ctx.strokeStyle = '#fff';
+      ctx.lineWidth = 2;
+      ctx.stroke();
+    });
+
+    simulatePaint('path-heart', (ctx, geom) => {
+      const cx = geom.width/2, cy = geom.height/2, scale = Math.min(geom.width, geom.height) / 150;
+      ctx.fillStyle = '#ec4899';
+      ctx.beginPath();
+      ctx.moveTo(cx, cy + 30 * scale);
+      ctx.bezierCurveTo(cx - 40*scale, cy - 10*scale, cx - 60*scale, cy + 20*scale, cx, cy + 50*scale);
+      ctx.bezierCurveTo(cx + 60*scale, cy + 20*scale, cx + 40*scale, cy - 10*scale, cx, cy + 30*scale);
+      ctx.fill();
+    });
+
+    // 5. 自定义属性（模拟）
+    simulatePaint('props-box', (ctx, geom) => {
+      const color = '#ec4899';
+      const size = 30;
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      ctx.arc(geom.width/2, geom.height/2, size, 0, Math.PI * 2);
+      ctx.fill();
+    });
+  </script>
+</body>
+</html>

--- a/examples/css/demos/houdini-paint-api/index.html
+++ b/examples/css/demos/houdini-paint-api/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Houdini Paint API — 示例总览</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 28px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 14px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .info { font-size: 13px; color: #8b949e; margin-bottom: 24px; padding: 12px; background: rgba(88,166,255,0.1); border-radius: 4px; border-left: 3px solid #58a6ff; }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; }
+    .demo-card { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; transition: all 0.15s; cursor: pointer; text-decoration: none; color: inherit; display: block; }
+    .demo-card:hover { border-color: #58a6ff; transform: translateY(-2px); }
+    .demo-card h3 { font-size: 15px; color: #f0f6fc; margin-bottom: 8px; }
+    .demo-card p { font-size: 13px; color: #8b949e; line-height: 1.5; }
+    .demo-card .tag { display: inline-block; padding: 2px 8px; background: #21262d; border-radius: 4px; font-size: 11px; color: #58a6ff; margin-top: 8px; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 600; margin-right: 4px; }
+    .badge-yes { background: #238636; color: #fff; }
+    .badge-no { background: #da3633; color: #fff; }
+    .warning { font-size: 13px; color: #f0883e; margin-top: 12px; padding: 12px; background: rgba(240,136,62,0.1); border-radius: 4px; border-left: 3px solid #f0883e; margin-bottom: 24px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Houdini Paint API</h1>
+    <p class="subtitle">通过 registerPaint 注册自定义 paint worklet，在 CSS 中绘制任意图案</p>
+
+    <div class="warning">
+      ⚠️ Houdini Paint API 需要通过 <strong>HTTP 服务器</strong> 访问才能运行。<br>
+      启动方式：<code>python -m http.server 8080</code> 或 <code>npx serve .</code>
+    </div>
+
+    <div class="info">
+      <strong>浏览器支持：</strong>
+      <span class="badge badge-yes">Chrome 65+</span>
+      <span class="badge badge-yes">Edge 79+</span>
+      <span class="badge badge-no">Firefox ❌</span>
+      <span class="badge badge-no">Safari ❌</span>
+    </div>
+
+    <div class="demo-grid">
+      <a class="demo-card" href="basic-paint.html">
+        <h3>基础图案示例</h3>
+        <p>圆点、棋盘格、条纹渐变、六边形网格、波浪背景等 5 种基础图案的 worklet 实现。</p>
+        <span class="tag">入门级</span>
+      </a>
+
+      <a class="demo-card" href="interactive-demo.html">
+        <h3>交互式演示</h3>
+        <p>Blob 动画（@property 驱动）、多边形边框、棋盘格遮罩。包含滑块控制和颜色切换。</p>
+        <span class="tag">进阶</span>
+      </a>
+
+      <a class="demo-card" href="ctx-methods-demo.html">
+        <h3>ctx 绘图方法详解</h3>
+        <p>矩形操作、渐变、路径绘制的完整演示。包含方法速查表和 inputProperties 示例。</p>
+        <span class="tag">参考</span>
+      </a>
+    </div>
+
+    <div style="margin-top:32px;">
+      <h2 style="font-size:16px;color:#f0f6fc;margin-bottom:12px;">Worklet 文件</h2>
+      <ul style="font-size:13px;color:#8b949e;list-style:disc;padding-left:20px;line-height:2;">
+        <li><code>worklets/basic-patterns.js</code> — Blob 动画 worklet</li>
+        <li><code>worklets/polygon-border.js</code> — 多边形边框 worklet</li>
+        <li><code>worklets/checkerboard.js</code> — 棋盘格遮罩 worklet</li>
+      </ul>
+    </div>
+  </div>
+</body>
+</html>

--- a/examples/css/demos/houdini-paint-api/interactive-demo.html
+++ b/examples/css/demos/houdini-paint-api/interactive-demo.html
@@ -1,0 +1,332 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CSS Houdini Paint API — 交互式演示</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; background: #0d1117; color: #c9d1d9; min-height: 100vh; padding: 24px; }
+    h1 { font-size: 24px; margin-bottom: 8px; color: #f0f6fc; }
+    .subtitle { font-size: 14px; color: #8b949e; margin-bottom: 24px; }
+    .container { max-width: 960px; margin: 0 auto; }
+    .section { background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 20px; margin-bottom: 20px; }
+    .section h2 { font-size: 16px; color: #f0f6fc; margin-bottom: 16px; padding-bottom: 8px; border-bottom: 1px solid #30363d; }
+    .demo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 16px; margin-bottom: 16px; }
+    .demo-box { height: 200px; border-radius: 8px; border: 1px solid #30363d; display: flex; align-items: center; justify-content: center; flex-direction: column; gap: 12px; position: relative; }
+    .demo-label { font-size: 12px; color: #8b949e; text-align: center; }
+    .controls { display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px; }
+    .btn { padding: 6px 14px; background: #21262d; border: 1px solid #30363d; border-radius: 4px; color: #c9d1d9; font-size: 13px; cursor: pointer; transition: all 0.15s; }
+    .btn:hover { background: #30363d; border-color: #58a6ff; }
+    .btn.active { background: #388bfd33; border-color: #58a6ff; color: #58a6ff; }
+    .code-block { background: #0d1117; border: 1px solid #30363d; border-radius: 4px; padding: 12px; font-family: 'SF Mono', Monaco, monospace; font-size: 12px; overflow-x: auto; white-space: pre-wrap; word-break: break-all; color: #79c0ff; margin-top: 12px; }
+    .info { font-size: 13px; color: #8b949e; margin-top: 12px; padding: 12px; background: rgba(88,166,255,0.1); border-radius: 4px; border-left: 3px solid #58a6ff; }
+    .warning { font-size: 13px; color: #f0883e; margin-top: 12px; padding: 12px; background: rgba(240,136,62,0.1); border-radius: 4px; border-left: 3px solid #f0883e; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 12px; font-weight: 600; margin-right: 4px; }
+    .badge-yes { background: #238636; color: #fff; }
+    .badge-no { background: #da3633; color: #fff; }
+    .info-bar { display: flex; gap: 16px; align-items: center; margin-bottom: 16px; flex-wrap: wrap; }
+    .slider-control { display: flex; flex-direction: column; gap: 4px; flex: 1; min-width: 200px; }
+    .slider-label { font-size: 12px; color: #8b949e; display: flex; justify-content: space-between; }
+    input[type="range"] { -webkit-appearance: none; background: #30363d; border-radius: 4px; height: 6px; cursor: pointer; }
+    input[type="range"]::-webkit-slider-thumb { -webkit-appearance: none; width: 14px; height: 14px; background: #58a6ff; border-radius: 50%; cursor: pointer; }
+    .demo-area { background: #fff; border-radius: 8px; padding: 20px; margin-bottom: 16px; }
+    .tab-nav { display: flex; gap: 4px; margin-bottom: 16px; border-bottom: 1px solid #30363d; }
+    .tab-btn { padding: 8px 16px; background: transparent; border: none; color: #8b949e; cursor: pointer; font-size: 14px; border-bottom: 2px solid transparent; margin-bottom: -1px; transition: all 0.15s; }
+    .tab-btn:hover { color: #c9d1d9; }
+    .tab-btn.active { color: #58a6ff; border-bottom-color: #58a6ff; }
+    .tab-content { display: none; }
+    .tab-content.active { display: block; }
+    .color-swatches { display: flex; gap: 8px; flex-wrap: wrap; }
+    .swatch { width: 28px; height: 28px; border-radius: 4px; cursor: pointer; border: 2px solid transparent; transition: all 0.15s; }
+    .swatch:hover { transform: scale(1.1); }
+    .swatch.active { border-color: #fff; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>CSS Houdini Paint API — 交互式演示</h1>
+    <p class="subtitle">通过 registerPaint 注册自定义 paint worklet，在 CSS 中绘制任意图案</p>
+
+    <div class="info-bar">
+      <span><strong>浏览器支持：</strong></span>
+      <span class="badge badge-yes">Chrome 65+</span>
+      <span class="badge badge-yes">Edge 79+</span>
+      <span class="badge badge-no">Firefox ❌</span>
+      <span class="badge badge-no">Safari ❌</span>
+    </div>
+
+    <div class="warning">
+      ⚠️ Houdini Paint API 需要通过 <strong>HTTP 服务器</strong>或 <strong>localhost</strong> 访问才能运行（不能直接打开本地 HTML 文件）。<br>
+      启动方式：<code>python -m http.server 8080</code> 或 <code>npx serve .</code>，然后访问 <code>http://localhost:8080/interactive-demo.html</code>
+    </div>
+
+    <!-- Tab 导航 -->
+    <div class="tab-nav">
+      <button class="tab-btn active" data-tab="blob">Blob 动画</button>
+      <button class="tab-btn" data-tab="polygon">多边形边框</button>
+      <button class="tab-btn" data-tab="checker">棋盘格遮罩</button>
+    </div>
+
+    <!-- Tab 1: Blob 动画 -->
+    <div class="tab-content active" id="tab-blob">
+      <div class="section">
+        <h2>Blob 动画（配合 @property）</h2>
+        <div class="demo-area">
+          <div class="demo-box" id="blob-demo" style="width:100%;height:200px;">
+            <span class="demo-label">--blob-radius 动画驱动</span>
+          </div>
+        </div>
+
+        <div class="controls">
+          <button class="btn" id="blob-animate-btn">▶ 开始动画</button>
+          <div class="slider-control">
+            <div class="slider-label">
+              <span>半径</span>
+              <span id="radius-val">50</span>
+            </div>
+            <input type="range" id="blob-radius" min="20" max="100" value="50">
+          </div>
+        </div>
+
+        <div style="margin-top:12px;" class="color-swatches">
+          <span style="font-size:12px;color:#8b949e;">颜色：</span>
+          <div class="swatch active" style="background:#6366f1;" data-color="#6366f1"></div>
+          <div class="swatch" style="background:#ec4899;" data-color="#ec4899"></div>
+          <div class="swatch" style="background:#f97316;" data-color="#f97316"></div>
+          <div class="swatch" style="background:#22c55e;" data-color="#22c55e"></div>
+          <div class="swatch" style="background:#3b82f6;" data-color="#3b82f6"></div>
+        </div>
+
+        <div class="code-block">/* CSS */
+@property --blob-radius {
+  syntax: '<number>';
+  initial-value: 50;
+  inherits: false;
+}
+
+.blob-element {
+  --blob-radius: 50;
+  --blob-color: #6366f1;
+  background-image: paint(blob);
+}
+
+/* JavaScript 动画驱动 */
+element.style.setProperty('--blob-radius', newValue);</div>
+      </div>
+    </div>
+
+    <!-- Tab 2: 多边形边框 -->
+    <div class="tab-content" id="tab-polygon">
+      <div class="section">
+        <h2>多边形边框（交互控制）</h2>
+        <div class="demo-area">
+          <div class="demo-box" id="polygon-demo" style="width:100%;height:200px;">
+            <span class="demo-label">--polygon-sides 交互控制</span>
+          </div>
+        </div>
+
+        <div class="controls">
+          <button class="btn active" data-sides="3">三角形</button>
+          <button class="btn" data-sides="4">四边形</button>
+          <button class="btn" data-sides="5">五边形</button>
+          <button class="btn" data-sides="6">六边形</button>
+          <button class="btn" data-sides="8">八边形</button>
+          <button class="btn" data-sides="12">十二边形</button>
+        </div>
+
+        <div class="slider-control" style="margin-top:12px;">
+          <div class="slider-label">
+            <span>边框宽度</span>
+            <span id="stroke-val">3</span>
+          </div>
+          <input type="range" id="stroke-width" min="1" max="10" value="3">
+        </div>
+
+        <div style="margin-top:12px;" class="color-swatches">
+          <span style="font-size:12px;color:#8b949e;">颜色：</span>
+          <div class="swatch active" style="background:#3b82f6;" data-color="#3b82f6"></div>
+          <div class="swatch" style="background:#ef4444;" data-color="#ef4444"></div>
+          <div class="swatch" style="background:#22c55e;" data-color="#22c55e"></div>
+          <div class="swatch" style="background:#f59e0b;" data-color="#f59e0b"></div>
+          <div class="swatch" style="background:#8b5cf6;" data-color="#8b5cf6"></div>
+        </div>
+
+        <div class="code-block">/* HTML */
+&lt;div id="polygon-demo"&gt;&lt;/div&gt;
+
+/* JavaScript */
+demo.style.setProperty('--polygon-sides', 6);
+demo.style.setProperty('--polygon-color', '#3b82f6');
+demo.style.setProperty('--polygon-stroke-width', 3);</div>
+      </div>
+    </div>
+
+    <!-- Tab 3: 棋盘格遮罩 -->
+    <div class="tab-content" id="tab-checker">
+      <div class="section">
+        <h2>棋盘格遮罩（图像处理）</h2>
+        <div class="demo-area">
+          <div style="position:relative;width:100%;height:200px;border-radius:8px;overflow:hidden;">
+            <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='400' height='200'%3E%3Crect fill='%23334155' width='400' height='200'/%3E%3Ccircle cx='200' cy='100' r='60' fill='%23f97316'/%3E%3Ccircle cx='160' cy='80' r='20' fill='%23fbbf24'/%3E%3Ccircle cx='240' cy='120' r='30' fill='%23ef4444'/%3E%3C/svg%3E" style="width:100%;height:100%;object-fit:cover;" alt="示例图片">
+            <div id="checker-overlay" style="position:absolute;inset:0;mix-blend-mode:multiply;background:#888;"></div>
+          </div>
+        </div>
+
+        <div class="slider-control">
+          <div class="slider-label">
+            <span>格子大小</span>
+            <span id="size-val">16</span>
+          </div>
+          <input type="range" id="checker-size" min="4" max="64" value="16">
+        </div>
+
+        <div class="code-block">/* CSS */
+.checker-overlay {
+  background-image: paint(checkerboard);
+  --checkerboard-size: 16;
+  --checkerboard-color: rgba(0,0,0,0.5);
+  mix-blend-mode: multiply;
+}</div>
+      </div>
+    </div>
+
+  </div>
+
+  <script>
+    // Tab 切换
+    document.querySelectorAll('.tab-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+        document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+        btn.classList.add('active');
+        document.getElementById('tab-' + btn.dataset.tab).classList.add('active');
+      });
+    });
+
+    // 检查是否支持 Paint Worklet
+    if ('paintWorklet' in CSS) {
+      // 加载 worklet
+      CSS.paintWorklet.addModule('worklets/basic-patterns.js');
+      CSS.paintWorklet.addModule('worklets/polygon-border.js');
+      CSS.paintWorklet.addModule('worklets/checkerboard.js');
+
+      // === Blob Demo ===
+      const blobDemo = document.getElementById('blob-demo');
+      const blobRadiusSlider = document.getElementById('blob-radius');
+      const radiusVal = document.getElementById('radius-val');
+      const blobAnimateBtn = document.getElementById('blob-animate-btn');
+      let blobColor = '#6366f1';
+      let isAnimating = false;
+      let animFrame;
+
+      // 初始化 blob
+      blobDemo.style.setProperty('--blob-radius', '50');
+      blobDemo.style.setProperty('--blob-color', blobColor);
+      blobDemo.style.backgroundImage = 'paint(blob)';
+
+      // 滑块控制
+      blobRadiusSlider.addEventListener('input', e => {
+        const val = e.target.value;
+        radiusVal.textContent = val;
+        blobDemo.style.setProperty('--blob-radius', val);
+      });
+
+      // 颜色选择
+      document.querySelectorAll('#tab-blob .swatch').forEach(s => {
+        s.addEventListener('click', () => {
+          document.querySelectorAll('#tab-blob .swatch').forEach(sw => sw.classList.remove('active'));
+          s.classList.add('active');
+          blobColor = s.dataset.color;
+          blobDemo.style.setProperty('--blob-color', blobColor);
+        });
+      });
+
+      // 动画
+      let start = null;
+      function animateBlob(timestamp) {
+        if (!start) start = timestamp;
+        const elapsed = timestamp - start;
+        const t = (elapsed % 2000) / 2000;
+        const eased = 0.5 + 0.5 * Math.sin(t * Math.PI * 2 - Math.PI / 2);
+        const radius = 30 + eased * 70;
+        blobDemo.style.setProperty('--blob-radius', radius.toFixed(1));
+        radiusVal.textContent = radius.toFixed(0);
+        blobRadiusSlider.value = radius;
+        animFrame = requestAnimationFrame(animateBlob);
+      }
+
+      blobAnimateBtn.addEventListener('click', () => {
+        isAnimating = !isAnimating;
+        if (isAnimating) {
+          blobAnimateBtn.textContent = '⏸ 暂停';
+          blobAnimateBtn.classList.add('active');
+          start = null;
+          animFrame = requestAnimationFrame(animateBlob);
+        } else {
+          blobAnimateBtn.textContent = '▶ 开始动画';
+          blobAnimateBtn.classList.remove('active');
+          cancelAnimationFrame(animFrame);
+        }
+      });
+
+      // === Polygon Demo ===
+      const polygonDemo = document.getElementById('polygon-demo');
+      const strokeSlider = document.getElementById('stroke-width');
+      const strokeVal = document.getElementById('stroke-val');
+      let polygonColor = '#3b82f6';
+
+      polygonDemo.style.setProperty('--polygon-sides', '3');
+      polygonDemo.style.setProperty('--polygon-color', polygonColor);
+      polygonDemo.style.setProperty('--polygon-stroke-width', '3');
+      polygonDemo.style.backgroundImage = 'paint(polygon-border)';
+
+      document.querySelectorAll('[data-sides]').forEach(btn => {
+        btn.addEventListener('click', () => {
+          document.querySelectorAll('[data-sides]').forEach(b => b.classList.remove('active'));
+          btn.classList.add('active');
+          polygonDemo.style.setProperty('--polygon-sides', btn.dataset.sides);
+        });
+      });
+
+      strokeSlider.addEventListener('input', e => {
+        const val = e.target.value;
+        strokeVal.textContent = val;
+        polygonDemo.style.setProperty('--polygon-stroke-width', val);
+      });
+
+      document.querySelectorAll('#tab-polygon .swatch').forEach(s => {
+        s.addEventListener('click', () => {
+          document.querySelectorAll('#tab-polygon .swatch').forEach(sw => sw.classList.remove('active'));
+          s.classList.add('active');
+          polygonColor = s.dataset.color;
+          polygonDemo.style.setProperty('--polygon-color', polygonColor);
+        });
+      });
+
+      // === Checker Demo ===
+      const checkerOverlay = document.getElementById('checker-overlay');
+      const checkerSizeSlider = document.getElementById('checker-size');
+      const sizeVal = document.getElementById('size-val');
+
+      checkerOverlay.style.setProperty('--checkerboard-size', '16');
+      checkerOverlay.style.setProperty('--checkerboard-color', 'rgba(0,0,0,0.3)');
+      checkerOverlay.style.backgroundImage = 'paint(checkerboard)';
+
+      checkerSizeSlider.addEventListener('input', e => {
+        const val = e.target.value;
+        sizeVal.textContent = val;
+        checkerOverlay.style.setProperty('--checkerboard-size', val);
+      });
+
+    } else {
+      // 不支持时的降级
+      document.querySelector('.warning').innerHTML =
+        '⚠️ 当前浏览器不支持 CSS Paint API。请使用 <strong>Chrome 65+</strong> 或 <strong>Edge 79+</strong> 访问此页面。';
+      document.querySelectorAll('.demo-box, .demo-area').forEach(el => {
+        el.style.background = 'repeating-conic-gradient(#ccc 0% 25%, #fff 0% 50%) 50%/20px 20px';
+      });
+    }
+  </script>
+</body>
+</html>

--- a/examples/css/demos/houdini-paint-api/worklets/basic-patterns.js
+++ b/examples/css/demos/houdini-paint-api/worklets/basic-patterns.js
@@ -1,0 +1,37 @@
+/**
+ * CSS Houdini Paint API — Blob Animation Worklet
+ * 演示如何通过 @property 自定义属性驱动 worklet 重绘
+ */
+
+// 定义可动画的 blob 半径
+class BlobPaint {
+  static get inputProperties() {
+    return ['--blob-radius', '--blob-color'];
+  }
+
+  paint(ctx, geom, properties) {
+    const radius = parseFloat(properties.get('--blob-radius')) || 50;
+    const color = properties.get('--blob-color')?.toString() || '#6366f1';
+    const cx = geom.width / 2;
+    const cy = geom.height / 2;
+
+    ctx.fillStyle = color;
+    ctx.beginPath();
+
+    // 用多个圆弧组合成 blob 形状
+    const points = 8;
+    for (let i = 0; i <= points; i++) {
+      const angle = (i / points) * Math.PI * 2;
+      // 通过正弦函数让半径随角度变化，产生不规则 blob 形状
+      const r = radius + Math.sin(angle * 3) * (radius * 0.3);
+      const x = cx + r * Math.cos(angle);
+      const y = cy + r * Math.sin(angle);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.fill();
+  }
+}
+
+registerPaint('blob', BlobPaint);

--- a/examples/css/demos/houdini-paint-api/worklets/checkerboard.js
+++ b/examples/css/demos/houdini-paint-api/worklets/checkerboard.js
@@ -1,0 +1,31 @@
+/**
+ * CSS Houdini Paint API — Checkerboard Blend Worklet
+ * 演示用 paint API 创建棋盘格混合效果（适合做图片遮罩）
+ */
+
+class CheckerboardPaint {
+  static get inputProperties() {
+    return ['--checkerboard-size', '--checkerboard-color', '--checkerboard-opacity'];
+  }
+
+  paint(ctx, geom, properties) {
+    const size = parseInt(properties.get('--checkerboard-size')) || 16;
+    const color = properties.get('--checkerboard-color')?.toString() || 'rgba(0,0,0,0.3)';
+    const opacity = parseFloat(properties.get('--checkerboard-opacity')) || 0.3;
+
+    ctx.clearRect(0, 0, geom.width, geom.height);
+
+    // 解析颜色并应用透明度
+    ctx.fillStyle = color;
+
+    for (let x = 0; x < geom.width; x += size) {
+      for (let y = 0; y < geom.height; y += size) {
+        if ((x / size + y / size) % 2 === 0) {
+          ctx.fillRect(x, y, size, size);
+        }
+      }
+    }
+  }
+}
+
+registerPaint('checkerboard', CheckerboardPaint);

--- a/examples/css/demos/houdini-paint-api/worklets/polygon-border.js
+++ b/examples/css/demos/houdini-paint-api/worklets/polygon-border.js
@@ -1,0 +1,37 @@
+/**
+ * CSS Houdini Paint API — Polygon Border Worklet
+ * 演示用 paint API 绘制可配置边数的多边形边框
+ */
+
+class PolygonBorderPaint {
+  static get inputProperties() {
+    return ['--polygon-sides', '--polygon-color', '--polygon-stroke-width'];
+  }
+
+  paint(ctx, geom, properties) {
+    const sides = parseInt(properties.get('--polygon-sides')) || 6;
+    const color = properties.get('--polygon-color')?.toString() || '#3b82f6';
+    const strokeWidth = parseFloat(properties.get('--polygon-stroke-width')) || 3;
+    const cx = geom.width / 2;
+    const cy = geom.height / 2;
+    const r = Math.min(cx, cy) * 0.8;
+
+    ctx.strokeStyle = color;
+    ctx.lineWidth = strokeWidth;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+
+    for (let i = 0; i <= sides; i++) {
+      const angle = (i / sides) * Math.PI * 2 - Math.PI / 2;
+      const x = cx + r * Math.cos(angle);
+      const y = cy + r * Math.sin(angle);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.stroke();
+  }
+}
+
+registerPaint('polygon-border', PolygonBorderPaint);

--- a/src/topics/09.advanced/houdini-paint-api/index.mdx
+++ b/src/topics/09.advanced/houdini-paint-api/index.mdx
@@ -1,0 +1,401 @@
+---
+title: "CSS Houdini Paint API"
+category: "高级特性"
+tags:
+  - Houdini
+  - Paint API
+  - CSS Paint
+  - 自定义 paint
+  - registerPaint
+description: "详解 CSS Houdini Paint API，通过 registerPaint 注册自定义 paint worklet，实现自定义图案绘制"
+keywords: "CSS Houdini, Paint API, registerPaint, paint worklet, 自定义图案"
+---
+
+# CSS Houdini Paint API
+
+**通过 JavaScript Worklet 在 CSS 中绘制自定义图案**
+
+---
+
+## 概述
+
+CSS Houdini 是浏览器提供的一套底层 API，允许开发者介入浏览器的 CSS 引擎处理过程。Paint API 是 Houdini 规范中最实用的部分之一，它允许我们通过 JavaScript 在 CSS 中绘制自定义图案。
+
+传统 CSS 能实现的效果有限，而 Paint API 让你可以用 Canvas 2D 的绘图能力，在 `background-image`、`border-image`、`list-style-image` 等属性中绘制任意图案。
+
+### 工作原理
+
+1. **注册 Worklet**：使用 `registerPaint()` 注册一个 paint worklet 类
+2. **加载 Worklet**：通过 `CSS.paintWorklet.addModule()` 加载 worklet 脚本
+3. **使用**：在 CSS 中通过 `paint(worklet-name)` 函数引用
+
+```js
+// my-paint.js
+class MyPaint {
+  paint(ctx, geom, properties) {
+    // ctx: CanvasRenderingContext2D
+    // geom: { width, height }
+    // properties: CSSStyleValue map
+  }
+}
+registerPaint('my-paint', MyPaint);
+```
+
+```html
+<script>
+  CSS.paintWorklet.addModule('my-paint.js');
+</script>
+<style>
+  .element {
+    background-image: paint(my-paint);
+  }
+</style>
+```
+
+---
+
+## registerPaint 注册自定义 paint worklet
+
+### 基本语法
+
+```js
+registerPaint(name, classDefinition)
+```
+
+- `name`：字符串，worklet 的名称，在 CSS 中通过 `paint(name)` 引用
+- `classDefinition`：类定义，必须实现 `paint()` 方法
+
+```js
+class DotPattern {
+  paint(ctx, geom) {
+    ctx.fillStyle = 'blue';
+    ctx.beginPath();
+    ctx.arc(geom.width / 2, geom.height / 2, 20, 0, Math.PI * 2);
+    ctx.fill();
+  }
+}
+registerPaint('dot', DotPattern);
+```
+
+### inputProperties 定义自定义属性
+
+通过 `inputProperties` 静态 getter 声明需要监听的自定义属性，让 CSS 变化时自动触发 worklet 重绘：
+
+```js
+class GradientPaint {
+  static get inputProperties() {
+    return ['--gradient-color1', '--gradient-color2'];
+  }
+
+  paint(ctx, geom, properties) {
+    const color1 = properties.get('--gradient-color1').toString();
+    const color2 = properties.get('--gradient-color2').toString();
+
+    const gradient = ctx.createLinearGradient(0, 0, geom.width, geom.height);
+    gradient.addColorStop(0, color1);
+    gradient.addColorStop(1, color2);
+
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, geom.width, geom.height);
+  }
+}
+registerPaint('gradient', GradientPaint);
+```
+
+```css
+.element {
+  --gradient-color1: red;
+  --gradient-color2: blue;
+  background-image: paint(gradient);
+}
+```
+
+---
+
+## paint(ctx, geom, properties) 回调参数详解
+
+### ctx — 绘图上下文
+
+`ctx` 是 `CanvasRenderingContext2D` 实例，支持大部分 Canvas 2D API：
+
+```js
+paint(ctx, geom, properties) {
+  // 矩形
+  ctx.fillRect(x, y, width, height);
+  ctx.strokeRect(x, y, width, height);
+  ctx.clearRect(x, y, width, height);
+
+  // 渐变
+  const gradient = ctx.createLinearGradient(x0, y0, x1, y1);
+  gradient.addColorStop(0, 'red');
+  gradient.addColorStop(1, 'blue');
+  ctx.fillStyle = gradient;
+
+  // 路径
+  ctx.beginPath();
+  ctx.moveTo(x, y);
+  ctx.lineTo(x, y);
+  ctx.arc(x, y, radius, startAngle, endAngle);
+  ctx.closePath();
+  ctx.fill();
+  ctx.stroke();
+}
+```
+
+### geom — 几何信息
+
+```js
+paint(ctx, geom, properties) {
+  console.log(geom.width);   // 元素宽度
+  console.log(geom.height);  // 元素高度
+  console.log(geom.width + geom.height); // 可用于缩放图案
+}
+```
+
+### properties — 样式属性
+
+`properties` 是 `CSSStyleValue` 的 Map，支持获取任意 CSS 属性：
+
+```js
+static get inputProperties() {
+  return ['--my-var', 'width', 'background-color'];
+}
+
+paint(ctx, geom, properties) {
+  // 获取自定义属性
+  const myVar = properties.get('--my-var');
+
+  // 获取计算样式
+  const bgColor = properties.get('background-color');
+
+  console.log(myVar.toString());    // 属性值字符串
+  console.log(bgColor.cssText);     // 颜色值
+}
+```
+
+---
+
+## ctx 绘图上下文方法
+
+### 矩形操作
+
+| 方法 | 说明 |
+|------|------|
+| `fillRect(x, y, w, h)` | 填充矩形 |
+| `strokeRect(x, y, w, h)` | 描边矩形 |
+| `clearRect(x, y, w, h)` | 清除矩形区域（透明） |
+
+```js
+paint(ctx, geom) {
+  // 绘制格子图案
+  const size = 20;
+  for (let x = 0; x < geom.width; x += size) {
+    for (let y = 0; y < geom.height; y += size) {
+      ctx.fillStyle = (x / size + y / size) % 2 === 0 ? '#fff' : '#000';
+      ctx.fillRect(x, y, size, size);
+    }
+  }
+}
+```
+
+### 渐变
+
+```js
+// 线性渐变
+const gradient = ctx.createLinearGradient(0, 0, geom.width, 0);
+gradient.addColorStop(0, 'red');
+gradient.addColorStop(0.5, 'yellow');
+gradient.addColorStop(1, 'blue');
+ctx.fillStyle = gradient;
+ctx.fillRect(0, 0, geom.width, geom.height);
+
+// 径向渐变
+const radial = ctx.createRadialGradient(
+  geom.width / 2, geom.height / 2, 0,
+  geom.width / 2, geom.height / 2, geom.width / 2
+);
+radial.addColorStop(0, 'white');
+radial.addColorStop(1, 'black');
+ctx.fillStyle = radial;
+ctx.fillRect(0, 0, geom.width, geom.height);
+```
+
+### 路径绘制
+
+```js
+paint(ctx, geom) {
+  // 多边形
+  ctx.beginPath();
+  const sides = 6;
+  const cx = geom.width / 2;
+  const cy = geom.height / 2;
+  const r = Math.min(cx, cy) * 0.8;
+
+  for (let i = 0; i <= sides; i++) {
+    const angle = (i / sides) * Math.PI * 2 - Math.PI / 2;
+    const x = cx + r * Math.cos(angle);
+    const y = cy + r * Math.sin(angle);
+    if (i === 0) ctx.moveTo(x, y);
+    else ctx.lineTo(x, y);
+  }
+  ctx.closePath();
+  ctx.fill();
+}
+```
+
+---
+
+## 实战案例
+
+### 案例一：Blob 动画
+
+通过 CSS 动画驱动 `@property` 自定义属性，worklet 读取属性值绘制动态 blob 形状：
+
+```js
+class BlobPaint {
+  static get inputProperties() {
+    return ['--blob-radius'];
+  }
+
+  paint(ctx, geom, properties) {
+    const radius = parseFloat(properties.get('--blob-radius')) || 50;
+    const cx = geom.width / 2;
+    const cy = geom.height / 2;
+
+    ctx.fillStyle = '#6366f1';
+    ctx.beginPath();
+
+    // 用多个圆弧组合成 blob 形状
+    const points = 8;
+    for (let i = 0; i <= points; i++) {
+      const angle = (i / points) * Math.PI * 2;
+      const r = radius + Math.sin(angle * 3) * (radius * 0.3);
+      const x = cx + r * Math.cos(angle);
+      const y = cy + r * Math.sin(angle);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.fill();
+  }
+}
+registerPaint('blob', BlobPaint);
+```
+
+**CSS**：
+```css
+@property --blob-radius {
+  syntax: '<number>';
+  initial-value: 50;
+  inherits: false;
+}
+
+.blob-element {
+  --blob-radius: 50;
+  background-image: paint(blob);
+  animation: blobAnim 2s ease-in-out infinite alternate;
+}
+
+@keyframes blobAnim {
+  to { --blob-radius: 80; }
+}
+```
+
+### 案例二：多边形边框
+
+```js
+class PolygonBorderPaint {
+  static get inputProperties() {
+    return ['--polygon-sides', '--polygon-color'];
+  }
+
+  paint(ctx, geom, properties) {
+    const sides = parseInt(properties.get('--polygon-sides')) || 6;
+    const color = properties.get('--polygon-color')?.toString() || '#3b82f6';
+    const cx = geom.width / 2;
+    const cy = geom.height / 2;
+    const r = Math.min(cx, cy) * 0.8;
+
+    ctx.strokeStyle = color;
+    ctx.lineWidth = 4;
+    ctx.beginPath();
+
+    for (let i = 0; i <= sides; i++) {
+      const angle = (i / sides) * Math.PI * 2 - Math.PI / 2;
+      const x = cx + r * Math.cos(angle);
+      const y = cy + r * Math.sin(angle);
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    }
+    ctx.closePath();
+    ctx.stroke();
+  }
+}
+registerPaint('polygon-border', PolygonBorderPaint);
+```
+
+### 案例三：图像分割（棋盘格混合）
+
+```js
+class CheckerboardPaint {
+  static get inputProperties() {
+    return ['--checkerboard-size', '--checkerboard-color'];
+  }
+
+  paint(ctx, geom, properties) {
+    const size = parseInt(properties.get('--checkerboard-size')) || 20;
+    const color = properties.get('--checkerboard-color')?.toString() || 'rgba(0,0,0,0.5)';
+
+    ctx.clearRect(0, 0, geom.width, geom.height);
+
+    for (let x = 0; x < geom.width; x += size) {
+      for (let y = 0; y < geom.height; y += size) {
+        if ((x / size + y / size) % 2 === 0) {
+          ctx.fillStyle = color;
+          ctx.fillRect(x, y, size, size);
+        }
+      }
+    }
+  }
+}
+registerPaint('checkerboard', CheckerboardPaint);
+```
+
+---
+
+## 浏览器兼容性
+
+| 浏览器 | 支持情况 |
+|--------|----------|
+| Chrome | ✅ 65+ |
+| Edge | ✅ 79+ |
+| Firefox | ❌ 不支持 |
+| Safari | ❌ 不支持 |
+| iOS Safari | ❌ 不支持 |
+
+**注意**：Paint API 需要通过 HTTPS 或 localhost 访问才能正常工作。
+
+### 功能检测
+
+```js
+if ('paintWorklet' in CSS) {
+  CSS.paintWorklet.addModule('my-paint.js');
+} else {
+  // 回退方案
+  document.querySelector('.element').style.background = 'blue';
+}
+```
+
+### 常见问题
+
+1. **Worklet 加载失败**：确保通过 HTTPS 或 localhost 访问
+2. **属性变化不重绘**：确认在 `inputProperties` 中声明了对应属性
+3. **性能问题**：避免在 paint 中执行耗时操作，Houdini 运行在独立线程但仍需高效
+
+---
+
+## 总结
+
+CSS Paint API 是 Houdini 中最实用的 API 之一，它让你可以用 Canvas 2D 的能力绘制任意 CSS 图案。配合 `@property` 定义的可动画自定义属性，可以实现过去只有 JavaScript 才能做到的复杂动画效果。
+
+尽管目前仅 Chrome/Edge 支持，但作为渐进增强的方案，可以在支持的浏览器中提供更丰富的视觉效果。


### PR DESCRIPTION
## 任务概述

完成 zen-css-41 任务：CSS Houdini Paint API 文档和演示。

## 变更内容

### 文档
- src/topics/09.advanced/houdini-paint-api/index.mdx - 完整的中文文档

### 演示文件
- examples/css/demos/houdini-paint-api/index.html - 示例总览
- examples/css/demos/houdini-paint-api/interactive-demo.html - 交互式演示（Blob 动画、多边形边框、棋盘格）
- examples/css/demos/houdini-paint-api/ctx-methods-demo.html - ctx 绘图方法详解
- examples/css/demos/houdini-paint-api/worklets/basic-patterns.js - 基础图案 worklet
- examples/css/demos/houdini-paint-api/worklets/checkerboard.js - 棋盘格 worklet
- examples/css/demos/houdini-paint-api/worklets/polygon-border.js - 多边形边框 worklet

## 核心内容

- egisterPaint() API 详解
- paint(ctx, geom, properties) 回调参数
- inputProperties 定义自定义属性监听
- ctx 绘图上下文方法（矩形、渐变、路径）
- 3个实战案例：Blob 动画、多边形边框、棋盘格混合
- 浏览器兼容性说明（Chrome/Edge only）

Closes zen-css-41